### PR TITLE
Adding device expansion support

### DIFF
--- a/resources/user-agents/browsers/android-browser/android-browser-3-1-3-2.json
+++ b/resources/user-agents/browsers/android-browser/android-browser-3-1-3-2.json
@@ -28,99 +28,31 @@
       },
       "children": [
         {
-          "match": "HTC?Dream Mozilla\/5.0 (#PLATFORM#) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
-          "device": "HTC Dream",
+          "match": "#DEVICE# Mozilla\/5.0 (#PLATFORM#) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
+          "devices": {
+            "HTC?Dream": "HTC Dream",
+            "HTC_Magic": "HTC Dream"
+          },
           "platforms": [
             "Android_1_5"
           ]
         },
         {
-          "match": "HTC_Magic Mozilla\/5.0 (#PLATFORM#) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
-          "device": "HTC Dream",
-          "platforms": [
-            "Android_1_5"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#GT-I5700* Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
-          "device": "Samsung GT-I5700",
-          "platforms": [
-            "Android_1_5"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#Galaxy Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
-          "device": "Samsung Galaxy",
-          "platforms": [
-            "Android_1_5"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#HTC * Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
-          "device": "HTC HTC",
-          "platforms": [
-            "Android_1_5"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#HTC Hero Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
-          "device": "HTC Hero",
-          "platforms": [
-            "Android_1_5"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#HTC Magic Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
-          "device": "HTC Magic",
-          "platforms": [
-            "Android_1_5", "Android_1_6"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#MB200 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
-          "device": "Motorola MB200",
-          "platforms": [
-            "Android_1_5"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#MB300 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
-          "device": "Motorola MB300",
-          "platforms": [
-            "Android_1_5"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#Pulse Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
-          "device": "T-Mobile Pulse",
-          "platforms": [
-            "Android_1_5"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#SPH-M900 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
-          "device": "Samsung SPH M900",
-          "platforms": [
-            "Android_1_5"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#T-Mobile G1 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
-          "device": "T-Mobile G1",
-          "platforms": [
-            "Android_1_5", "Android_1_6"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#T-Mobile_G2_Touch Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
-          "device": "T-Mobile G2 Touch",
-          "platforms": [
-            "Android_1_5"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#WS171 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
-          "device": "general Mobile Phone",
+          "match": "Mozilla\/5.0 (#PLATFORM##DEVICE# Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
+          "devices": {
+            "GT-I5700*": "Samsung GT-I5700",
+            "Galaxy": "Samsung Galaxy",
+            "HTC *": "HTC HTC",
+            "HTC Hero": "HTC Hero",
+            "HTC Magic": "HTC Magic",
+            "MB200": "Motorola MB200",
+            "MB300": "Motorola MB300",
+            "Pulse": "T-Mobile Pulse",
+            "SPH-M900": "Samsung SPH M900",
+            "T-Mobile G1": "T-Mobile G1",
+            "T-Mobile_G2_Touch": "T-Mobile G2 Touch",
+            "WS171": "general Mobile Phone"
+          },
           "platforms": [
             "Android_1_5"
           ]
@@ -133,106 +65,24 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Archos5 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
-          "device": "Archos 5",
-          "platforms": [
-            "Android_1_6"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#E10i Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
-          "device": "SonyEricsson E10i",
-          "platforms": [
-            "Android_1_6"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#HTC Dream G1 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
-          "device": "HTC Dream",
-          "platforms": [
-            "Android_1_6"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#HTC Tattoo Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
-          "device": "HTC Tattoo",
-          "platforms": [
-            "Android_1_6"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#LG KH5200 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
-          "device": "LG KH5200",
-          "platforms": [
-            "Android_1_6"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#LG-GT540* Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
-          "device": "LG GT540",
-          "platforms": [
-            "Android_1_6"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#SH-10B Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
-          "device": "Sharp 10B",
-          "platforms": [
-            "Android_1_6"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#SonyEricssonE10iv Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
-          "device": "SonyEricsson E10iv",
-          "platforms": [
-            "Android_1_6"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#SonyEricssonE15i Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
-          "device": "SonyEricsson E15i",
-          "platforms": [
-            "Android_1_6"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#SonyEricssonU20i Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
-          "device": "SonyEricsson U20i",
-          "platforms": [
-            "Android_1_6"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#SonyEricssonU20iv Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
-          "device": "SonyEricsson U20iv",
-          "platforms": [
-            "Android_1_6"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#SonyEricssonX10a Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
-          "device": "SonyEricsson X10a",
-          "platforms": [
-            "Android_1_6"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#SonyEricssonX10i Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
-          "device": "SonyEricsson X10i",
-          "platforms": [
-            "Android_1_6"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#Zio Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
-          "device": "general Mobile Phone",
-          "platforms": [
-            "Android_1_6"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#edge Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
-          "device": "general Mobile Phone",
+          "match": "Mozilla\/5.0 (#PLATFORM##DEVICE# Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari\/*",
+          "devices": {
+            "Archos5": "Archos 5",
+            "E10i": "SonyEricsson E10i",
+            "HTC Dream G1": "HTC Dream",
+            "HTC Tattoo": "HTC Tattoo",
+            "LG KH5200": "LG KH5200",
+            "LG-GT540*": "LG GT540",
+            "SH-10B": "Sharp 10B",
+            "SonyEricssonE10iv": "SonyEricsson E10iv",
+            "SonyEricssonE15i": "SonyEricsson E15i",
+            "SonyEricssonU20i": "SonyEricsson U20i",
+            "SonyEricssonU20iv": "SonyEricsson U20iv",
+            "SonyEricssonX10a": "SonyEricsson X10a",
+            "SonyEricssonX10i": "SonyEricsson X10i",
+            "Zio": "general Mobile Phone",
+            "edge": "general Mobile Phone"
+          },
           "platforms": [
             "Android_1_6"
           ]

--- a/resources/user-agents/browsers/android-browser/android-browser-4-1.json
+++ b/resources/user-agents/browsers/android-browser/android-browser-4-1.json
@@ -28,15 +28,12 @@
       },
       "children": [
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Micromax A27 Build\/*)*AppleWebKit\/*(*KHTML,*LIKE Gecko*)*Version\/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Micromax A27",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#Micromax A35 Build\/*)*AppleWebKit\/*(*KHTML,*like Gecko*)*Version\/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Micromax A35",
+          "match": "Mozilla\/5.0 (#PLATFORM##DEVICE# Build\/*)*AppleWebKit\/*(*KHTML,*LIKE Gecko*)*Version\/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Micromax A27": "Micromax A27",
+            "Micromax A35": "Micromax A35",
+            "Micromax A40": "Micromax A40"
+          },
           "platforms": [
             "Android_2_3"
           ]
@@ -49,36 +46,21 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Micromax A40 Build\/*)*AppleWebKit\/*(*khtml,*LIKE Gecko*)*Version\/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Micromax A40",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#ALCATEL ONE TOUCH 4030D Build\/*)*AppleWebKit\/*(*khtml,*LIKE Gecko*)*Version\/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Alcatel OT-4030D",
+          "match": "Mozilla\/5.0 (#PLATFORM##DEVICE# Build\/*)*AppleWebKit\/*(*khtml,*LIKE Gecko*)*Version\/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Alcatel OT-4030D": "ALCATEL ONE TOUCH 4030D",
+            "GT-I9100": "GT-I9100"
+          },
           "platforms": [
             "Android_4_1"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#GT-I9100 Build\/*)*AppleWebKit\/*(*khtml,*LIKE Gecko*)*Version\/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "GT-I9100",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#LG-D805 Build\/*)*AppleWebKit\/*(*KHTML,*like Gecko*)*Version\/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG D805",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#HTC_One_X Build\/*)*AppleWebKit\/*(*khtml,*LIKE Gecko*)*Version\/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC PJ83100",
+          "match": "Mozilla\/5.0 (#PLATFORM##DEVICE# Build\/*)*AppleWebKit\/*(*KHTML,*like Gecko*)*Version\/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "LG D805": "LG-D805",
+            "HTC PJ83100": "HTC_One_X"
+          },
           "platforms": [
             "Android_4_2"
           ]
@@ -159,22 +141,14 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#ALCATEL ONE TOUCH 5020D Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Alcatel OT-5020D",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#Vodafone 975N Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Alcatel 975N",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#ALCATEL ONE TOUCH 6030D Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Alcatel OT-6030D",
+          "match": "Mozilla\/5.0 (#PLATFORM##DEVICE# Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Alcatel OT-5020D": "ALCATEL ONE TOUCH 5020D",
+            "Alcatel 975N": "Vodafone 975N",
+            "Alcatel OT-6030D": "ALCATEL ONE TOUCH 6030D",
+            "Alcatel OT-6010D": "ALCATEL ONE TOUCH 6010D",
+            "Alcatel OT-6030X": "ALCATEL ONE TOUCH 6030X"
+          },
           "platforms": [
             "Android_4_1"
           ]
@@ -187,20 +161,6 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#ALCATEL ONE TOUCH 6010D Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Alcatel OT-6010D",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#ALCATEL ONE TOUCH 6030X Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Alcatel OT-6030X",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
           "match": "Mozilla\/5.0 (#PLATFORM#C6603 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*)",
           "device": "Sony C6603",
           "platforms": [
@@ -208,15 +168,11 @@
           ]
         },
         {
-          "match": "HTC7088_TD\/1.0 Android\/#MAJORVER#.#MINORVER# release\/2013 Browser\/WAP2.0 Profile\/MIDP-2.0 Configuration\/CLDC-1.1*",
-          "device": "HTC 7088",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "HTC802t_TD\/1.0 Android\/#MAJORVER#.#MINORVER# release\/2013 Browser\/WAP2.0 Profile\/MIDP-2.0 Configuration\/CLDC-1.1*",
-          "device": "HTC 802T",
+          "match": "#DEVICE#\/1.0 Android\/#MAJORVER#.#MINORVER# release\/2013 Browser\/WAP2.0 Profile\/MIDP-2.0 Configuration\/CLDC-1.1*",
+          "devices": {
+            "HTC 7088": "HTC7088_TD",
+            "HTC 802T": "HTC802t_TD"
+          },
           "platforms": [
             "Android_4_1"
           ]

--- a/resources/user-agents/browsers/android-browser/android-browser-4-1.json
+++ b/resources/user-agents/browsers/android-browser/android-browser-4-1.json
@@ -48,7 +48,7 @@
         {
           "match": "Mozilla\/5.0 (#PLATFORM##DEVICE# Build\/*)*AppleWebKit\/*(*khtml,*LIKE Gecko*)*Version\/#MAJORVER#.#MINORVER#*Safari*",
           "devices": {
-            "Alcatel OT-4030D": "ALCATEL ONE TOUCH 4030D",
+            "ALCATEL ONE TOUCH 4030D": "Alcatel OT-4030D",
             "GT-I9100": "GT-I9100"
           },
           "platforms": [
@@ -58,8 +58,8 @@
         {
           "match": "Mozilla\/5.0 (#PLATFORM##DEVICE# Build\/*)*AppleWebKit\/*(*KHTML,*like Gecko*)*Version\/#MAJORVER#.#MINORVER#*Safari*",
           "devices": {
-            "LG D805": "LG-D805",
-            "HTC PJ83100": "HTC_One_X"
+            "LG-D805": "LG D805",
+            "HTC_One_X": "HTC PJ83100"
           },
           "platforms": [
             "Android_4_2"
@@ -143,11 +143,11 @@
         {
           "match": "Mozilla\/5.0 (#PLATFORM##DEVICE# Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari*",
           "devices": {
-            "Alcatel OT-5020D": "ALCATEL ONE TOUCH 5020D",
-            "Alcatel 975N": "Vodafone 975N",
-            "Alcatel OT-6030D": "ALCATEL ONE TOUCH 6030D",
-            "Alcatel OT-6010D": "ALCATEL ONE TOUCH 6010D",
-            "Alcatel OT-6030X": "ALCATEL ONE TOUCH 6030X"
+            "ALCATEL ONE TOUCH 5020D": "Alcatel OT-5020D",
+            "Vodafone 975N": "Alcatel 975N",
+            "ALCATEL ONE TOUCH 6030D": "Alcatel OT-6030D",
+            "ALCATEL ONE TOUCH 6010D": "Alcatel OT-6010D",
+            "ALCATEL ONE TOUCH 6030X": "Alcatel OT-6030X"
           },
           "platforms": [
             "Android_4_1"
@@ -170,8 +170,8 @@
         {
           "match": "#DEVICE#\/1.0 Android\/#MAJORVER#.#MINORVER# release\/2013 Browser\/WAP2.0 Profile\/MIDP-2.0 Configuration\/CLDC-1.1*",
           "devices": {
-            "HTC 7088": "HTC7088_TD",
-            "HTC 802T": "HTC802t_TD"
+            "HTC7088_TD": "HTC 7088",
+            "HTC802t_TD": "HTC 802T"
           },
           "platforms": [
             "Android_4_1"

--- a/resources/user-agents/browsers/android-browser/android-browser-4-2.json
+++ b/resources/user-agents/browsers/android-browser/android-browser-4-2.json
@@ -28,15 +28,12 @@
       },
       "children": [
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Micromax A27 Build\/*)*AppleWebKit\/*(*KHTML,*LIKE Gecko*)*Version\/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Micromax A27",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#Micromax A35 Build\/*)*AppleWebKit\/*(*KHTML,*like Gecko*)*Version\/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Micromax A35",
+          "match": "Mozilla\/5.0 (#PLATFORM##DEVICE# Build\/*)*AppleWebKit\/*(*KHTML,*LIKE Gecko*)*Version\/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Micromax A27": "Micromax A27",
+            "Micromax A35": "Micromax A35",
+            "Micromax A40": "Micromax A40"
+          },
           "platforms": [
             "Android_2_3"
           ]
@@ -49,36 +46,21 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Micromax A40 Build\/*)*AppleWebKit\/*(*khtml,*LIKE Gecko*)*Version\/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Micromax A40",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#ALCATEL ONE TOUCH 4030D Build\/*)*AppleWebKit\/*(*khtml,*LIKE Gecko*)*Version\/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Alcatel OT-4030D",
+          "match": "Mozilla\/5.0 (#PLATFORM##DEVICE# Build\/*)*AppleWebKit\/*(*khtml,*LIKE Gecko*)*Version\/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Alcatel OT-4030D": "ALCATEL ONE TOUCH 4030D",
+            "GT-I9100": "GT-I9100"
+          },
           "platforms": [
             "Android_4_1"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#GT-I9100 Build\/*)*AppleWebKit\/*(*khtml,*LIKE Gecko*)*Version\/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "GT-I9100",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#LG-D805 Build\/*)*AppleWebKit\/*(*KHTML,*like Gecko*)*Version\/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG D805",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#HTC_One_X Build\/*)*AppleWebKit\/*(*khtml,*LIKE Gecko*)*Version\/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC PJ83100",
+          "match": "Mozilla\/5.0 (#PLATFORM##DEVICE# Build\/*)*AppleWebKit\/*(*KHTML,*like Gecko*)*Version\/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "LG D805": "LG-D805",
+            "HTC PJ83100": "HTC_One_X"
+          },
           "platforms": [
             "Android_4_2"
           ]
@@ -108,99 +90,39 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo B8000-F\/*) AppleWebKit* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo B8000-F",
+          "match": "Mozilla\/5.0 (#PLATFORM##DEVICE#*) AppleWebKit* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Lenovo B8000-F": "Lenovo B8000-F\/",
+            "Lenovo S5000-H": "Lenovo S5000-H\/",
+            "Lenovo B6000-F": "Lenovo B6000-F",
+            "Alcatel OT-7047D": "ALCATEL ONE TOUCH 7047D",
+            "MTC 982": "MTC 982 Build\/",
+            "Vodafone Smart Tab 4": "Vodafone Smart Tab 4 Build\/",
+            "ZOPO ZP980": "Z980\/",
+            "Lenovo B6000-H": "Lenovo B6000-H\/",
+            "Lenovo B8000-H": "Lenovo B8000-H\/",
+            "Alcatel P310X": "ALCATEL ONE TOUCH P310X Build\/"
+          },
           "platforms": [
             "Android_4_2"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo S5000-H\/*) AppleWebKit* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo S5000-H",
+          "match": "Mozilla\/5.0 (#PLATFORM##DEVICE#*) *AppleWebKit* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Vodafone 785": "Vodafone 785 Build\/",
+            "Lenovo A859": "Lenovo A859"
+          },
           "platforms": [
             "Android_4_2"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo B6000-F*) AppleWebKit* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo B6000-F",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#ALCATEL ONE TOUCH 7047D*) AppleWebKit* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Alcatel OT-7047D",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#MTC 982 Build\/*) AppleWebKit* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "MTC 982",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#Vodafone Smart Tab 4 Build\/*) AppleWebKit* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Vodafone Smart Tab 4",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#Z980\/*) AppleWebKit* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "ZOPO ZP980",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo B6000-H\/*) AppleWebKit* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo B6000-H",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo B8000-H\/*) AppleWebKit* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo B8000-H",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#ALCATEL ONE TOUCH P310X Build\/*) AppleWebKit* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Alcatel P310X",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#Vodafone 785 Build\/*) *AppleWebKit* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Vodafone 785",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo A859*) *AppleWebKit* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo A859",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#C6603 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*)",
-          "device": "Sony C6603",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#Galaxy Nexus Build\/*) AppleWebKit\/* (KHTML,*like Gecko*)",
-          "device": "Samsung Galaxy Nexus",
+          "match": "Mozilla\/5.0 (#PLATFORM##DEVICE# Build\/*) AppleWebKit\/* (KHTML,*like Gecko*)",
+          "devices": {
+            "Sony C6603": "C6603",
+            "Samsung Galaxy Nexus": "Galaxy Nexus"
+          },
           "platforms": [
             "Android_4_2"
           ]
@@ -249,15 +171,11 @@
           ]
         },
         {
-          "match": "Lenovo-A880*Linux\/* Android\/4.2* Release\/* Browser\/AppleWebkit*",
-          "device": "Lenovo A880",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Lenovo-A889*Linux\/* Android\/4.2* Release\/* Browser\/AppleWebkit*",
-          "device": "Lenovo A889",
+          "match": "#DEVICE#*Linux\/* Android\/4.2* Release\/* Browser\/AppleWebkit*",
+          "devices": {
+            "Lenovo A880": "Lenovo-A880",
+            "Lenovo A889": "Lenovo-A889"
+          },
           "platforms": [
             "Android_4_2"
           ]

--- a/resources/user-agents/browsers/android-browser/android-browser-4-2.json
+++ b/resources/user-agents/browsers/android-browser/android-browser-4-2.json
@@ -48,7 +48,7 @@
         {
           "match": "Mozilla\/5.0 (#PLATFORM##DEVICE# Build\/*)*AppleWebKit\/*(*khtml,*LIKE Gecko*)*Version\/#MAJORVER#.#MINORVER#*Safari*",
           "devices": {
-            "Alcatel OT-4030D": "ALCATEL ONE TOUCH 4030D",
+            "ALCATEL ONE TOUCH 4030D": "Alcatel OT-4030D",
             "GT-I9100": "GT-I9100"
           },
           "platforms": [
@@ -58,8 +58,8 @@
         {
           "match": "Mozilla\/5.0 (#PLATFORM##DEVICE# Build\/*)*AppleWebKit\/*(*KHTML,*like Gecko*)*Version\/#MAJORVER#.#MINORVER#*Safari*",
           "devices": {
-            "LG D805": "LG-D805",
-            "HTC PJ83100": "HTC_One_X"
+            "LG-D805": "LG D805",
+            "HTC_One_X": "HTC PJ83100"
           },
           "platforms": [
             "Android_4_2"
@@ -92,16 +92,16 @@
         {
           "match": "Mozilla\/5.0 (#PLATFORM##DEVICE#*) AppleWebKit* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari*",
           "devices": {
-            "Lenovo B8000-F": "Lenovo B8000-F\/",
-            "Lenovo S5000-H": "Lenovo S5000-H\/",
+            "Lenovo B8000-F\/": "Lenovo B8000-F",
+            "Lenovo S5000-H\/": "Lenovo S5000-H",
             "Lenovo B6000-F": "Lenovo B6000-F",
-            "Alcatel OT-7047D": "ALCATEL ONE TOUCH 7047D",
-            "MTC 982": "MTC 982 Build\/",
-            "Vodafone Smart Tab 4": "Vodafone Smart Tab 4 Build\/",
-            "ZOPO ZP980": "Z980\/",
-            "Lenovo B6000-H": "Lenovo B6000-H\/",
-            "Lenovo B8000-H": "Lenovo B8000-H\/",
-            "Alcatel P310X": "ALCATEL ONE TOUCH P310X Build\/"
+            "ALCATEL ONE TOUCH 7047D": "Alcatel OT-7047D",
+            "MTC 982 Build\/": "MTC 982",
+            "Vodafone Smart Tab 4 Build\/": "Vodafone Smart Tab 4",
+            "Z980\/": "ZOPO ZP980",
+            "Lenovo B6000-H\/": "Lenovo B6000-H",
+            "Lenovo B8000-H\/": "Lenovo B8000-H",
+            "ALCATEL ONE TOUCH P310X Build\/": "Alcatel P310X"
           },
           "platforms": [
             "Android_4_2"
@@ -110,7 +110,7 @@
         {
           "match": "Mozilla\/5.0 (#PLATFORM##DEVICE#*) *AppleWebKit* (KHTML,*like Gecko*) Version\/#MAJORVER#.#MINORVER#*Safari*",
           "devices": {
-            "Vodafone 785": "Vodafone 785 Build\/",
+            "Vodafone 785 Build\/": "Vodafone 785",
             "Lenovo A859": "Lenovo A859"
           },
           "platforms": [
@@ -120,8 +120,8 @@
         {
           "match": "Mozilla\/5.0 (#PLATFORM##DEVICE# Build\/*) AppleWebKit\/* (KHTML,*like Gecko*)",
           "devices": {
-            "Sony C6603": "C6603",
-            "Samsung Galaxy Nexus": "Galaxy Nexus"
+            "C6603": "Sony C6603",
+            "Galaxy Nexus": "Samsung Galaxy Nexus"
           },
           "platforms": [
             "Android_4_2"
@@ -173,8 +173,8 @@
         {
           "match": "#DEVICE#*Linux\/* Android\/4.2* Release\/* Browser\/AppleWebkit*",
           "devices": {
-            "Lenovo A880": "Lenovo-A880",
-            "Lenovo A889": "Lenovo-A889"
+            "Lenovo-A880": "Lenovo A880",
+            "Lenovo-A889": "Lenovo A889"
           },
           "platforms": [
             "Android_4_2"

--- a/resources/user-agents/browsers/android-browser/android-browser-4-4.json
+++ b/resources/user-agents/browsers/android-browser/android-browser-4-4.json
@@ -35,15 +35,11 @@
           ]
         },
         {
-          "match": "HTCD816t_LTE\/1.0 Android\/#MAJORVER#.#MINORVER#* Release\/* Browser\/*AppleWebKit*",
-          "device": "HTC D816t",
-          "platforms": [
-            "Android_4_4"
-          ]
-        },
-        {
-          "match": "HTCM8St_TD\/1.0 Android\/#MAJORVER#.#MINORVER#* Release\/* Browser\/*AppleWebKit*",
-          "device": "HTC M8St",
+          "match": "#DEVICE#\/1.0 Android\/#MAJORVER#.#MINORVER#* Release\/* Browser\/*AppleWebKit*",
+          "devices": {
+            "HTCD816t_LTE": "HTC D816t",
+            "HTCM8St_TD": "HTC M8St"
+          },
           "platforms": [
             "Android_4_4"
           ]
@@ -68,106 +64,24 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#itel it1701;*Release\/*) *AppleWebKit\/* (KHTML* like Gecko) Mobile Safari*",
-          "device": "itel it1701",
-          "platforms": [
-            "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#itel_it1502;*Release\/*) *AppleWebKit\/* (KHTML* like Gecko) Mobile Safari*",
-          "device": "itel it1502",
-          "platforms": [
-            "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#AquaSense5.0;*Release\/*) *AppleWebKit\/* (KHTML* like Gecko) Mobile Safari*",
-          "device": "Intex Aqua Sense 5.0",
-          "platforms": [
-            "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#X1 Beats;*Release\/*) *AppleWebKit\/* (KHTML* like Gecko) Mobile Safari*",
-          "device": "Lava Iris X1 Beats",
-          "platforms": [
-            "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#X1 atom;*Release\/*) *AppleWebKit\/* (KHTML* like Gecko) Mobile Safari*",
-          "device": "Lava Iris X1 Atom S",
-          "platforms": [
-            "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#Andi 4F ARC3;*Release\/*) *AppleWebKit\/* (KHTML* like Gecko) Mobile Safari*",
-          "device": "iBall Andi 4F ARC3",
-          "platforms": [
-            "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#Aqua_Life V;*Release\/*) *AppleWebKit\/* (KHTML* like Gecko) Mobile Safari*",
-          "device": "Intex Aqua_Life V",
-          "platforms": [
-            "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#Aqua Q3;*Release\/*) *AppleWebKit\/* (KHTML* like Gecko) Mobile Safari*",
-          "device": "Intex Aqua Q3",
-          "platforms": [
-            "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#WOW;*Release\/*) *AppleWebKit\/* (KHTML* like Gecko) Mobile Safari*",
-          "device": "Intex WOW",
-          "platforms": [
-            "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#PLAY Style;*Release\/*) *AppleWebKit\/* (KHTML* like Gecko) Mobile Safari*",
-          "device": "Star PLAY Style",
-          "platforms": [
-            "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#era;*Release\/*) *AppleWebKit\/* (KHTML* like Gecko) Mobile Safari*",
-          "device": "XOLO era",
-          "platforms": [
-            "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#Aqua Star II;*Release\/*) *AppleWebKit\/* (KHTML* like Gecko) Mobile Safari*",
-          "device": "Intex Aqua Star 2",
-          "platforms": [
-            "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#Atom 2;*Release\/*) *AppleWebKit\/* (KHTML* like Gecko) Mobile Safari*",
-          "device": "Lava Iris Atom 2",
-          "platforms": [
-            "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#8_96_Android;*Release\/*) *AppleWebKit\/* (KHTML* like Gecko) Mobile Safari*",
-          "device": "O+ 8.96 Android",
-          "platforms": [
-            "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#Aqua Star II HD;*Release\/*) *AppleWebKit\/* (KHTML* like Gecko) Mobile Safari*",
-          "device": "Intex Aqua Star 2 HD",
+          "match": "Mozilla\/5.0 (#PLATFORM##DEVICE#;*Release\/*) *AppleWebKit\/* (KHTML* like Gecko) Mobile Safari*",
+          "devices": {
+            "itel it1701": "itel it1701",
+            "itel_it1502": "itel it1502",
+            "AquaSense5.0": "Intex Aqua Sense 5.0",
+            "X1 Beats": "Lava Iris X1 Beats",
+            "X1 atom": "Lava Iris X1 Atom S",
+            "Andi 4F ARC3": "iBall Andi 4F ARC3",
+            "Aqua_Life V": "Intex Aqua_Life V",
+            "Aqua Q3": "Intex Aqua Q3",
+            "WOW": "Intex WOW",
+            "PLAY Style": "Star PLAY Style",
+            "era": "XOLO era",
+            "Aqua Star II": "Intex Aqua Star 2",
+            "Atom 2": "Lava Iris Atom 2",
+            "8_96_Android": "O+ 8.96 Android",
+            "Aqua Star II HD": "Intex Aqua Star 2 HD"
+          },
           "platforms": [
             "Android_4_4"
           ]

--- a/src/Browscap/Data/DataCollection.php
+++ b/src/Browscap/Data/DataCollection.php
@@ -363,6 +363,20 @@ class DataCollection
                         );
                     }
 
+                    if (isset($child['device']) && isset($child['devices'])) {
+                        throw new \LogicException(
+                            'a child may not define both the "device" and the "devices" entries for key "'
+                            . $useragent['userAgent'] . '", for child data: ' . json_encode($child)
+                        );
+                    }
+
+                    if (isset($child['devices']) && !is_array($child['devices'])) {
+                        throw new \UnexpectedValueException(
+                            'the "devices" entry has to be an array for key "'
+                            . $useragent['userAgent'] . '", for child data: ' . json_encode($child)
+                        );
+                    }
+
                     if (!isset($child['match'])) {
                         throw new \UnexpectedValueException(
                             'each entry of the children property requires an "match" entry for key "'

--- a/src/Browscap/Data/Expander.php
+++ b/src/Browscap/Data/Expander.php
@@ -196,10 +196,24 @@ class Expander
         }
 
         foreach ($uaData['children'] as $child) {
-            $output = array_merge(
-                $output,
-                $this->parseChildren($ua, $child, $lite, $standard)
-            );
+            if (isset($child['devices']) && is_array($child['devices'])) {
+                // Replace our device array with a single device property with our #DEVICE# token replaced
+                foreach ($child['devices'] as $deviceName => $deviceMatch) {
+                    $subChild           = $child;
+                    $subChild['match']  = str_replace('#DEVICE#', $deviceMatch, $subChild['match']);
+                    $subChild['device'] = $deviceName;
+                    unset($subChild['devices']);
+                    $output = array_merge(
+                        $output,
+                        $this->parseChildren($ua, $subChild, $lite, $standard)
+                    );
+                }
+            } else {
+                $output = array_merge(
+                    $output,
+                    $this->parseChildren($ua, $child, $lite, $standard)
+                );
+            }
         }
 
         return $output;

--- a/src/Browscap/Data/Expander.php
+++ b/src/Browscap/Data/Expander.php
@@ -198,7 +198,7 @@ class Expander
         foreach ($uaData['children'] as $child) {
             if (isset($child['devices']) && is_array($child['devices'])) {
                 // Replace our device array with a single device property with our #DEVICE# token replaced
-                foreach ($child['devices'] as $deviceName => $deviceMatch) {
+                foreach ($child['devices'] as $deviceMatch => $deviceName) {
                     $subChild           = $child;
                     $subChild['match']  = str_replace('#DEVICE#', $deviceMatch, $subChild['match']);
                     $subChild['device'] = $deviceName;

--- a/tests/BrowscapTest/Data/DataCollectionTest.php
+++ b/tests/BrowscapTest/Data/DataCollectionTest.php
@@ -854,6 +854,34 @@ HERE;
     }
 
     /**
+     * checks if a exception is thrown if the device and devices keys are set
+     *
+     * @expectedException \LogicException
+     * @expectedExceptionMessage a child may not define both the "device" and the "devices" entries
+     *
+     * @group data
+     * @group sourcetest
+     */
+    public function testAddSourceFileThrowsExceptionIfChildHasDeviceAndDevicesKeys()
+    {
+        $this->object->addSourceFile(__DIR__ . '/../../fixtures/ua/ua-with-children-with-device-and-devices.json');
+    }
+
+    /**
+     * checks if a exception is thrown if the devices entry is not an array
+     *
+     * @expectedException \UnexpectedValueException
+     * @expectedExceptionMessage the "devices" entry has to be an array
+     *
+     * @group data
+     * @group sourcetest
+     */
+    public function testAddSourceFileThrowsExceptionIfDevicesEntryIsNotAnArray()
+    {
+        $this->object->addSourceFile(__DIR__ . '/../../fixtures/ua/ua-with-children-with-devices-not-array.json');
+    }
+
+    /**
      * checks if a exception is thrown if a division is defined twice in the source files
      *
      * @expectedException \UnexpectedValueException

--- a/tests/fixtures/issues/issue-1201.php
+++ b/tests/fixtures/issues/issue-1201.php
@@ -53,5 +53,5 @@ return [
         ],
         'lite' => false,
         'standard' => true,
-    ]
+    ],
 ];

--- a/tests/fixtures/ua/ua-with-children-with-device-and-devices.json
+++ b/tests/fixtures/ua/ua-with-children-with-device-and-devices.json
@@ -1,0 +1,30 @@
+{
+  "division": "Division1",
+  "versions": ["1.0"],
+  "sortIndex": 200,
+  "lite": true,
+  "standard": true,
+  "userAgents": [
+    {
+      "userAgent": "UA1",
+      "properties": {
+        "Parent": "DefaultProperties",
+        "Comment": "UA1",
+        "Browser": "UA1",
+        "Version": "1.0",
+        "MajorVer": "1",
+        "MinorVer": "0"
+      },
+      "children": [
+        {
+          "match": "cde",
+          "device": "efg",
+          "devices": {
+            "efg": "abc",
+            "def": "cde"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/ua/ua-with-children-with-devices-not-array.json
+++ b/tests/fixtures/ua/ua-with-children-with-devices-not-array.json
@@ -1,0 +1,26 @@
+{
+  "division": "Division1",
+  "versions": ["1.0"],
+  "sortIndex": 200,
+  "lite": true,
+  "standard": true,
+  "userAgents": [
+    {
+      "userAgent": "UA1",
+      "properties": {
+        "Parent": "DefaultProperties",
+        "Comment": "UA1",
+        "Browser": "UA1",
+        "Version": "1.0",
+        "MajorVer": "1",
+        "MinorVer": "0"
+      },
+      "children": [
+        {
+          "match": "cde",
+          "devices": "efg"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Discussed more in #1239. This adds support to the JSON files and the Expander class to allow a "devices" key on a child object.  This should make it a bit easier (less copy/paste) to add a lot of child useragents that differ just by their device identifier.

Syntax would be:

```json
"match": "Some User Agent #DEVICE# Chrome"
"devices": {
    "HTC DESIRE HD": "Device 1",
    "DESIRE HD": "Device 2",
    "HTC DESIRE": "Device 1"
},
```

Where the key of each of those is the match string that will be expanded into the `#DEVICE#` token for each device in the array. The value of the array is the Device's name from devices.json.

For example, when the above sample is expanded, it would result in three different patterns:

>Some User Agent HTC DESIRE HD Chrome
>Some User Agent DESIRE HD Chrome
>Some User Agent HTC DESIRE Chrome

I've converted a few files from the Android Browser group to this syntax, which resulted in a fair amount of savings in number of lines:

 * android-browser-3-1-3-2.json: from 255 lines to 105 lines
 * android-browser-4-1.json: from 242 lines to 198 lines
 * android-browser-4-2.json: from 283 lines to 201 lines
 * android-browser-4-4.json: from 184 lines to 98 lines

This may help reveal patterns that could be modified slightly (I only condensed patterns that were exactly the same except for where the #DEVICE# token would be replaced), since they'll stand out a bit more than before.

Added some source tests to cover the added code.