### PR TITLE
added missing properties, fixed issues in DocBlocks

### DIFF
--- a/src/Browscap/Generator/BrowscapCsvGenerator.php
+++ b/src/Browscap/Generator/BrowscapCsvGenerator.php
@@ -21,9 +21,9 @@ class BrowscapCsvGenerator extends AbstractGenerator
     /**
      * renders all found useragents into a string
      *
-     * @param array[]  $allDivisions
-     * @param string $output
-     * @param array[]  $allProperties
+     * @param array[] $allDivisions
+     * @param string  $output
+     * @param array   $allProperties
      *
      * @return string
      */

--- a/src/Browscap/Generator/BrowscapIniGenerator.php
+++ b/src/Browscap/Generator/BrowscapIniGenerator.php
@@ -5,6 +5,16 @@ namespace Browscap\Generator;
 class BrowscapIniGenerator extends AbstractGenerator
 {
     /**
+     * @var string
+     */
+    private $format = null;
+
+    /**
+     * @var string
+     */
+    private $type = null;
+
+    /**
      * Generate and return the formatted browscap data
      *
      * @param string $format
@@ -54,9 +64,9 @@ class BrowscapIniGenerator extends AbstractGenerator
     /**
      * renders all found useragents into a string
      *
-     * @param array[]  $allDivisions
-     * @param string $output
-     * @param array[]  $allProperties
+     * @param array[] $allDivisions
+     * @param string  $output
+     * @param array   $allProperties
      *
      * @return string
      */

--- a/src/Browscap/Generator/BrowscapXmlGenerator.php
+++ b/src/Browscap/Generator/BrowscapXmlGenerator.php
@@ -45,7 +45,7 @@ class BrowscapXmlGenerator extends AbstractGenerator
      * renders all found useragents into a string
      *
      * @param array[] $allDivisions
-     * @param array[] $allProperties
+     * @param array   $allProperties
      *
      * @return string
      */

--- a/src/Browscap/Generator/CollectionParser.php
+++ b/src/Browscap/Generator/CollectionParser.php
@@ -133,7 +133,7 @@ class CollectionParser
     /**
      * Render a single User Agent block
      *
-     * @param string[] $uaData
+     * @param array    $uaData
      * @param string   $majorVer
      * @param string   $minorVer
      * @param boolean  $lite


### PR DESCRIPTION
I added the two missing properties. I also changed some DocBlocks:

$allProperties is an simple array, not an array of arrays (like $allDivisions)
$uaData is not an array of strings, some of the entries are arrays
