### PR TITLE
Facebook App Generic should always go after Safari (inc Mobile) Generic

### DIFF
--- a/resources/user-agents/apps/facebook/facebook-app.json
+++ b/resources/user-agents/apps/facebook/facebook-app.json
@@ -1,6 +1,6 @@
 {
   "division": "Facebook App",
-  "sortIndex": 1949,
+  "sortIndex": 1951,
   "lite": true,
   "userAgents": [
     {

--- a/resources/user-agents/browsers/safari/safari-generic.json
+++ b/resources/user-agents/browsers/safari/safari-generic.json
@@ -1,6 +1,6 @@
 {
   "division": "Safari Generic",
-  "sortIndex": 1951,
+  "sortIndex": 1949,
   "lite": true,
   "userAgents": [
     {


### PR DESCRIPTION
Current order is:
FaceBook App Generic
Mobile Safari Generic
Safari Generic

Should be:
Safari Generic
Mobile Safari Generic
FaceBook App Generic
