### PR TITLE
Generate a lite_browscap.json

### DIFF
--- a/src/Browscap/Writer/Factory/FullCollectionFactory.php
+++ b/src/Browscap/Writer/Factory/FullCollectionFactory.php
@@ -136,6 +136,15 @@ class FullCollectionFactory
         ;
         $writerCollection->addWriter($jsonWriter);
 
+        $liteJsonWriter = new JsonWriter($buildFolder . '/lite_browscap.json');
+        $formatter  = new JsonFormatter();
+        $liteJsonWriter
+          ->setLogger($logger)
+          ->setFormatter($formatter->setFilter($liteFilter))
+          ->setFilter($liteFilter)
+        ;
+        $writerCollection->addWriter($liteJsonWriter);
+
         return $writerCollection;
     }
 }


### PR DESCRIPTION
The full browscap.json is too big for our project - it consumes about 1.2 GB of process memory in our node.js browscap microservice.

The lite build is (surprise!) much more lightweight, it only consumes ~50 MB.

Please also add the lite_browscap.json to the Downloads page after accepting this pull request.