### PR TITLE
fixing assert statement

### DIFF
--- a/tests/BrowscapTest/BrowscapTest.php
+++ b/tests/BrowscapTest/BrowscapTest.php
@@ -16,16 +16,16 @@ class BrowscapTest extends \PHPUnit_Framework_TestCase
     {
         $cmdObject = $app->get($command);
 
-        $this->assertInstanceOf('Symfony\Component\Console\Command\Command', $cmdObject);
-        $this->assertSame($command, $cmdObject->getName());
+        self::assertInstanceOf('Symfony\Component\Console\Command\Command', $cmdObject);
+        self::assertSame($command, $cmdObject->getName());
     }
 
     public function testConstructorAddsExpectedCommands()
     {
         $app = new Browscap();
 
-        $this->assertAppHasCommand($app, 'build');
-        $this->assertAppHasCommand($app, 'diff');
-        $this->assertAppHasCommand($app, 'grep');
+        self::assertAppHasCommand($app, 'build');
+        self::assertAppHasCommand($app, 'diff');
+        self::assertAppHasCommand($app, 'grep');
     }
 }

--- a/tests/BrowscapTest/Generator/DataCollectionTest.php
+++ b/tests/BrowscapTest/Generator/DataCollectionTest.php
@@ -67,10 +67,10 @@ class DataCollectionTest extends \PHPUnit_Framework_TestCase
             ],
         ];
 
-        $this->assertSame($expected, $platforms);
+        self::assertSame($expected, $platforms);
 
-        $this->assertSame($expected['Platform1'], $data->getPlatform('Platform1'));
-        $this->assertSame($expected['Platform2'], $data->getPlatform('Platform2'));
+        self::assertSame($expected['Platform1'], $data->getPlatform('Platform1'));
+        self::assertSame($expected['Platform2'], $data->getPlatform('Platform2'));
     }
 
     public function testAddPlatformsFileThrowsExceptionIfFileDoesNotExist()
@@ -114,7 +114,7 @@ HERE;
     public function testGetVersion()
     {
         $data = new DataCollection('1234');
-        $this->assertSame('1234', $data->getVersion());
+        self::assertSame('1234', $data->getVersion());
     }
 
     public function testGetGenerationDate()
@@ -128,11 +128,11 @@ HERE;
 
         $testDateTime = $data->getGenerationDate();
 
-        $this->assertInstanceOf('\DateTime', $testDateTime);
+        self::assertInstanceOf('\DateTime', $testDateTime);
 
         $testTime = $testDateTime->getTimestamp();
-        $this->assertGreaterThanOrEqual($minTime, $testTime);
-        $this->assertLessThanOrEqual($maxTime, $testTime);
+        self::assertGreaterThanOrEqual($minTime, $testTime);
+        self::assertLessThanOrEqual($maxTime, $testTime);
     }
 
     public function testAddSourceFile()
@@ -149,7 +149,7 @@ HERE;
 
         $expected = require_once __DIR__ . '/../../fixtures/DataCollectionTestArray.php';
 
-        $this->assertEquals($expected, $divisions);
+        self::assertEquals($expected, $divisions);
     }
 
     public function testAddSourceFileThrowsExceptionIfFileDoesNotExist()

--- a/tests/BrowscapTest/Parser/IniParserTest.php
+++ b/tests/BrowscapTest/Parser/IniParserTest.php
@@ -14,7 +14,7 @@ class IniParserTest extends \PHPUnit_Framework_TestCase
     public function testConstructorSetsFilename()
     {
         $parser = new IniParser('foobar');
-        $this->assertSame('foobar', $parser->getFilename());
+        self::assertSame('foobar', $parser->getFilename());
     }
 
     public function testSetShouldSort()
@@ -22,28 +22,28 @@ class IniParserTest extends \PHPUnit_Framework_TestCase
         $parser = new IniParser('');
 
         // Test the default value
-        $this->assertAttributeEquals(false, 'shouldSort', $parser);
+        self::assertAttributeEquals(false, 'shouldSort', $parser);
 
         // Test setting it to true
         $parser->setShouldSort(true);
-        $this->assertAttributeEquals(true, 'shouldSort', $parser);
+        self::assertAttributeEquals(true, 'shouldSort', $parser);
 
         // Test setting it back to false
         $parser->setShouldSort(false);
-        $this->assertAttributeEquals(false, 'shouldSort', $parser);
+        self::assertAttributeEquals(false, 'shouldSort', $parser);
     }
 
     public function testShouldSort()
     {
         $parser = new IniParser('');
 
-        $this->assertFalse($parser->shouldSort());
+        self::assertFalse($parser->shouldSort());
 
         $parser->setShouldSort(true);
-        $this->assertTrue($parser->shouldSort());
+        self::assertTrue($parser->shouldSort());
 
         $parser->setShouldSort(false);
-        $this->assertFalse($parser->shouldSort());
+        self::assertFalse($parser->shouldSort());
     }
 
     public function sortArrayDataProvider()
@@ -69,7 +69,7 @@ class IniParserTest extends \PHPUnit_Framework_TestCase
 
         $sortMethod = new \ReflectionMethod('\Browscap\Parser\IniParser', 'sortArrayAndChildArrays');
         $sortMethod->setAccessible(true);
-        $this->assertSame($sorted, $sortMethod->invokeArgs($parser, [$unsorted]));
+        self::assertSame($sorted, $sortMethod->invokeArgs($parser, [$unsorted]));
     }
 
     public function testGetLinesFromFileReturnsArrayWithLines()
@@ -97,7 +97,7 @@ HERE;
             'test=test',
         ];
 
-        $this->assertSame($expected, $out);
+        self::assertSame($expected, $out);
     }
 
     public function testGetLinesFromFileThrowsExceptionIfFileDoesNotExist()
@@ -133,7 +133,7 @@ HERE;
             'test=test',
         ];
 
-        $this->assertSame($expected, $out);
+        self::assertSame($expected, $out);
     }
 
     public function testGetFileLinesReturnsLinesFromPreviouslySetLines()
@@ -143,7 +143,7 @@ HERE;
         $parser = new IniParser('');
         $parser->setFileLines($lines);
 
-        $this->assertSame($lines, $parser->getFileLines());
+        self::assertSame($lines, $parser->getFileLines());
     }
 
     public function testParseWithoutSorting()
@@ -182,9 +182,9 @@ HERE;
 
         $data = $parser->parse();
 
-        $this->assertSame($data, $parser->getParsed());
+        self::assertSame($data, $parser->getParsed());
 
-        $this->assertEquals($expected, $data);
+        self::assertEquals($expected, $data);
     }
 
     public function testParseWithSorting()
@@ -223,7 +223,7 @@ HERE;
 
         $data = $parser->parse();
 
-        $this->assertSame($expected, $data);
+        self::assertSame($expected, $data);
     }
 
     public function testParseThrowsExceptionWhenInvalidFormatting()


### PR DESCRIPTION
Sometimes the assert statements are not written as static methods. This should be corrected, like in the other test files before.
