### PR TITLE
Provide full browscap in JSON build

### DIFF
--- a/src/Browscap/Writer/Factory/FullCollectionFactory.php
+++ b/src/Browscap/Writer/Factory/FullCollectionFactory.php
@@ -131,8 +131,8 @@ class FullCollectionFactory
         $formatter  = new JsonFormatter();
         $jsonWriter
             ->setLogger($logger)
-            ->setFormatter($formatter->setFilter($stdFilter))
-            ->setFilter($stdFilter)
+            ->setFormatter($formatter->setFilter($fullFilter))
+            ->setFilter($fullFilter)
         ;
         $writerCollection->addWriter($jsonWriter);
 


### PR DESCRIPTION
Since c43e3924b5ce1e3942e1c2ec5be8519a8a079318 the JSON build didn't contain the full data. This appeared the browscap.org release of 2015-03-12, leading to browser detection errors.