### PR TITLE
[FIX] Platform version for iOS 7

### DIFF
--- a/resources/user-agents/browsers/mobile-safari/mobile-safari-7-0.json
+++ b/resources/user-agents/browsers/mobile-safari/mobile-safari-7-0.json
@@ -12,7 +12,7 @@
         "MajorVer": "7",
         "MinorVer": "0",
         "Platform": "iOS",
-        "Platform_Version": "6.0",
+        "Platform_Version": "7.0",
         "Platform_Description": "iPod, iPhone & iPad",
         "Frames": "true",
         "IFrames": "true",


### PR DESCRIPTION
I'm not 100% sure that Mobile Safari 7.0 necessarily implies iOS 7, but we're getting iOS 7 users showing up in our system as iOS 6 and I believe this is why.

Thanks

FYI @koden-km
