### PR TITLE
Issue parser in tests

### DIFF
--- a/tests/BrowscapTest/UserAgentsTest.php
+++ b/tests/BrowscapTest/UserAgentsTest.php
@@ -86,7 +86,7 @@ class UserAgentsTest extends \PHPUnit_Framework_TestCase
             self::assertArrayHasKey(
                 $propName,
                 $actualProps,
-                'Actual property did not have "' . $propName . '" property'
+                'Actual properties did not have "' . $propName . '" property'
             );
 
             self::assertSame(


### PR DESCRIPTION
For the useragent test it is not nessesary to create all files, only the full php ini file is used. To make the tests a little bit faster, only the needed file should be created.
