### PR TITLE
fix line endings issue

### DIFF
--- a/src/Browscap/Command/GrepCommand.php
+++ b/src/Browscap/Command/GrepCommand.php
@@ -129,14 +129,17 @@ class GrepCommand extends Command
 
         $fileContents = file_get_contents($inputFile);
 
-        $uas = explode(PHP_EOL, $fileContents);
-
-
+        if (false !== strpos("\r\n", $fileContents)) {
+            $uas = explode("\r\n", $fileContents);
+        } else {
+            $uas = explode("\n", $fileContents);
+        }
+        
         $foundMode = 0;
         $foundInvisible = 0;
         $foundUnexpected = 0;
 
-        foreach ($uas as $ua) {
+        foreach (array_unique($uas) as $ua) {
             if (!$ua) {
                 continue;
             }


### PR DESCRIPTION
An error occured on my system, when using files with Linux line endings on my Windows system. With using PHP_EOL to split the file I got one long string as useragent which didn't match anything.

The `array_unique` call is to make sure each useragent is only tested once.
