### PR TITLE
Add regression test to ensure Default Browser always exists

### DIFF
--- a/tests/fixtures/issues/issue-620.php
+++ b/tests/fixtures/issues/issue-620.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'issue-620' => [
+        'this user agent should never exist hopefully as it is is only used in browscap tests',
+        [
+            'Browser' => 'Default Browser',
+        ],
+        'lite' => true,
+    ],
+];


### PR DESCRIPTION
This adds a regression test to ensure #620 doesn't break again (i.e. all browscap files should contain the `Default Browser` entry, including lite).