### PR TITLE
Issue 259

### DIFF
--- a/src/Browscap/Generator/BrowscapIniGenerator.php
+++ b/src/Browscap/Generator/BrowscapIniGenerator.php
@@ -136,26 +136,6 @@ class BrowscapIniGenerator extends AbstractGenerator
                 unset($propertiesToOutput[$property]);
             }
 
-            if (BuildGenerator::OUTPUT_TYPE_FULL !== $this->type) {
-                // check if only extra properties are in the actual division
-                // skip that division if the extra properties are not in the output
-                $propertiesToCheck = $propertiesToOutput;
-
-                unset($propertiesToCheck['Parent']);
-
-                foreach (array_keys($propertiesToCheck) as $property) {
-                    if (!CollectionParser::isOutputProperty($property)
-                        || CollectionParser::isExtraProperty($property)
-                    ) {
-                        unset($propertiesToCheck[$property]);
-                    }
-                }
-
-                if (empty($propertiesToCheck)) {
-                    continue;
-                }
-            }
-
             // create output - php
             if ('DefaultProperties' === $key
                 || '*' === $key || empty($properties['Parent'])


### PR DESCRIPTION
The removed code was intended to remove sections which contain except the parent parent only extra properties. This was made to remove sections which contain only device information.

But also all other sections are removed which contain only the parent property like "Palm Source", as there is no check for child sections.
#259
