### PR TITLE
Typo in UA pattern for UC Browser on Android

### DIFF
--- a/resources/user-agents/browsers/uc-browser/uc-web-7.json
+++ b/resources/user-agents/browsers/uc-browser/uc-web-7.json
@@ -88,7 +88,7 @@
           ]
         },
         {
-          "match": "#PLATFORM)UCWEB#MAJORVER#.#MINORVER#*",
+          "match": "#PLATFORM#)UCWEB#MAJORVER#.#MINORVER#*",
           "platforms": [
             "Android_G_2_2", "Android_G"
           ]


### PR DESCRIPTION
The `PLATFORM` macro was ill formed.