### PR TITLE
add 64 bit Linux to all Firefoxes and to Iceweasel

### DIFF
--- a/resources/user-agents/browsers/firefox/firefox-1-0.json
+++ b/resources/user-agents/browsers/firefox/firefox-1-0.json
@@ -28,7 +28,7 @@
         {
           "match": "Mozilla\/5.0 (#PLATFORM#)*Gecko\/*Firefox\/#MAJORVER#.*",
           "platforms": [
-            "FreeBSD", "HPUX", "IRIX64", "Linux",
+            "FreeBSD", "HPUX", "IRIX64", "Linux", "Linux_64",
             "OSX", "OSX_10_4_A", "OSX_10_4_B", "OSX_10_5_A", "OSX_10_5_B", "OSX_10_6_A", "OSX_10_6_B", "OSX_10_7_A",
             "OSX_10_7_B", "OSX_10_8_A", "OSX_10_8_B", "OSX_10_9_A", "OSX_10_9_B",
             "OpenBSD", "SunOS", "Win95", "Win98", "WinME", "NT4_2",

--- a/resources/user-agents/browsers/firefox/firefox-14.json
+++ b/resources/user-agents/browsers/firefox/firefox-14.json
@@ -31,7 +31,7 @@
         {
           "match": "Mozilla\/5.0 (#PLATFORM#)*Gecko\/*Firefox\/#MAJORVER#.*",
           "platforms": [
-            "AndroidMobile", "FreeBSD", "HPUX", "IRIX64", "Linux",
+            "AndroidMobile", "FreeBSD", "HPUX", "IRIX64", "Linux", "Linux_64",
             "OSX", "OSX_10_4_A", "OSX_10_4_B", "OSX_10_5_A", "OSX_10_5_B", "OSX_10_6_A", "OSX_10_6_B", "OSX_10_7_A",
             "OSX_10_7_B", "OSX_10_8_A", "OSX_10_8_B", "OSX_10_9_A", "OSX_10_9_B",
             "OpenBSD", "SunOS", "Win2000", "WinXPa_32",

--- a/resources/user-agents/browsers/firefox/firefox-15-16-17-18-20-21-22-23.json
+++ b/resources/user-agents/browsers/firefox/firefox-15-16-17-18-20-21-22-23.json
@@ -31,7 +31,7 @@
         {
           "match": "Mozilla\/5.0 (#PLATFORM#)*Gecko\/*Firefox\/#MAJORVER#.*",
           "platforms": [
-            "AndroidMobile", "AndroidTablet", "FreeBSD", "HPUX", "IRIX64", "Linux",
+            "AndroidMobile", "AndroidTablet", "FreeBSD", "HPUX", "IRIX64", "Linux", "Linux_64",
             "OSX", "OSX_10_4_A", "OSX_10_4_B", "OSX_10_5_A", "OSX_10_5_B", "OSX_10_6_A", "OSX_10_6_B", "OSX_10_7_A",
             "OSX_10_7_B", "OSX_10_8_A", "OSX_10_8_B", "OSX_10_9_A", "OSX_10_9_B",
             "OpenBSD", "SunOS", "Win2000", "WinXPa_32",

--- a/resources/user-agents/browsers/firefox/firefox-19.json
+++ b/resources/user-agents/browsers/firefox/firefox-19.json
@@ -31,7 +31,7 @@
         {
           "match": "Mozilla\/5.0 (#PLATFORM#)*Gecko\/*Firefox\/#MAJORVER#.*",
           "platforms": [
-            "AndroidMobile", "AndroidTablet", "FreeBSD", "HPUX", "IRIX64", "Linux",
+            "AndroidMobile", "AndroidTablet", "FreeBSD", "HPUX", "IRIX64", "Linux", "Linux_64",
             "OSX", "OSX_10_4_A", "OSX_10_4_B", "OSX_10_5_A", "OSX_10_5_B", "OSX_10_6_A", "OSX_10_6_B", "OSX_10_7_A",
             "OSX_10_7_B", "OSX_10_8_A", "OSX_10_8_B", "OSX_10_9_A", "OSX_10_9_B",
             "OpenBSD", "SunOS", "Win2000", "WinXPa_32",

--- a/resources/user-agents/browsers/firefox/firefox-2-0.json
+++ b/resources/user-agents/browsers/firefox/firefox-2-0.json
@@ -28,7 +28,7 @@
         {
           "match": "Mozilla\/5.0 (#PLATFORM#)*Gecko\/*Firefox\/#MAJORVER#.*",
           "platforms": [
-            "FreeBSD", "HPUX", "IRIX64", "Linux",
+            "FreeBSD", "HPUX", "IRIX64", "Linux", "Linux_64",
             "OSX", "OSX_10_4_A", "OSX_10_4_B", "OSX_10_5_A", "OSX_10_5_B", "OSX_10_6_A", "OSX_10_6_B", "OSX_10_7_A",
             "OSX_10_7_B", "OSX_10_8_A", "OSX_10_8_B", "OSX_10_9_A", "OSX_10_9_B",
             "OpenBSD", "SunOS", "Win95", "Win98", "WinME", "NT4_2",

--- a/resources/user-agents/browsers/firefox/firefox-3-0.json
+++ b/resources/user-agents/browsers/firefox/firefox-3-0.json
@@ -29,7 +29,7 @@
         {
           "match": "Mozilla\/5.0 (#PLATFORM#)*Gecko\/*Firefox\/#MAJORVER#.#MINORVER#*",
           "platforms": [
-            "FreeBSD", "HPUX", "IRIX64", "Linux",
+            "FreeBSD", "HPUX", "IRIX64", "Linux", "Linux_64",
             "OSX", "OSX_10_4_A", "OSX_10_4_B", "OSX_10_5_A", "OSX_10_5_B", "OSX_10_6_A", "OSX_10_6_B", "OSX_10_7_A",
             "OSX_10_7_B", "OSX_10_8_A", "OSX_10_8_B", "OSX_10_9_A", "OSX_10_9_B",
             "OpenBSD", "SunOS", "Win2000", "WinXPa_32",

--- a/resources/user-agents/browsers/firefox/firefox-3-1.json
+++ b/resources/user-agents/browsers/firefox/firefox-3-1.json
@@ -29,7 +29,7 @@
         {
           "match": "Mozilla\/5.0 (#PLATFORM#)*Gecko\/*Firefox\/#MAJORVER#.#MINORVER#*",
           "platforms": [
-            "FreeBSD", "HPUX", "IRIX64", "Linux",
+            "FreeBSD", "HPUX", "IRIX64", "Linux", "Linux_64",
             "OSX", "OSX_10_4_A", "OSX_10_4_B", "OSX_10_5_A", "OSX_10_5_B", "OSX_10_6_A", "OSX_10_6_B", "OSX_10_7_A",
             "OSX_10_7_B", "OSX_10_8_A", "OSX_10_8_B", "OSX_10_9_A", "OSX_10_9_B",
             "OpenBSD", "SunOS", "Win2000", "WinXPa_32",

--- a/resources/user-agents/browsers/firefox/firefox-3-5.json
+++ b/resources/user-agents/browsers/firefox/firefox-3-5.json
@@ -29,7 +29,7 @@
         {
           "match": "Mozilla\/5.0 (#PLATFORM#)*Gecko\/*Firefox\/#MAJORVER#.#MINORVER#*",
           "platforms": [
-            "FreeBSD", "HPUX", "IRIX64", "Linux",
+            "FreeBSD", "HPUX", "IRIX64", "Linux", "Linux_64",
             "OSX", "OSX_10_4_A", "OSX_10_4_B", "OSX_10_5_A", "OSX_10_5_B", "OSX_10_6_A", "OSX_10_6_B", "OSX_10_7_A",
             "OSX_10_7_B", "OSX_10_8_A", "OSX_10_8_B", "OSX_10_9_A", "OSX_10_9_B",
             "OpenBSD", "SunOS", "Win2000", "WinXPa_32",

--- a/resources/user-agents/browsers/firefox/firefox-4-0.json
+++ b/resources/user-agents/browsers/firefox/firefox-4-0.json
@@ -29,7 +29,7 @@
         {
           "match": "Mozilla\/5.0 (#PLATFORM#)*Gecko\/*Firefox\/#MAJORVER#.*",
           "platforms": [
-            "FreeBSD", "HPUX", "IRIX64", "Linux",
+            "FreeBSD", "HPUX", "IRIX64", "Linux", "Linux_64",
             "OSX", "OSX_10_4_A", "OSX_10_4_B", "OSX_10_5_A", "OSX_10_5_B", "OSX_10_6_A", "OSX_10_6_B", "OSX_10_7_A",
             "OSX_10_7_B", "OSX_10_8_A", "OSX_10_8_B", "OSX_10_9_A", "OSX_10_9_B",
             "OpenBSD", "SunOS", "Win2000", "WinXPa_32",

--- a/resources/user-agents/browsers/firefox/firefox-4-2.json
+++ b/resources/user-agents/browsers/firefox/firefox-4-2.json
@@ -29,7 +29,7 @@
         {
           "match": "Mozilla\/5.0 (#PLATFORM#)*Gecko\/*Firefox\/#MAJORVER#.#MINORVER#*",
           "platforms": [
-            "FreeBSD", "HPUX", "IRIX64", "Linux",
+            "FreeBSD", "HPUX", "IRIX64", "Linux", "Linux_64",
             "OSX", "OSX_10_4_A", "OSX_10_4_B", "OSX_10_5_A", "OSX_10_5_B", "OSX_10_6_A", "OSX_10_6_B", "OSX_10_7_A",
             "OSX_10_7_B", "OSX_10_8_A", "OSX_10_8_B", "OSX_10_9_A", "OSX_10_9_B",
             "OpenBSD", "SunOS", "Win2000", "WinXPa_32",

--- a/resources/user-agents/browsers/firefox/firefox-5-0.json
+++ b/resources/user-agents/browsers/firefox/firefox-5-0.json
@@ -29,7 +29,7 @@
         {
           "match": "Mozilla\/5.0 (#PLATFORM#)*Gecko\/*Firefox\/#MAJORVER#.*",
           "platforms": [
-            "FreeBSD", "HPUX", "IRIX64", "Linux",
+            "FreeBSD", "HPUX", "IRIX64", "Linux", "Linux_64",
             "OSX", "OSX_10_4_A", "OSX_10_4_B", "OSX_10_5_A", "OSX_10_5_B", "OSX_10_6_A", "OSX_10_6_B", "OSX_10_7_A",
             "OSX_10_7_B", "OSX_10_8_A", "OSX_10_8_B", "OSX_10_9_A", "OSX_10_9_B",
             "OpenBSD", "SunOS", "Win2000", "WinXPa_32",

--- a/resources/user-agents/browsers/firefox/firefox-6-7-8-9-10-11-12-13.json
+++ b/resources/user-agents/browsers/firefox/firefox-6-7-8-9-10-11-12-13.json
@@ -31,7 +31,7 @@
         {
           "match": "Mozilla\/5.0 (#PLATFORM#)*Gecko*Firefox\/#MAJORVER#.*",
           "platforms": [
-            "FreeBSD", "HPUX", "IRIX64", "Linux",
+            "FreeBSD", "HPUX", "IRIX64", "Linux", "Linux_64",
             "OSX", "OSX_10_4_A", "OSX_10_4_B", "OSX_10_5_A", "OSX_10_5_B", "OSX_10_6_A", "OSX_10_6_B", "OSX_10_7_A",
             "OSX_10_7_B", "OSX_10_8_A", "OSX_10_8_B", "OSX_10_9_A", "OSX_10_9_B",
             "OpenBSD", "SunOS", "Win2000", "WinXPa_32",

--- a/resources/user-agents/browsers/iceweasel/iceweasel-5-on.json
+++ b/resources/user-agents/browsers/iceweasel/iceweasel-5-on.json
@@ -35,7 +35,7 @@
         {
           "match": "Mozilla\/5.0 (#PLATFORM#) Gecko\/* Iceweasel\/#MAJORVER#* (like Firefox\/*",
           "platforms": [
-            "Debian"
+            "Debian", "Debian_64"
           ]
         }
       ]


### PR DESCRIPTION
Hello,

after thinking about issue #102, I added the 64 bit Linux to all other Firefoxes and to one Iceweasel.
