### PR TITLE
Removing escaped slashes for UCBrowser files

### DIFF
--- a/resources/user-agents/browsers/uc-browser/uc-web-10.json
+++ b/resources/user-agents/browsers/uc-browser/uc-web-10.json
@@ -28,196 +28,196 @@
       },
       "children": [
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#SM-T531 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#SM-T531 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "device": "Samsung SM-T531",
           "platforms": [
             "Android_4_4"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#IQ4411 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#IQ4411 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "device": "Fly IQ4411",
           "platforms": [
             "Android_4_1"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#A101 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#A101 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "device": "Micromax A101",
           "platforms": [
             "Android_3_2"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#LG-P705 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#LG-P705 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "device": "LG P705",
           "platforms": [
             "Android_4_0"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#QS0716D Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#QS0716D Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "device": "3Q QS0716D",
           "platforms": [
             "Android_4_0"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#RMD-1025 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#RMD-1025 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "device": "Ritmix RMD-1025",
           "platforms": [
             "Android_4_0"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#iDnD7 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#iDnD7 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "device": "Digma iDnD7",
           "platforms": [
             "Android_4_1"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Philips-W8500 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Philips-W8500 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "device": "Philips W8500",
           "platforms": [
             "Android_4_1"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#s4502M Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#s4502M Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "device": "DNS S4502M",
           "platforms": [
             "Android_4_1"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Surfer 7.34 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Surfer 7.34 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "device": "Explay Surfer 7.34 3G",
           "platforms": [
             "Android_4_1"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#TG97 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#TG97 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "device": "Irbis TG97",
           "platforms": [
             "Android_4_2"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Micromax A120 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Micromax A120 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "device": "Micromax A120",
           "platforms": [
             "Android_4_2"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#ARK Benefit M3S Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#ARK Benefit M3S Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "device": "ARK Benefit M3S",
           "platforms": [
             "Android_4_2"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#F031 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#F031 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "device": "Samsung F031",
           "platforms": [
             "Android_4_2"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#X-pad STYLE 7.1 3G* Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#X-pad STYLE 7.1 3G* Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "device": "TeXet TM-7058",
           "platforms": [
             "Android_4_2"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Z150 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Z150 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "device": "Acer Z150",
           "platforms": [
             "Android_4_2"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#ZTE V967S Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#ZTE V967S Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "device": "ZTE V967S",
           "platforms": [
             "Android_4_2"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#ASUS_T00N Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#ASUS_T00N Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "device": "Asus T00N",
           "platforms": [
             "Android_4_4"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#BQ 7056G Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#BQ 7056G Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "device": "BQ 7056G",
           "platforms": [
             "Android_4_4"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#M1_Plus Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#M1_Plus Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "device": "Explay M1 Plus",
           "platforms": [
             "Android_4_4"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Philips W3509 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Philips W3509 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "device": "Philips W3509",
           "platforms": [
             "Android_4_4"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#SM-G900W8 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#SM-G900W8 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "device": "Samsung SM-G900W8",
           "platforms": [
             "Android_4_4"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#V370 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#V370 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "device": "Acer V370",
           "platforms": [
             "Android_4_4"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#SM-G900F Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#SM-G900F Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "device": "Samsung SM-G900F",
           "platforms": [
             "Android_4_4"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#P4501 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#P4501 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "device": "Medion P4501",
           "platforms": [
             "Android_4_1"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#GT-I9500 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#GT-I9500 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "device": "Samsung GT-I9500",
           "platforms": [
             "Android_4_3", "Android_4_4", "Android_5_0"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Cubot GT99 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Cubot GT99 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "device": "Cubot GT99",
           "platforms": [
             "Android_4_2"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#GT-I9300 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#GT-I9300 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Samsung GT-I9300",
           "platforms": [
@@ -225,7 +225,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#M601 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#M601 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "AOC M601",
           "platforms": [
@@ -233,7 +233,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#LG-P713 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#LG-P713 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "LG P713",
           "platforms": [
@@ -241,7 +241,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#TAB-97E-01 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#TAB-97E-01 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Reellex TAB-97E-01",
           "platforms": [
@@ -249,7 +249,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#LT26w Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#LT26w Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Sony LT26w",
           "platforms": [
@@ -257,7 +257,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#M7T Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#M7T Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "PiPO M7T",
           "platforms": [
@@ -265,7 +265,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#ORION7o Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#ORION7o Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "GOCLEVER ORION7o",
           "platforms": [
@@ -273,7 +273,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#M5301 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#M5301 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "iRU M5301",
           "platforms": [
@@ -281,7 +281,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#SO-02D Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#SO-02D Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Sony SO-02D",
           "platforms": [
@@ -289,7 +289,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#SmartTab7 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#SmartTab7 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Vodafone Smart Tab 7",
           "platforms": [
@@ -297,7 +297,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#MB40II1 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#MB40II1 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "DNS MB40II1",
           "platforms": [
@@ -305,7 +305,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo B8000-H Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* *Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Lenovo B8000-H Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* *Safari/*",
           "engine": "U3",
           "device": "Lenovo B8000-H",
           "platforms": [
@@ -313,7 +313,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#HW-W718 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#HW-W718 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Haier W718",
           "platforms": [
@@ -321,7 +321,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#ZTE Geek Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#ZTE Geek Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "ZTE V975",
           "platforms": [
@@ -329,7 +329,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#SM-N910C Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#SM-N910C Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Samsung SM-N910C",
           "platforms": [
@@ -337,7 +337,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo B6000-H Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* *Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Lenovo B6000-H Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* *Safari/*",
           "engine": "U3",
           "device": "Lenovo B6000-H",
           "platforms": [
@@ -345,7 +345,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#SP-6020 QUASAR Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#SP-6020 QUASAR Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Woo SP6020",
           "platforms": [
@@ -353,7 +353,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#LG-D325 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#LG-D325 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "LG D325",
           "platforms": [
@@ -361,7 +361,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#CTAB785R16-3G Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#CTAB785R16-3G Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Condor CTAB785R16-3G",
           "platforms": [
@@ -369,7 +369,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#RG500 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#RG500 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "RugGear RG500",
           "platforms": [
@@ -377,7 +377,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#N003 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#N003 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "NEO N003",
           "platforms": [
@@ -385,7 +385,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#TCL M2U Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#TCL M2U Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "TCL M2U",
           "platforms": [
@@ -393,7 +393,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#x909 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#x909 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "OPPO X909",
           "platforms": [
@@ -401,7 +401,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#GT-I8552 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#GT-I8552 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Samsung GT-I8552",
           "platforms": [
@@ -409,7 +409,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#A1002 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#A1002 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Lexand A1002",
           "platforms": [
@@ -417,7 +417,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#ALCATEL ONE TOUCH 6030X Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#ALCATEL ONE TOUCH 6030X Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Alcatel OT-6030X",
           "platforms": [
@@ -425,7 +425,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#ZTE Blade L2 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#ZTE Blade L2 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "ZTE Blade L2",
           "platforms": [
@@ -433,7 +433,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#GT-N7000 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#GT-N7000 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Samsung GT-N7000",
           "platforms": [
@@ -441,7 +441,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Boost IIse Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Boost IIse Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Highscreen Boost II SE",
           "platforms": [
@@ -449,7 +449,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Novo7Fire Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Novo7Fire Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Ainol Novo 7 Fire",
           "platforms": [
@@ -457,7 +457,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#PMP3970B Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#PMP3970B Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Prestigio PMP3970B",
           "platforms": [
@@ -465,7 +465,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#LIFE PLAY Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#LIFE PLAY Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "BLU Life Play",
           "platforms": [
@@ -473,7 +473,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#GT-I9082 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#GT-I9082 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Samsung GT-I9082",
           "platforms": [
@@ -481,7 +481,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#XLD Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#XLD Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Alps XLD",
           "platforms": [
@@ -489,7 +489,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#BQS-4501 Bristol Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#BQS-4501 Bristol Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "BQ BQS-4501",
           "platforms": [
@@ -497,7 +497,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#HTC Desire 400 dual sim Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#HTC Desire 400 dual sim Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "HTC Desire 400",
           "platforms": [
@@ -505,7 +505,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#GU730C Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#GU730C Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Globex GU730C",
           "platforms": [
@@ -513,7 +513,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#NT-3502M Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#NT-3502M Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "iconBIT NT-3502M",
           "platforms": [
@@ -521,7 +521,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#M5302 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#M5302 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "iRU M5302",
           "platforms": [
@@ -529,7 +529,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#A808 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#A808 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Lenovo A808",
           "platforms": [
@@ -537,7 +537,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Android TV Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Android TV Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "general TV Device",
           "platforms": [
@@ -545,7 +545,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#MD027G Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#MD027G Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "M-way MD027G",
           "platforms": [
@@ -553,7 +553,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#JIAYU-G2S Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#JIAYU-G2S Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Jiayu G2S",
           "platforms": [
@@ -561,7 +561,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Kiano Elegance by Zanetti Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Kiano Elegance by Zanetti Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Kiano Elegance",
           "platforms": [
@@ -569,7 +569,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#OV-Vertis-01 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#OV-Vertis-01 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Overmax Vertis 01",
           "platforms": [
@@ -577,7 +577,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Oysters T37 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Oysters T37 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Oysters T37",
           "platforms": [
@@ -585,7 +585,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Alpha GTR Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Alpha GTR Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Highscreen Alpha GTR",
           "platforms": [
@@ -593,7 +593,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#NetTAB THOR-LE Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#NetTAB THOR-LE Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "iconBIT THOR-LE",
           "platforms": [
@@ -601,7 +601,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#MI 2S Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#MI 2S Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Xiaomi MI 2S",
           "platforms": [
@@ -609,7 +609,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#MID-717R Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#MID-717R Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "VastKing MID-717R",
           "platforms": [
@@ -617,7 +617,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Coolpad 8675 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Coolpad 8675 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Coolpad 8675",
           "platforms": [
@@ -625,7 +625,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#NT-3507M Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#NT-3507M Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "iconBIT NT-3507M",
           "platforms": [
@@ -633,7 +633,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#JINGA_IGO_M1 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#JINGA_IGO_M1 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Jinga IGO M1",
           "platforms": [
@@ -641,7 +641,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#F600 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#F600 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Flying F600",
           "platforms": [
@@ -649,7 +649,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#X10 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#X10 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "SonyEricsson X10",
           "platforms": [
@@ -657,7 +657,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#E380 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#E380 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Acer E380",
           "platforms": [
@@ -665,7 +665,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#PAP4020DUO Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#PAP4020DUO Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Prestigio PAP4020DUO",
           "platforms": [
@@ -673,7 +673,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#P4 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#P4 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "PiPO P4",
           "platforms": [
@@ -681,7 +681,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#SM-G530H Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#SM-G530H Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Samsung SM-G530H",
           "platforms": [
@@ -689,7 +689,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#GT-I9105P Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#GT-I9105P Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Samsung GT-I9105P",
           "platforms": [
@@ -697,7 +697,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#HUAWEI P7-L09 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#HUAWEI P7-L09 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Huawei P7-L09",
           "platforms": [
@@ -705,7 +705,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Flylife Connect 7.85 3G Slim Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Flylife Connect 7.85 3G Slim Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Fly Flylife Connect 7.85 3G Slim",
           "platforms": [
@@ -713,7 +713,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo A516 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A516 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Lenovo A516",
           "platforms": [
@@ -721,7 +721,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo A319 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A319 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Lenovo A319",
           "platforms": [
@@ -729,7 +729,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo A328 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A328 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Lenovo A328",
           "platforms": [
@@ -737,7 +737,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo A7600-H Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A7600-H Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Lenovo A7600-H",
           "platforms": [
@@ -745,7 +745,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo A536 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A536 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Lenovo A536",
           "platforms": [
@@ -753,7 +753,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo A5000 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A5000 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Lenovo A5000",
           "platforms": [
@@ -761,7 +761,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo A5500-H Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A5500-H Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Lenovo A5500-H",
           "platforms": [
@@ -769,7 +769,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo A5500-H Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A5500-H Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Lenovo A5500-H",
           "platforms": [
@@ -777,7 +777,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Coolpad 8297-T01 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Coolpad 8297-T01 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Coolpad 8297-T01",
           "platforms": [
@@ -785,7 +785,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Coolpad 8730L Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Coolpad 8730L Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Coolpad 8730L",
           "platforms": [
@@ -793,7 +793,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Coolpad 8089 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Coolpad 8089 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Coolpad 8089",
           "platforms": [
@@ -801,7 +801,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#XT1021 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#XT1021 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Motorola XT1021",
           "platforms": [
@@ -809,7 +809,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#IdealTab 10 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#IdealTab 10 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Lenovo IdealTab 10",
           "platforms": [
@@ -817,7 +817,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#XT1068 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#XT1068 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Motorola XT1068",
           "platforms": [
@@ -825,7 +825,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#HTC One M9 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#HTC One M9 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "HTC M9",
           "platforms": [
@@ -833,20 +833,20 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM# Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM# Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "platforms": [
             "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4", "Android_5_0", "Android_5_1", "Android_6_0", "Android_6_1", "Android_7_0", "Android_7_1", "Android"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM# Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* Chrome\/* Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile",
+          "match": "Mozilla/5.0 (#PLATFORM# Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* Chrome/* Safari/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile",
           "engine": "Blink",
           "platforms": [
             "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4", "Android_5_0", "Android_5_1", "Android_6_0", "Android_6_1", "Android_7_0", "Android_7_1", "Android"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (Linux; U;* iphone 6s Build\/KVT49L) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (Linux; U;* iphone 6s Build/KVT49L) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Xianghe iphone 6s",
           "platforms": [
@@ -854,14 +854,14 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (Linux; U;* Build\/KVT49L) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (Linux; U;* Build/KVT49L) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "platforms": [
             "Android_4_4"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#GT-P5200 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile",
+          "match": "Mozilla/5.0 (#PLATFORM#GT-P5200 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* Safari/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile",
           "engine": "WebKit",
           "device": "Samsung GT-P5200",
           "platforms": [
@@ -869,7 +869,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#JY-F1 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile",
+          "match": "Mozilla/5.0 (#PLATFORM#JY-F1 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* Safari/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile",
           "engine": "WebKit",
           "device": "Jiayu F1",
           "platforms": [
@@ -877,14 +877,14 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM# Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile",
+          "match": "Mozilla/5.0 (#PLATFORM# Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* Safari/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile",
           "engine": "WebKit",
           "platforms": [
             "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4", "Android_5_0", "Android_5_1", "Android_6_0", "Android_6_1", "Android_7_0", "Android_7_1", "Android"
           ]
         },
         {
-          "match": "UCWEB\/2.0 (Linux; U; Opera Mini\/*; GSmart_T4) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "UCWEB/2.0 (Linux; U; Opera Mini/*; GSmart_T4) U2/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "U2",
           "device": "Gigabyte GSmart T4",
           "platforms": [
@@ -892,7 +892,7 @@
           ]
         },
         {
-          "match": "UCWEB\/2.0 (Linux; U; Opera Mini\/*; S-TELL_M260) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "UCWEB/2.0 (Linux; U; Opera Mini/*; S-TELL_M260) U2/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "U2",
           "device": "S-TELL M260",
           "platforms": [
@@ -900,7 +900,7 @@
           ]
         },
         {
-          "match": "UCWEB\/2.0 (Linux; U; Opera Mini\/*; SPHS_on_Hsdroid) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "UCWEB/2.0 (Linux; U; Opera Mini/*; SPHS_on_Hsdroid) U2/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "U2",
           "device": "sprd SPHS On HSDroid",
           "platforms": [
@@ -908,7 +908,7 @@
           ]
         },
         {
-          "match": "UCWEB\/2.0 (Linux; U; Opera Mini\/*; InFocus_M310) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "UCWEB/2.0 (Linux; U; Opera Mini/*; InFocus_M310) U2/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "U2",
           "device": "Foxconn Infocus M310",
           "platforms": [
@@ -916,14 +916,14 @@
           ]
         },
         {
-          "match": "UCWEB\/2.0 (Linux; U; Opera Mini\/*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "UCWEB/2.0 (Linux; U; Opera Mini/*) U2/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "U2",
           "platforms": [
             "Android_4_2", "Android"
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#H1+) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#H1+) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Hummer H1+",
           "platforms": [
@@ -931,7 +931,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#HTC_Desire_816) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#HTC_Desire_816) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "HTC Desire 816",
           "platforms": [
@@ -939,7 +939,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#S4501M) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#S4501M) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "DNS S4501M",
           "platforms": [
@@ -947,7 +947,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#SUPRA_M121G) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#SUPRA_M121G) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Supra M121G",
           "platforms": [
@@ -955,7 +955,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#Micromax_A106) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#Micromax_A106) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Micromax A106",
           "platforms": [
@@ -963,7 +963,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#GT-I5500) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#GT-I5500) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "GT-I5500",
           "platforms": [
@@ -971,7 +971,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#PICOpad_S1*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#PICOpad_S1*) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Axioo PicoPad S1",
           "platforms": [
@@ -979,7 +979,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#H30-U10) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#H30-U10) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Huawei H30-U10",
           "platforms": [
@@ -987,7 +987,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#S200) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#S200) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Cubot S200",
           "platforms": [
@@ -995,7 +995,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#M785) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#M785) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "AOSON M785",
           "platforms": [
@@ -1003,7 +1003,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#Micromax_A35) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#Micromax_A35) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Micromax A35",
           "platforms": [
@@ -1011,7 +1011,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#GT-P3110) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#GT-P3110) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Samsung GT-P3110",
           "platforms": [
@@ -1019,7 +1019,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "general Mobile Phone (Touch)",
           "platforms": [
@@ -1031,7 +1031,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (iPhone#PLATFORM#)*AppleWebKit\/*(*KHTML* like Gecko*)*UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "Mozilla/5.0 (iPhone#PLATFORM#)*AppleWebKit/*(*KHTML* like Gecko*)*UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "WebKit",
           "device": "iPhone",
           "platforms": [
@@ -1046,7 +1046,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#)*AppleWebKit\/*(*KHTML* like Gecko*)*UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "Mozilla/5.0 (#PLATFORM#)*AppleWebKit/*(*KHTML* like Gecko*)*UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "WebKit",
           "device": "general Mobile Device (Apple)",
           "platforms": [
@@ -1084,7 +1084,7 @@
       },
       "children": [
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#; Desktop) AppleWebKit\/* (KHTML* like Gecko) UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "Mozilla/5.0 (#PLATFORM#; Desktop) AppleWebKit/* (KHTML* like Gecko) UCBrowser/#MAJORVER#.#MINORVER#*",
           "platforms": [
             "Win8_1_64", "Win8_1_32", "Win8_64", "Win8_32", "Win7_64", "Win7_32", "Vista_64", "Vista_32"
           ]

--- a/resources/user-agents/browsers/uc-browser/uc-web-11.json
+++ b/resources/user-agents/browsers/uc-browser/uc-web-11.json
@@ -28,7 +28,7 @@
       },
       "children": [
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Moto G (4) Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Moto G (4) Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Motorola G4",
           "platforms": [
@@ -36,7 +36,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM##DEVICE# Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "devices": {
             "F103 Pro": "Gionee F103 Pro",
@@ -53,7 +53,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM##DEVICE# Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "devices": {
             "N9132": "ZTE Prestige",
@@ -85,7 +85,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM##DEVICE# Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "devices": {
             "SM-G530F": "Samsung SM-G530F",
@@ -100,7 +100,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM##DEVICE# Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "devices": {
             "ASUS_Z007": "Asus Z007",
@@ -122,7 +122,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM##DEVICE# Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "devices": {
             "Micromax A177": "Micromax A177",
@@ -134,7 +134,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM##DEVICE# Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "devices": {
             "GT-S7262": "Samsung GT-S7262",
@@ -145,7 +145,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#SM-G530H Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#SM-G530H Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Samsung SM-G530H",
           "platforms": [
@@ -153,7 +153,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#SM-G900F Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#SM-G900F Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Samsung SM-G900F",
           "platforms": [
@@ -161,7 +161,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM# Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM# Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "platforms": [
             "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2",
             "Android_4_3", "Android_4_4", "Android_5_0", "Android_5_1",
@@ -193,7 +193,7 @@
       },
       "children": [
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#; Desktop) AppleWebKit\/* (KHTML* like Gecko) UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "Mozilla/5.0 (#PLATFORM#; Desktop) AppleWebKit/* (KHTML* like Gecko) UCBrowser/#MAJORVER#.#MINORVER#*",
           "platforms": [
             "Win8_1_64", "Win8_1_32", "Win8_64", "Win8_32", "Win7_64", "Win7_32", "Vista_64", "Vista_32"
           ]

--- a/resources/user-agents/browsers/uc-browser/uc-web-2.json
+++ b/resources/user-agents/browsers/uc-browser/uc-web-2.json
@@ -35,28 +35,28 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#) AppleWebKit\/* (KHTML,*like Gecko*) UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* *Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#) AppleWebKit/* (KHTML,*like Gecko*) UCBrowser/#MAJORVER#.#MINORVER#* U3/* *Safari/*",
           "engine": "U3",
           "platforms": [
             "Android_2_2", "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#) AppleWebKit\/* (KHTML,*like Gecko*) UCBrowser\/#MAJORVER#.#MINORVER#*Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#) AppleWebKit/* (KHTML,*like Gecko*) UCBrowser/#MAJORVER#.#MINORVER#*Safari/*",
           "engine": "WebKit",
           "platforms": [
             "Android_2_2", "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#) AppleWebKit\/* (KHTML,*like Gecko*) Version\/*Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "Mozilla/5.0 (#PLATFORM#) AppleWebKit/* (KHTML,*like Gecko*) Version/*Safari/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "WebKit",
           "platforms": [
             "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android"
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "device": "general Mobile Phone (Touch)",
           "engine": "U2",
           "platforms": [
@@ -68,21 +68,21 @@
           ]
         },
         {
-          "match": "UCWEB\/*(Linux; U; Opera Mini\/*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "UCWEB/*(Linux; U; Opera Mini/*) U2/* UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "U2",
           "platforms": [
             "Android"
           ]
         },
         {
-          "match": "UCWEB\/*(Android; U; Opera Mini\/*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "UCWEB/*(Android; U; Opera Mini/*) U2/* UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "U2",
           "platforms": [
             "Android"
           ]
         },
         {
-          "match": "UCWEB\/*(Java*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "UCWEB/*(Java*) U2/* UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "U2",
           "device": "general Mobile Device",
           "platforms": [
@@ -90,7 +90,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0*(iPad#PLATFORM#) AppleWebKit\/* (KHTML* like Gecko) UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0*(iPad#PLATFORM#) AppleWebKit/* (KHTML* like Gecko) UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "iPad",
           "platforms": [
@@ -98,15 +98,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0*(iPad#PLATFORM#) AppleWebKit\/* (KHTML* like Gecko) UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
-          "engine": "U3",
-          "device": "iPad",
-          "platforms": [
-            "iOS_C_7_1", "iOS_C_7_0", "iOS_C_8_0"
-          ]
-        },
-        {
-          "match": "Mozilla\/5.0 (#PLATFORM#LG-P970 Build\/*) AppleWebKit\/* (KHTML* like Gecko) Version\/* Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "Mozilla/5.0 (#PLATFORM#LG-P970 Build/*) AppleWebKit/* (KHTML* like Gecko) Version/* Safari/* UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "WebKit",
           "device": "LG P970",
           "platforms": [
@@ -114,14 +106,14 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#) AppleWebKit\/* (KHTML* like Gecko) Version\/* Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "Mozilla/5.0 (#PLATFORM#) AppleWebKit/* (KHTML* like Gecko) Version/* Safari/* UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "WebKit",
           "platforms": [
             "Android_2_3"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#) AppleWebKit\/* (KHTML* like Gecko) Version\/* Chrome\/*Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "Mozilla/5.0 (#PLATFORM#) AppleWebKit/* (KHTML* like Gecko) Version/* Chrome/*Safari/* UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "WebKit",
           "platforms": [
             "Android_4_4"

--- a/resources/user-agents/browsers/uc-browser/uc-web-3.json
+++ b/resources/user-agents/browsers/uc-browser/uc-web-3.json
@@ -39,7 +39,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#) AppleWebKit\/* (KHTML,*like Gecko*) UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* *Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#) AppleWebKit/* (KHTML,*like Gecko*) UCBrowser/#MAJORVER#.#MINORVER#* U3/* *Safari/*",
           "engine": "U3",
           "platforms": [
             "Android_2_2",
@@ -52,7 +52,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#) AppleWebKit\/* (KHTML,*like Gecko*) UCBrowser\/#MAJORVER#.#MINORVER#*Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#) AppleWebKit/* (KHTML,*like Gecko*) UCBrowser/#MAJORVER#.#MINORVER#*Safari/*",
           "engine": "WebKit",
           "platforms": [
             "Android_2_2",
@@ -65,7 +65,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM##DEVICE# Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/*Chrome\/*Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/*Chrome/*Safari/* UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "Blink",
           "devices": {
             "Lenovo A5500-H": "Lenovo A5500-H",
@@ -83,14 +83,14 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#) AppleWebKit\/* (KHTML,*like Gecko*) Version\/*Chrome\/*Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "Mozilla/5.0 (#PLATFORM#) AppleWebKit/* (KHTML,*like Gecko*) Version/*Chrome/*Safari/* UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "Blink",
           "platforms": [
             "Android_4_4", "Android"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#A701 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/*Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "Mozilla/5.0 (#PLATFORM#A701 Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/*Safari/* UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "WebKit",
           "device": "Acer A701",
           "platforms": [
@@ -98,7 +98,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#SM-P601 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/*Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "Mozilla/5.0 (#PLATFORM#SM-P601 Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/*Safari/* UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "WebKit",
           "device": "Samsung SM-P601",
           "platforms": [
@@ -106,7 +106,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM##DEVICE# Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/*Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/*Safari/* UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "WebKit",
           "devices": {
             "HL-PC1088": "Honlin PC1088",
@@ -119,7 +119,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM##DEVICE# Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/*Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/*Safari/* UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "WebKit",
           "devices": {
             "iDxD4": "Digma iDxD4 3G",
@@ -130,7 +130,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#JY-G3 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/*Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "Mozilla/5.0 (#PLATFORM#JY-G3 Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/*Safari/* UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "WebKit",
           "device": "Jiayu G3",
           "platforms": [
@@ -138,7 +138,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#) AppleWebKit\/* (KHTML,*like Gecko*) Version\/*Chrome\/*Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "Mozilla/5.0 (#PLATFORM#) AppleWebKit/* (KHTML,*like Gecko*) Version/*Chrome/*Safari/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "Blink",
           "platforms": [
             "Android_2_3",
@@ -153,7 +153,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#) AppleWebKit\/* (KHTML,*like Gecko*) Version\/*Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "Mozilla/5.0 (#PLATFORM#) AppleWebKit/* (KHTML,*like Gecko*) Version/*Safari/* UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "WebKit",
           "platforms": [
             "Android_2_3",
@@ -168,7 +168,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#SAMSUNG; GT-I8350*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#SAMSUNG; GT-I8350*) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Samsung GT-I8350",
           "platforms": [
@@ -177,7 +177,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(*GT-P3100*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(*GT-P3100*) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Samsung GT-P3100",
           "platforms": [
@@ -185,7 +185,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "platforms": [
             "Android_E_2_1",
@@ -211,21 +211,21 @@
           ]
         },
         {
-          "match": "UCWEB\/*(Linux; U; Opera Mini\/*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "UCWEB/*(Linux; U; Opera Mini/*) U2/* UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "U2",
           "platforms": [
             "Android"
           ]
         },
         {
-          "match": "UCWEB\/*(Android; U; Opera Mini\/*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "UCWEB/*(Android; U; Opera Mini/*) U2/* UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "U2",
           "platforms": [
             "Android"
           ]
         },
         {
-          "match": "UCWEB\/*(Java*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "UCWEB/*(Java*) U2/* UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "U2",
           "device": "general Mobile Device",
           "platforms": [
@@ -233,7 +233,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(MIDP-2.0*#DEVICE#) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "UCWEB/*(MIDP-2.0*#DEVICE#) U2/* UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "U2",
           "devices": {
             "C2305": "Sony C2305",
@@ -249,14 +249,14 @@
           ]
         },
         {
-          "match": "UCWEB\/*(MIDP-2.0*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "UCWEB/*(MIDP-2.0*) U2/* UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "U2",
           "platforms": [
             "JAVA"
           ]
         },
         {
-          "match": "Mozilla\/5.0*(iPad#PLATFORM#) AppleWebKit\/* (KHTML* like Gecko) Version\/*Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "Mozilla/5.0*(iPad#PLATFORM#) AppleWebKit/* (KHTML* like Gecko) Version/*Safari/* UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "WebKit",
           "device": "iPad",
           "platforms": [
@@ -264,7 +264,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0*(#PLATFORM#) AppleWebKit\/* (KHTML* like Gecko) Version\/*Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "Mozilla/5.0*(#PLATFORM#) AppleWebKit/* (KHTML* like Gecko) Version/*Safari/* UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "WebKit",
           "device": "general Mobile Device (Apple)",
           "platforms": [
@@ -294,7 +294,7 @@
       },
       "children": [
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#) AppleWebKit\/* (KHTML* like Gecko) Chrome\/* Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "Mozilla/5.0 (#PLATFORM#) AppleWebKit/* (KHTML* like Gecko) Chrome/* Safari/* UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "WebKit",
           "device": "Macintosh",
           "platforms": [

--- a/resources/user-agents/browsers/uc-browser/uc-web-4.json
+++ b/resources/user-agents/browsers/uc-browser/uc-web-4.json
@@ -28,7 +28,7 @@
       },
       "children": [
         {
-          "match": "UCWEB\/*(#PLATFORM##DEVICE#*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM##DEVICE#*) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "devices": {
             "NOKIA; RM-914": "Nokia Lumia 520 RM-914",
             "NOKIA; RM-974": "Nokia Lumia 635 RM-974",
@@ -42,14 +42,14 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#NOKIA; RM-1045*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#NOKIA; RM-1045*) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "device": "Nokia Lumia 930 RM-1045",
           "platforms": [
             "WinPhone10_B", "WinPhone8.1_B"
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "platforms": [
             "WinPhone8.1_B"
           ]

--- a/resources/user-agents/browsers/uc-browser/uc-web-5.json
+++ b/resources/user-agents/browsers/uc-browser/uc-web-5.json
@@ -27,7 +27,7 @@
       },
       "children": [
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#) AppleWebKit\/* (KHTML, like Gecko) Chrome\/* UBrowser\/#MAJORVER#.#MINORVER#* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#) AppleWebKit/* (KHTML, like Gecko) Chrome/* UBrowser/#MAJORVER#.#MINORVER#* Safari/*",
           "platforms": [
             "Win10_x64", "Win10_64", "Win10_32", "Win10_x64_B", "Win10_64_B", "Win10_32_B",
             "Win8_1_64", "Win8_1_32", "Win8_64", "Win8_32", "Win7_64", "Win7_32", "Vista_64", "Vista_32"

--- a/resources/user-agents/browsers/uc-browser/uc-web-7.json
+++ b/resources/user-agents/browsers/uc-browser/uc-web-7.json
@@ -91,7 +91,7 @@
           ]
         },
         {
-          "match": "#DEVICE#\/UC Browser#MAJORVER#.#MINORVER#*",
+          "match": "#DEVICE#/UC Browser#MAJORVER#.#MINORVER#*",
           "devices": {
             "NokiaE63": "Nokia E63",
             "NokiaN73": "Nokia N73",
@@ -102,7 +102,7 @@
           }
         },
         {
-          "match": "#DEVICE#\/UC Browser#MAJORVER#.#MINORVER#*",
+          "match": "#DEVICE#/UC Browser#MAJORVER#.#MINORVER#*",
           "devices": {
             "Nokia5230": "Nokia 5230",
             "nokia6120c": "Nokia 6120c"
@@ -112,21 +112,21 @@
           ]
         },
         {
-          "match": "S8500 UCWEB6.0\/UC Browser#MAJORVER#.#MINORVER#*",
+          "match": "S8500 UCWEB6.0/UC Browser#MAJORVER#.#MINORVER#*",
           "device": "Samsung S8500",
           "platforms": [
             "Bada"
           ]
         },
         {
-          "match": "IUC(U;iOS 4.3*)\/UCWEB#MAJORVER#.#MINORVER#*",
+          "match": "IUC(U;iOS 4.3*)/UCWEB#MAJORVER#.#MINORVER#*",
           "device": "iPod Touch",
           "platforms": [
             "iOS_G_4_3"
           ]
         },
         {
-          "match": "LG-KS20* Browser\/IEMobile\/* MMS\/LG-MMS-WINCE* (compatible; MSIE 4.01; Windows CE*)\/UC Browser#MAJORVER#.#MINORVER#*",
+          "match": "LG-KS20* Browser/IEMobile/* MMS/LG-MMS-WINCE* (compatible; MSIE 4.01; Windows CE*)/UC Browser#MAJORVER#.#MINORVER#*",
           "engine": "Trident",
           "device": "LG KS20",
           "platforms": [
@@ -134,14 +134,14 @@
           ]
         },
         {
-          "match": "NokiaC1-01\/* Profile\/MIDP* nokiac1-01\/UC Browser#MAJORVER#.#MINORVER#*",
+          "match": "NokiaC1-01/* Profile/MIDP* nokiac1-01/UC Browser#MAJORVER#.#MINORVER#*",
           "device": "Nokia C1-01",
           "platforms": [
             "JAVA"
           ]
         },
         {
-          "match": "*\/UC Browser#MAJORVER#.#MINORVER#*"
+          "match": "*/UC Browser#MAJORVER#.#MINORVER#*"
         }
       ]
     }

--- a/resources/user-agents/browsers/uc-browser/uc-web-8.json
+++ b/resources/user-agents/browsers/uc-browser/uc-web-8.json
@@ -35,7 +35,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#SonyEricssonU1) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#SonyEricssonU1) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "SonyEricsson U1",
           "platforms": [
@@ -43,7 +43,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM##DEVICE#) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM##DEVICE#) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "devices": {
             "GT-S5570": "Samsung GT-S5570",
@@ -55,7 +55,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM##DEVICE#) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM##DEVICE#) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "devices": {
             "D2105": "Sony D2105",
@@ -67,7 +67,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM##DEVICE#) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM##DEVICE#) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "devices": {
             "IQ4490": "Fly IQ4490",
@@ -79,7 +79,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM##DEVICE#) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM##DEVICE#) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "devices": {
             "GT-I9082": "Samsung GT-I9082",
@@ -91,7 +91,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#SM-G530H) U2\/* UC Browser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#SM-G530H) U2/* UC Browser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Samsung SM-G530H",
           "platforms": [
@@ -99,7 +99,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#IQ440) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#IQ440) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Fly IQ440",
           "platforms": [
@@ -107,7 +107,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "general Mobile Phone (Touch)",
           "platforms": [
@@ -119,7 +119,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(Linux; U; Opera Mini\/*GT-S7262) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "UCWEB/*(Linux; U; Opera Mini/*GT-S7262) U2/* UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "U2",
           "device": "Samsung GT-S7262",
           "platforms": [
@@ -127,7 +127,7 @@
           ]
         },
         {
-          "match": "UCWEB\/2.0 (Linux; U; Opera Mini\/*; #DEVICE#) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "UCWEB/2.0 (Linux; U; Opera Mini/*; #DEVICE#) U2/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "U2",
           "devices": {
             "ASUS_T00J": "Asus T00J",
@@ -138,7 +138,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(Linux; U; Opera Mini\/*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "UCWEB/*(Linux; U; Opera Mini/*) U2/* UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "U2",
           "device": "general Mobile Phone (Touch)",
           "platforms": [
@@ -146,7 +146,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(Android; U; Opera Mini\/*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "UCWEB/*(Android; U; Opera Mini/*) U2/* UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "U2",
           "device": "general Mobile Phone (Touch)",
           "platforms": [
@@ -154,14 +154,14 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (Java;*samsung-gt-s5263) UCBrowser#MAJORVER#.#MINORVER#*UCWEB*Mobile*UNTRUSTED\/*",
+          "match": "Mozilla/5.0 (Java;*samsung-gt-s5263) UCBrowser#MAJORVER#.#MINORVER#*UCWEB*Mobile*UNTRUSTED/*",
           "device": "Samsung GT-S5263",
           "platforms": [
             "JAVA"
           ]
         },
         {
-          "match": "UCWEB\/*(Java*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "UCWEB/*(Java*) U2/* UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "U2",
           "device": "general Mobile Phone",
           "platforms": [
@@ -169,13 +169,13 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#DEVICE#*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "UCWEB/*(#DEVICE#*) U2/* UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "U2",
           "devices": {
-            "BlackBerry*8520\/": "Blackberry 8520",
-            "BlackBerry*8530\/": "Blackberry 8530",
-            "BlackBerry*9320\/": "Blackberry 9320",
-            "BlackBerry*9700\/": "Blackberry 9700",
+            "BlackBerry*8520/": "Blackberry 8520",
+            "BlackBerry*8530/": "Blackberry 8530",
+            "BlackBerry*9320/": "Blackberry 9320",
+            "BlackBerry*9700/": "Blackberry 9700",
             "BlackBerry": "Blackberry Blackberry"
           },
           "platforms": [
@@ -183,7 +183,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#GT-I9100 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) UCBrowser\/#MAJORVER#.#MINORVER#* Mobile Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#GT-I9100 Build/*) AppleWebKit/* (KHTML,*like Gecko*) UCBrowser/#MAJORVER#.#MINORVER#* Mobile Safari/*",
           "engine": "WebKit",
           "device": "GT-I9100",
           "platforms": [
@@ -191,14 +191,14 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#GT-I9100G Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) UCBrowser\/#MAJORVER#.#MINORVER#* Mobile Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#GT-I9100G Build/*) AppleWebKit/* (KHTML,*like Gecko*) UCBrowser/#MAJORVER#.#MINORVER#* Mobile Safari/*",
           "device": "GT-I9100G",
           "platforms": [
             "Android_2_3"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#) AppleWebKit\/* (KHTML,*like Gecko*) UCBrowser\/#MAJORVER#.#MINORVER#*Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#) AppleWebKit/* (KHTML,*like Gecko*) UCBrowser/#MAJORVER#.#MINORVER#*Safari/*",
           "engine": "WebKit",
           "device": "general Mobile Phone (Touch)",
           "platforms": [
@@ -206,7 +206,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo P780_ROW Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/*Safari\/*UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "Mozilla/5.0 (#PLATFORM#Lenovo P780_ROW Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/*Safari/*UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "WebKit",
           "device": "Lenovo P780",
           "platforms": [
@@ -214,7 +214,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#SM-G130H Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/*Safari\/*UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "Mozilla/5.0 (#PLATFORM#SM-G130H Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/*Safari/*UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "WebKit",
           "device": "Samsung SM-G130H",
           "platforms": [
@@ -222,7 +222,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#ST25i Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/*Safari\/*UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "Mozilla/5.0 (#PLATFORM#ST25i Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/*Safari/*UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "WebKit",
           "device": "SonyEricsson ST25i",
           "platforms": [
@@ -230,7 +230,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#) AppleWebKit\/* (KHTML,*like Gecko*) Version\/*Safari\/*UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "Mozilla/5.0 (#PLATFORM#) AppleWebKit/* (KHTML,*like Gecko*) Version/*Safari/*UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "WebKit",
           "device": "general Mobile Phone (Touch)",
           "platforms": [
@@ -238,14 +238,14 @@
           ]
         },
         {
-          "match": "#DEVICE#\/UC Browser#MAJORVER#.#MINORVER#* UNTRUSTED\/1.0",
+          "match": "#DEVICE#/UC Browser#MAJORVER#.#MINORVER#* UNTRUSTED/1.0",
           "devices": {
             "samsung-gt-s5620": "Samsung GT-S5620",
             "samsung-gt-s3370": "Samsung GT-S3370"
           }
         },
         {
-          "match": "*\/UC Browser#MAJORVER#.#MINORVER#* UNTRUSTED\/1.0",
+          "match": "*/UC Browser#MAJORVER#.#MINORVER#* UNTRUSTED/1.0",
           "device": "general Mobile Phone (Touch)"
         }
       ]

--- a/resources/user-agents/browsers/uc-browser/uc-web-9.json
+++ b/resources/user-agents/browsers/uc-browser/uc-web-9.json
@@ -35,7 +35,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Mi-440 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/* Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile",
+          "match": "Mozilla/5.0 (#PLATFORM#Mi-440 Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/* Safari/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile",
           "engine": "WebKit",
           "device": "Spice Mi-440",
           "platforms": [
@@ -43,14 +43,14 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM# Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/* Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile",
+          "match": "Mozilla/5.0 (#PLATFORM# Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/* Safari/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile",
           "engine": "WebKit",
           "platforms": [
             "Android_4_2", "Android_4_3", "Android_4_4", "Android"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#HTC T328w Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#HTC T328w Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "HTC T328w",
           "platforms": [
@@ -58,7 +58,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#GT-A7100 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#GT-A7100 Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "sprd GT-A7100",
           "platforms": [
@@ -66,7 +66,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#WT19i Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#WT19i Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "SonyEricsson WT19i",
           "platforms": [
@@ -74,7 +74,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#HTC Desire SV Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#HTC Desire SV Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "HTC Desire SV",
           "platforms": [
@@ -82,7 +82,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#C6903 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#C6903 Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Sony C6903",
           "platforms": [
@@ -90,7 +90,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#PMP7074B3GRU Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#PMP7074B3GRU Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Prestigio PMP7074B3GRU",
           "platforms": [
@@ -98,7 +98,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#D2302 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#D2302 Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Sony D2302",
           "platforms": [
@@ -106,7 +106,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#LG-D325 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#LG-D325 Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "LG D325",
           "platforms": [
@@ -114,7 +114,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#s4502 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#s4502 Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "DNS S4502",
           "platforms": [
@@ -122,7 +122,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#GT-S7390 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#GT-S7390 Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Samsung GT-S7390",
           "platforms": [
@@ -130,7 +130,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#ZTE LEO Q2 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#ZTE LEO Q2 Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "ZTE V769M",
           "platforms": [
@@ -138,7 +138,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Sky Plus Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Sky Plus Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Odys Sky Plus 3G",
           "platforms": [
@@ -146,7 +146,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo S720 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Lenovo S720 Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Lenovo S720",
           "platforms": [
@@ -154,7 +154,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#DG800 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#DG800 Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Doogee DG800",
           "platforms": [
@@ -162,7 +162,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo S660 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Lenovo S660 Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Lenovo S660",
           "platforms": [
@@ -170,7 +170,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#LG-D690 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#LG-D690 Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "LG D690",
           "platforms": [
@@ -178,7 +178,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#GT-S7392 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#GT-S7392 Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Samsung GT-S7392",
           "platforms": [
@@ -186,7 +186,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#ST25i Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#ST25i Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "SonyEricsson ST25i",
           "platforms": [
@@ -194,7 +194,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#DIGMA iDsD10 3G Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#DIGMA iDsD10 3G Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Digma iDsD10 3G",
           "platforms": [
@@ -202,7 +202,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#K1 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#K1 Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Lenovo K1",
           "platforms": [
@@ -210,7 +210,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Keneksi-Libra_Dual Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Keneksi-Libra_Dual Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Keneksi Libra",
           "platforms": [
@@ -218,7 +218,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#LG-P936 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#LG-P936 Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "LG P936",
           "platforms": [
@@ -226,7 +226,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#DIGMA iDsD8 3G Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#DIGMA iDsD8 3G Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Digma iDsD8 3G",
           "platforms": [
@@ -234,7 +234,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#ALCATEL ONE TOUCH 6010X Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#ALCATEL ONE TOUCH 6010X Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Alcatel OT-6010X",
           "platforms": [
@@ -242,7 +242,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#AirTab M104G Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#AirTab M104G Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "DNS AirTab M104G",
           "platforms": [
@@ -250,7 +250,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#L925(L1020) Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#L925(L1020) Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "China L925 l1020",
           "platforms": [
@@ -258,7 +258,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#ASUS Transformer Pad TF700T*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#ASUS Transformer Pad TF700T*) AppleWebKit/* (KHTML,*like Gecko*) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Asus TF700T",
           "platforms": [
@@ -266,7 +266,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo A320t Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/* UCBrowser\/#MAJORVER#.#MINORVER#*\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A320t Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/* UCBrowser/#MAJORVER#.#MINORVER#*/* Safari/*",
           "engine": "U3",
           "device": "Lenovo A320t",
           "platforms": [
@@ -274,7 +274,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#GT-I9100 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) UCBrowser\/#MAJORVER#.#MINORVER#* Mobile Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#GT-I9100 Build/*) AppleWebKit/* (KHTML,*like Gecko*) UCBrowser/#MAJORVER#.#MINORVER#* Mobile Safari/*",
           "engine": "WebKit",
           "device": "GT-I9100",
           "platforms": [
@@ -282,7 +282,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#GT-I9100T Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) UCBrowser\/#MAJORVER#.#MINORVER#* Mobile Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#GT-I9100T Build/*) AppleWebKit/* (KHTML,*like Gecko*) UCBrowser/#MAJORVER#.#MINORVER#* Mobile Safari/*",
           "engine": "WebKit",
           "device": "Samsung GT-I9100T",
           "platforms": [
@@ -290,7 +290,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#LA-M1 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) UCBrowser\/#MAJORVER#.#MINORVER#* Mobile Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#LA-M1 Build/*) AppleWebKit/* (KHTML,*like Gecko*) UCBrowser/#MAJORVER#.#MINORVER#* Mobile Safari/*",
           "engine": "WebKit",
           "device": "Beidou LA-M1",
           "platforms": [
@@ -298,7 +298,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#TM-5204 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Mobile Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#TM-5204 Build/*) AppleWebKit/* (KHTML,*like Gecko*) UCBrowser/#MAJORVER#.#MINORVER#* U3/* Mobile Safari/*",
           "engine": "U3",
           "device": "TeXet TM-5204",
           "platforms": [
@@ -306,7 +306,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#GT-S7562 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#GT-S7562 Build/*) AppleWebKit/* (KHTML,*like Gecko*) UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Samsung GT-S7562",
           "platforms": [
@@ -314,7 +314,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#C1505 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#C1505 Build/*) AppleWebKit/* (KHTML,*like Gecko*) UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Sony C1505",
           "platforms": [
@@ -322,7 +322,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#HUAWEI Y320-U10 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#HUAWEI Y320-U10 Build/*) AppleWebKit/* (KHTML,*like Gecko*) UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Huawei Y320-U10",
           "platforms": [
@@ -330,7 +330,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#HTC One S Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#HTC One S Build/*) AppleWebKit/* (KHTML,*like Gecko*) UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "HTC PJ401",
           "platforms": [
@@ -338,7 +338,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#GT-I9152 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#GT-I9152 Build/*) AppleWebKit/* (KHTML,*like Gecko*) UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Samsung GT-I9152",
           "platforms": [
@@ -346,7 +346,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo A390t Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A390t Build/*) AppleWebKit/* (KHTML,*like Gecko*) UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Lenovo A390t",
           "platforms": [
@@ -354,21 +354,21 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM# Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM# Build/*) AppleWebKit/* (KHTML,*like Gecko*) UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "platforms": [
             "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM# Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) UCBrowser\/#MAJORVER#.#MINORVER#* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM# Build/*) AppleWebKit/* (KHTML,*like Gecko*) UCBrowser/#MAJORVER#.#MINORVER#* Safari/*",
           "engine": "WebKit",
           "platforms": [
             "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#GT-I9300 *) AppleWebKit\/* (KHTML,*like Gecko*) *UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#GT-I9300 *) AppleWebKit/* (KHTML,*like Gecko*) *UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Samsung GT-I9300",
           "platforms": [
@@ -376,7 +376,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#MI 3W *) AppleWebKit\/* (KHTML,*like Gecko*) *UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#MI 3W *) AppleWebKit/* (KHTML,*like Gecko*) *UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Xiaomi MI 3W",
           "platforms": [
@@ -384,7 +384,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#FP1 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) *UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#FP1 Build/*) AppleWebKit/* (KHTML,*like Gecko*) *UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Fairphone FP1",
           "platforms": [
@@ -392,7 +392,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#HUAWEI U8815 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) *UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#HUAWEI U8815 Build/*) AppleWebKit/* (KHTML,*like Gecko*) *UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Huawei U8815",
           "platforms": [
@@ -400,7 +400,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#WEXLER-TAB-7T Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) *UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#WEXLER-TAB-7T Build/*) AppleWebKit/* (KHTML,*like Gecko*) *UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Wexler TAB-7T",
           "platforms": [
@@ -408,7 +408,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#GV7777 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) *UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#GV7777 Build/*) AppleWebKit/* (KHTML,*like Gecko*) *UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Prestigio GV7777",
           "platforms": [
@@ -416,7 +416,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#GT-S6802 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) *UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#GT-S6802 Build/*) AppleWebKit/* (KHTML,*like Gecko*) *UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Samsung GT-S6802",
           "platforms": [
@@ -424,7 +424,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo A316i Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) *UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A316i Build/*) AppleWebKit/* (KHTML,*like Gecko*) *UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Lenovo A316i",
           "platforms": [
@@ -432,7 +432,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo A606 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) *UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A606 Build/*) AppleWebKit/* (KHTML,*like Gecko*) *UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Lenovo A606",
           "platforms": [
@@ -440,7 +440,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo A319 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) *UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A319 Build/*) AppleWebKit/* (KHTML,*like Gecko*) *UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Lenovo A319",
           "platforms": [
@@ -448,7 +448,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo A369i Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) *UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A369i Build/*) AppleWebKit/* (KHTML,*like Gecko*) *UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Lenovo A369i",
           "platforms": [
@@ -456,7 +456,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo A536 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) *UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A536 Build/*) AppleWebKit/* (KHTML,*like Gecko*) *UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Lenovo A536",
           "platforms": [
@@ -464,7 +464,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo A6000 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) *UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A6000 Build/*) AppleWebKit/* (KHTML,*like Gecko*) *UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Lenovo A6000",
           "platforms": [
@@ -472,7 +472,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo A859 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) *UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A859 Build/*) AppleWebKit/* (KHTML,*like Gecko*) *UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Lenovo A859",
           "platforms": [
@@ -480,7 +480,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo A526 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) *UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A526 Build/*) AppleWebKit/* (KHTML,*like Gecko*) *UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Lenovo A526",
           "platforms": [
@@ -488,7 +488,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo A880 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) *UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A880 Build/*) AppleWebKit/* (KHTML,*like Gecko*) *UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Lenovo A880",
           "platforms": [
@@ -496,7 +496,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo A238t Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) *UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A238t Build/*) AppleWebKit/* (KHTML,*like Gecko*) *UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Lenovo A238t",
           "platforms": [
@@ -504,7 +504,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo A320t Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) *UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A320t Build/*) AppleWebKit/* (KHTML,*like Gecko*) *UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Lenovo A320t",
           "platforms": [
@@ -512,7 +512,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo A328 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) *UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A328 Build/*) AppleWebKit/* (KHTML,*like Gecko*) *UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Lenovo A328",
           "platforms": [
@@ -520,7 +520,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo A5500-H Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) *UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A5500-H Build/*) AppleWebKit/* (KHTML,*like Gecko*) *UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "device": "Lenovo A5500-H",
           "platforms": [
@@ -528,21 +528,21 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#) AppleWebKit\/* (KHTML,*like Gecko*) *UCBrowser\/#MAJORVER#.#MINORVER#* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#) AppleWebKit/* (KHTML,*like Gecko*) *UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "engine": "U3",
           "platforms": [
             "Android_2_2", "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4", "Android"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#) AppleWebKit\/* (KHTML,*like Gecko*) *UCBrowser\/#MAJORVER#.#MINORVER#*Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#) AppleWebKit/* (KHTML,*like Gecko*) *UCBrowser/#MAJORVER#.#MINORVER#*Safari/*",
           "engine": "WebKit",
           "platforms": [
             "Android_2_2", "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4", "Android"
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#W200 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/*Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "Mozilla/5.0 (#PLATFORM#W200 Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/*Safari/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "WebKit",
           "device": "ThL W200",
           "platforms": [
@@ -550,7 +550,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo_S820_ROW Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/*Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "Mozilla/5.0 (#PLATFORM#Lenovo_S820_ROW Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/*Safari/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "WebKit",
           "device": "Lenovo S820_ROW",
           "platforms": [
@@ -558,7 +558,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Impress_L Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/*Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "Mozilla/5.0 (#PLATFORM#Impress_L Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/*Safari/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "WebKit",
           "device": "Vertex Impress L",
           "platforms": [
@@ -566,7 +566,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#GT-S5830 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/*Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "Mozilla/5.0 (#PLATFORM#GT-S5830 Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/*Safari/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "WebKit",
           "device": "GT-S5830",
           "platforms": [
@@ -574,7 +574,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#UMI_X2 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/*Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "Mozilla/5.0 (#PLATFORM#UMI_X2 Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/*Safari/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "WebKit",
           "device": "UMi X2",
           "platforms": [
@@ -582,7 +582,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#SK17i Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/*Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "Mozilla/5.0 (#PLATFORM#SK17i Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/*Safari/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "WebKit",
           "device": "SonyEricsson SK17i",
           "platforms": [
@@ -590,7 +590,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#GT-S6802 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/*Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "Mozilla/5.0 (#PLATFORM#GT-S6802 Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/*Safari/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "WebKit",
           "device": "Samsung GT-S6802",
           "platforms": [
@@ -598,7 +598,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#PAP4500DUO Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/*Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "Mozilla/5.0 (#PLATFORM#PAP4500DUO Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/*Safari/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "WebKit",
           "device": "Prestigio PAP4500DUO",
           "platforms": [
@@ -606,7 +606,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#LG-D415 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/*Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "Mozilla/5.0 (#PLATFORM#LG-D415 Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/*Safari/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "WebKit",
           "device": "LG D415",
           "platforms": [
@@ -614,7 +614,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#GT-S6500T Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/*Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "Mozilla/5.0 (#PLATFORM#GT-S6500T Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/*Safari/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "WebKit",
           "device": "Samsung GT-S6500T",
           "platforms": [
@@ -622,7 +622,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#GT-I9060 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/*Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "Mozilla/5.0 (#PLATFORM#GT-I9060 Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/*Safari/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "WebKit",
           "device": "Samsung GT-I9060",
           "platforms": [
@@ -630,7 +630,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#HTC_One Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/*Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "Mozilla/5.0 (#PLATFORM#HTC_One Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/*Safari/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "WebKit",
           "device": "HTC M7",
           "platforms": [
@@ -638,7 +638,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#Lenovo_A529 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/*Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "Mozilla/5.0 (#PLATFORM#Lenovo_A529 Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/*Safari/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "WebKit",
           "device": "Lenovo A529",
           "platforms": [
@@ -646,7 +646,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#IQ430 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/*Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "Mozilla/5.0 (#PLATFORM#IQ430 Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/*Safari/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "WebKit",
           "device": "Fly IQ430",
           "platforms": [
@@ -654,7 +654,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#TF-SP4502 Build\/*) AppleWebKit\/* (KHTML,*like Gecko*) Version\/*Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "Mozilla/5.0 (#PLATFORM#TF-SP4502 Build/*) AppleWebKit/* (KHTML,*like Gecko*) Version/*Safari/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "WebKit",
           "device": "Telefunken TF-SP4502",
           "platforms": [
@@ -662,14 +662,14 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#) AppleWebKit\/* (KHTML,*like Gecko*) Version\/*Safari\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "Mozilla/5.0 (#PLATFORM#) AppleWebKit/* (KHTML,*like Gecko*) Version/*Safari/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "WebKit",
           "platforms": [
             "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4", "Android"
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#iPh*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#iPh*) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "iPhone",
           "platforms": [
@@ -677,7 +677,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#GT-S5360) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#GT-S5360) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Samsung GT-S5360",
           "platforms": [
@@ -686,7 +686,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#GT-S7562) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#GT-S7562) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Samsung GT-S7562",
           "platforms": [
@@ -695,7 +695,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#Micromax A27) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#Micromax A27) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Micromax A27",
           "platforms": [
@@ -704,7 +704,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#W8_beyond) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#W8_beyond) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "ThL W8",
           "platforms": [
@@ -713,7 +713,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#Micromax_A106) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#Micromax_A106) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Micromax A106",
           "platforms": [
@@ -721,7 +721,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#MT11i) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#MT11i) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "SonyEricsson MT11i",
           "platforms": [
@@ -730,7 +730,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#PMP7070C3G) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#PMP7070C3G) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Prestigio PMP7070C3G",
           "platforms": [
@@ -738,7 +738,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#NOKIAE5-00u) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#NOKIAE5-00u) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Nokia E5-00",
           "platforms": [
@@ -746,7 +746,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#GT-9000) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#GT-9000) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Star GT9000",
           "platforms": [
@@ -754,7 +754,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#W100) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#W100) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "ThL W100",
           "platforms": [
@@ -762,7 +762,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#T118) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#T118) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Twinovo T118",
           "platforms": [
@@ -770,7 +770,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#ZTE_V829) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#ZTE_V829) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "ZTE V829",
           "platforms": [
@@ -778,7 +778,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#HM_1SW) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#HM_1SW) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Xiaomi HM 1SW",
           "platforms": [
@@ -786,7 +786,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#GT-I9100) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#GT-I9100) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "GT-I9100",
           "platforms": [
@@ -794,7 +794,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#GT-I9100P) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#GT-I9100P) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "GT-I9100P",
           "platforms": [
@@ -802,7 +802,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#NOKIA6700s) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#NOKIA6700s) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Nokia 6700s",
           "platforms": [
@@ -810,7 +810,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#LG-P765) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#LG-P765) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "LG P765",
           "platforms": [
@@ -818,7 +818,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#MB300) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#MB300) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Motorola MB300",
           "platforms": [
@@ -826,7 +826,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#LG-D724) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#LG-D724) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "LG D724",
           "platforms": [
@@ -834,7 +834,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#U8230) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#U8230) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Huawei U8230",
           "platforms": [
@@ -842,7 +842,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#HTC_Ruby) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#HTC_Ruby) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "HTC Ruby",
           "platforms": [
@@ -850,7 +850,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#Lenovo_A706_ROW) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#Lenovo_A706_ROW) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Lenovo A706",
           "platforms": [
@@ -858,7 +858,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#Lenovo_K910L) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#Lenovo_K910L) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Lenovo K910L",
           "platforms": [
@@ -866,7 +866,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#HTC_Desire_310) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#HTC_Desire_310) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "HTC Desire 310",
           "platforms": [
@@ -874,7 +874,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#CinemaTV_3G) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#CinemaTV_3G) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Explay CinemaTV 3G",
           "platforms": [
@@ -882,7 +882,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#HS-U98) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#HS-U98) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Hisense HS-U98",
           "platforms": [
@@ -890,7 +890,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#Lenovo_A3000-H) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#Lenovo_A3000-H) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Lenovo A3000-H",
           "platforms": [
@@ -898,7 +898,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#Lenovo_A516) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#Lenovo_A516) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Lenovo A516",
           "platforms": [
@@ -906,7 +906,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#PantechP9060) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#PantechP9060) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Pantech P9060",
           "platforms": [
@@ -914,7 +914,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#Micromax_A94) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#Micromax_A94) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Micromax A94",
           "platforms": [
@@ -922,7 +922,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#iDxD8_3G) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#iDxD8_3G) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Digma iDxD8 3G",
           "platforms": [
@@ -930,7 +930,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#SM-T311) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#SM-T311) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Samsung SM-T311",
           "platforms": [
@@ -938,7 +938,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#Lenovo_P770) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#Lenovo_P770) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Lenovo P770",
           "platforms": [
@@ -946,7 +946,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#WEXLER.BOOK_T7008) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#WEXLER.BOOK_T7008) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Wexler Book T7008",
           "platforms": [
@@ -954,7 +954,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#GT-N8000) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#GT-N8000) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Samsung GT-N8000",
           "platforms": [
@@ -962,7 +962,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#T8700) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#T8700) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Ninetology T8700",
           "platforms": [
@@ -970,7 +970,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#Lenovo?A316i) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#Lenovo?A316i) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Lenovo A316i",
           "platforms": [
@@ -978,7 +978,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#Lenovo_A318t) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#Lenovo_A318t) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Lenovo A318t",
           "platforms": [
@@ -986,7 +986,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#Lenovo_A390t) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#Lenovo_A390t) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Lenovo A390t",
           "platforms": [
@@ -994,7 +994,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#GT-I9195) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#GT-I9195) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Samsung GT-I9195",
           "platforms": [
@@ -1002,7 +1002,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#Lenovo A7600-H) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#Lenovo A7600-H) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Lenovo A7600-H",
           "platforms": [
@@ -1010,7 +1010,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#Lenovo A369i) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#Lenovo A369i) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "Lenovo A369i",
           "platforms": [
@@ -1018,7 +1018,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/*",
+          "match": "UCWEB/*(#PLATFORM#) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/*",
           "engine": "U2",
           "device": "general Mobile Phone (Touch)",
           "platforms": [
@@ -1030,14 +1030,14 @@
           ]
         },
         {
-          "match": "UCWEB\/*(Android; U; Opera Mini\/*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "UCWEB/*(Android; U; Opera Mini/*) U2/* UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "U2",
           "platforms": [
             "Android"
           ]
         },
         {
-          "match": "UCWEB\/2.0(Linux; U; Opera Mini\/*; GT-S5670 Build\/*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "UCWEB/2.0(Linux; U; Opera Mini/*; GT-S5670 Build/*) U2/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "U2",
           "device": "Samsung GT-S5670",
           "platforms": [
@@ -1045,7 +1045,7 @@
           ]
         },
         {
-          "match": "UCWEB\/2.0(Linux; U; Opera Mini\/*; MB525 Build\/*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "UCWEB/2.0(Linux; U; Opera Mini/*; MB525 Build/*) U2/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "U2",
           "device": "Motorola MB525",
           "platforms": [
@@ -1053,14 +1053,14 @@
           ]
         },
         {
-          "match": "UCWEB\/2.0(Linux; U; Opera Mini\/*; * Build\/*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "UCWEB/2.0(Linux; U; Opera Mini/*; * Build/*) U2/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "U2",
           "platforms": [
             "Android"
           ]
         },
         {
-          "match": "UCWEB\/2.0 (Linux; U; Opera Mini\/*; Videocon_A15) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "UCWEB/2.0 (Linux; U; Opera Mini/*; Videocon_A15) U2/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "U2",
           "device": "Videocon A15",
           "platforms": [
@@ -1068,7 +1068,7 @@
           ]
         },
         {
-          "match": "UCWEB\/2.0 (Linux; U; Opera Mini\/*; QUMO_QUEST_450) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "UCWEB/2.0 (Linux; U; Opera Mini/*; QUMO_QUEST_450) U2/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "U2",
           "device": "Qumo QUEST 450",
           "platforms": [
@@ -1076,7 +1076,7 @@
           ]
         },
         {
-          "match": "UCWEB\/2.0 (Linux; U; Opera Mini\/*; ATLAS_W) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "UCWEB/2.0 (Linux; U; Opera Mini/*; ATLAS_W) U2/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "U2",
           "device": "ZTE Atlas W",
           "platforms": [
@@ -1084,7 +1084,7 @@
           ]
         },
         {
-          "match": "UCWEB\/2.0 (Linux; U; Opera Mini\/*; LG-E612) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "UCWEB/2.0 (Linux; U; Opera Mini/*; LG-E612) U2/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "U2",
           "device": "LG E612",
           "platforms": [
@@ -1092,7 +1092,7 @@
           ]
         },
         {
-          "match": "UCWEB\/2.0 (Linux; U; Opera Mini\/*; SHV-E210K) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "UCWEB/2.0 (Linux; U; Opera Mini/*; SHV-E210K) U2/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "U2",
           "device": "Samsung SHV-E210K",
           "platforms": [
@@ -1100,7 +1100,7 @@
           ]
         },
         {
-          "match": "UCWEB\/2.0 (Linux; U; Opera Mini\/*; SHV-E250S) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "UCWEB/2.0 (Linux; U; Opera Mini/*; SHV-E250S) U2/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "U2",
           "device": "Samsung SHV-E250S",
           "platforms": [
@@ -1108,7 +1108,7 @@
           ]
         },
         {
-          "match": "UCWEB\/2.0 (Linux; U; Opera Mini\/*; USCCADR6230US) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "UCWEB/2.0 (Linux; U; Opera Mini/*; USCCADR6230US) U2/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "U2",
           "device": "HTC Wildfire S ADR6230",
           "platforms": [
@@ -1116,7 +1116,7 @@
           ]
         },
         {
-          "match": "UCWEB\/2.0 (Linux; U; Opera Mini\/*; thl_4400) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "UCWEB/2.0 (Linux; U; Opera Mini/*; thl_4400) U2/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "U2",
           "device": "ThL 4400",
           "platforms": [
@@ -1124,7 +1124,7 @@
           ]
         },
         {
-          "match": "UCWEB\/2.0 (Linux; U; Opera Mini\/*; Adi_5S) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "UCWEB/2.0 (Linux; U; Opera Mini/*; Adi_5S) U2/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "U2",
           "device": "Artel Adi5S",
           "platforms": [
@@ -1132,7 +1132,7 @@
           ]
         },
         {
-          "match": "UCWEB\/2.0 (Linux; U; Opera Mini\/*; SM-T2105) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "UCWEB/2.0 (Linux; U; Opera Mini/*; SM-T2105) U2/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "U2",
           "device": "Samsung SM-T2105",
           "platforms": [
@@ -1140,7 +1140,7 @@
           ]
         },
         {
-          "match": "UCWEB\/2.0 (Linux; U; Opera Mini\/*; Oysters_T72HRi_3G) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "UCWEB/2.0 (Linux; U; Opera Mini/*; Oysters_T72HRi_3G) U2/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "U2",
           "device": "Oysters T72HRi 3G",
           "platforms": [
@@ -1148,7 +1148,7 @@
           ]
         },
         {
-          "match": "UCWEB\/2.0 (Linux; U; Opera Mini\/*; Lenovo_A376) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "UCWEB/2.0 (Linux; U; Opera Mini/*; Lenovo_A376) U2/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "U2",
           "device": "Lenovo A376",
           "platforms": [
@@ -1156,7 +1156,7 @@
           ]
         },
         {
-          "match": "UCWEB\/2.0 (Linux; U; Opera Mini\/*; ZTE_Grand_Era) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "UCWEB/2.0 (Linux; U; Opera Mini/*; ZTE_Grand_Era) U2/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "U2",
           "device": "ZTE Grand Era",
           "platforms": [
@@ -1164,7 +1164,7 @@
           ]
         },
         {
-          "match": "UCWEB\/2.0 (Linux; U; Opera Mini\/*; PMP7280C3G) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "UCWEB/2.0 (Linux; U; Opera Mini/*; PMP7280C3G) U2/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "U2",
           "device": "Prestigio PMP7280C3G",
           "platforms": [
@@ -1172,7 +1172,7 @@
           ]
         },
         {
-          "match": "UCWEB\/2.0 (Linux; U; Opera Mini\/*; HTC_Desire_S) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "UCWEB/2.0 (Linux; U; Opera Mini/*; HTC_Desire_S) U2/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "U2",
           "device": "HTC Desire S",
           "platforms": [
@@ -1180,7 +1180,7 @@
           ]
         },
         {
-          "match": "UCWEB\/2.0 (Linux; U; Opera Mini\/*; T8700) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "UCWEB/2.0 (Linux; U; Opera Mini/*; T8700) U2/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "U2",
           "device": "Ninetology T8700",
           "platforms": [
@@ -1188,21 +1188,21 @@
           ]
         },
         {
-          "match": "UCWEB\/2.0 (Linux; U; Opera Mini\/*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* Mobile*",
+          "match": "UCWEB/2.0 (Linux; U; Opera Mini/*) U2/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "U2",
           "platforms": [
             "Android"
           ]
         },
         {
-          "match": "UCWEB\/2.0 (Linux; U; Opera Mini\/*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "UCWEB/2.0 (Linux; U; Opera Mini/*) U2/* UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "U2",
           "platforms": [
             "Android"
           ]
         },
         {
-          "match": "UCWEB\/2.0 (Java; *SAMSUNG-SGH-T669) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/* Mobile*",
+          "match": "UCWEB/2.0 (Java; *SAMSUNG-SGH-T669) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/* Mobile*",
           "engine": "U2",
           "device": "Samsung SGH-T669",
           "platforms": [
@@ -1210,7 +1210,7 @@
           ]
         },
         {
-          "match": "UCWEB\/2.0 (Java; *nokiaasha500dualsim) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/* Mobile*",
+          "match": "UCWEB/2.0 (Java; *nokiaasha500dualsim) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/* Mobile*",
           "engine": "U2",
           "device": "Nokia Asha 500 Dual Sim",
           "platforms": [
@@ -1218,7 +1218,7 @@
           ]
         },
         {
-          "match": "UCWEB\/2.0 (Java; *NokiaC6-01) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/* Mobile*",
+          "match": "UCWEB/2.0 (Java; *NokiaC6-01) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/* Mobile*",
           "engine": "U2",
           "device": "Nokia C6-01",
           "platforms": [
@@ -1226,7 +1226,7 @@
           ]
         },
         {
-          "match": "UCWEB\/2.0 (Java; *NokiaC6-00) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/* Mobile*",
+          "match": "UCWEB/2.0 (Java; *NokiaC6-00) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/* Mobile*",
           "engine": "U2",
           "device": "Nokia C6-00",
           "platforms": [
@@ -1234,7 +1234,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(Java; *ALCATEL_one_touch_818) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/* Mobile*",
+          "match": "UCWEB/*(Java; *ALCATEL_one_touch_818) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/* Mobile*",
           "engine": "U2",
           "device": "Alcatel OT-818",
           "platforms": [
@@ -1242,7 +1242,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(Java; *SonyEricssonK790i) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/* Mobile*",
+          "match": "UCWEB/*(Java; *SonyEricssonK790i) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/* Mobile*",
           "engine": "U2",
           "device": "SonyEricsson K790i",
           "platforms": [
@@ -1250,7 +1250,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(Java*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "UCWEB/*(Java*) U2/* UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "U2",
           "device": "general Mobile Phone",
           "platforms": [
@@ -1258,7 +1258,7 @@
           ]
         },
         {
-          "match": "Nokia5130c-2\/* Profile\/MIDP-2* UCWEB\/2.0 (*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/* Mobile*",
+          "match": "Nokia5130c-2/* Profile/MIDP-2* UCWEB/2.0 (*) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/* Mobile*",
           "engine": "U2",
           "device": "Nokia 5130c-2",
           "platforms": [
@@ -1266,7 +1266,7 @@
           ]
         },
         {
-          "match": "Nokia305\/* Profile\/MIDP-2* UCWEB\/2.0 (*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/* Mobile*",
+          "match": "Nokia305/* Profile/MIDP-2* UCWEB/2.0 (*) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/* Mobile*",
           "engine": "U2",
           "device": "Nokia 305",
           "platforms": [
@@ -1274,7 +1274,7 @@
           ]
         },
         {
-          "match": "Nokia308\/* Profile\/MIDP-2* UCWEB\/2.0 (*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/* Mobile*",
+          "match": "Nokia308/* Profile/MIDP-2* UCWEB/2.0 (*) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/* Mobile*",
           "engine": "U2",
           "device": "Nokia 308",
           "platforms": [
@@ -1282,7 +1282,7 @@
           ]
         },
         {
-          "match": "Nokia311\/* Profile\/MIDP-2* UCWEB\/2.0 (*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/* Mobile*",
+          "match": "Nokia311/* Profile/MIDP-2* UCWEB/2.0 (*) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/* Mobile*",
           "engine": "U2",
           "device": "Nokia 311",
           "platforms": [
@@ -1290,7 +1290,7 @@
           ]
         },
         {
-          "match": "Nokia110\/* Profile\/MIDP-2* UCWEB\/2.0 (*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/* Mobile*",
+          "match": "Nokia110/* Profile/MIDP-2* UCWEB/2.0 (*) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/* Mobile*",
           "engine": "U2",
           "device": "Nokia 110",
           "platforms": [
@@ -1298,7 +1298,7 @@
           ]
         },
         {
-          "match": "Nokia210\/* Profile\/MIDP-2* UCWEB\/2.0 (*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/* Mobile*",
+          "match": "Nokia210/* Profile/MIDP-2* UCWEB/2.0 (*) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/* Mobile*",
           "engine": "U2",
           "device": "Nokia 210",
           "platforms": [
@@ -1306,7 +1306,7 @@
           ]
         },
         {
-          "match": "Nokia200\/* Profile\/MIDP-2* UCWEB\/2.0 (*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/* Mobile*",
+          "match": "Nokia200/* Profile/MIDP-2* UCWEB/2.0 (*) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/* Mobile*",
           "engine": "U2",
           "device": "Nokia 200",
           "platforms": [
@@ -1314,7 +1314,7 @@
           ]
         },
         {
-          "match": "Nokia205\/* Profile\/MIDP-2* UCWEB\/2.0 (*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/* Mobile*",
+          "match": "Nokia205/* Profile/MIDP-2* UCWEB/2.0 (*) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/* Mobile*",
           "engine": "U2",
           "device": "Nokia 205",
           "platforms": [
@@ -1322,7 +1322,7 @@
           ]
         },
         {
-          "match": "Nokia206\/* Profile\/MIDP-2* UCWEB\/2.0 (*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/* Mobile*",
+          "match": "Nokia206/* Profile/MIDP-2* UCWEB/2.0 (*) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/* Mobile*",
           "engine": "U2",
           "device": "Nokia 206",
           "platforms": [
@@ -1330,7 +1330,7 @@
           ]
         },
         {
-          "match": "NokiaX2-02\/* Profile\/MIDP-2* UCWEB\/2.0 (*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/* Mobile*",
+          "match": "NokiaX2-02/* Profile/MIDP-2* UCWEB/2.0 (*) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/* Mobile*",
           "engine": "U2",
           "device": "Nokia X2-02",
           "platforms": [
@@ -1338,7 +1338,7 @@
           ]
         },
         {
-          "match": "NokiaX2-01\/* Profile\/MIDP-2* UCWEB\/2.0 (*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/* Mobile*",
+          "match": "NokiaX2-01/* Profile/MIDP-2* UCWEB/2.0 (*) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/* Mobile*",
           "engine": "U2",
           "device": "Nokia X2-01",
           "platforms": [
@@ -1346,7 +1346,7 @@
           ]
         },
         {
-          "match": "NokiaX3-02\/* Profile\/MIDP-2* UCWEB\/2.0 (*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/* Mobile*",
+          "match": "NokiaX3-02/* Profile/MIDP-2* UCWEB/2.0 (*) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/* Mobile*",
           "engine": "U2",
           "device": "Nokia X3-02",
           "platforms": [
@@ -1354,7 +1354,7 @@
           ]
         },
         {
-          "match": "NokiaC2-03\/* Profile\/MIDP-2* UCWEB\/2.0 (*) U2\/* UCBrowser\/#MAJORVER#.#MINORVER#* U2\/* Mobile*",
+          "match": "NokiaC2-03/* Profile/MIDP-2* UCWEB/2.0 (*) U2/* UCBrowser/#MAJORVER#.#MINORVER#* U2/* Mobile*",
           "engine": "U2",
           "device": "Nokia C2-03",
           "platforms": [
@@ -1362,14 +1362,14 @@
           ]
         },
         {
-          "match": "dv(GT-S6102);pr(UCBrowser\/#MAJORVER#.#MINORVER#*);ov(Android 2.3.6)*",
+          "match": "dv(GT-S6102);pr(UCBrowser/#MAJORVER#.#MINORVER#*);ov(Android 2.3.6)*",
           "device": "Samsung GT-S6102",
           "platforms": [
             "Android_2_3"
           ]
         },
         {
-          "match": "dv(*);pr(UCBrowser\/#MAJORVER#.#MINORVER#*);ov(Android*",
+          "match": "dv(*);pr(UCBrowser/#MAJORVER#.#MINORVER#*);ov(Android*",
           "platforms": [
             "Android"
           ]
@@ -1397,7 +1397,7 @@
       },
       "children": [
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#; Desktop) AppleWebKit\/* (KHTML* like Gecko) UCBrowser\/#MAJORVER#.#MINORVER#*",
+          "match": "Mozilla/5.0 (#PLATFORM#; Desktop) AppleWebKit/* (KHTML* like Gecko) UCBrowser/#MAJORVER#.#MINORVER#*",
           "engine": "WebKit",
           "platforms": [
             "Win10_x64", "Win10_64", "Win10_32", "Win10_x64_B", "Win10_64_B", "Win10_32_B",

--- a/resources/user-agents/browsers/uc-browser/uc-web-generic.json
+++ b/resources/user-agents/browsers/uc-browser/uc-web-generic.json
@@ -31,7 +31,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#AO5510) U2\/* UCBrowser*",
+          "match": "UCWEB/*(#PLATFORM#AO5510) U2/* UCBrowser*",
           "engine": "U2",
           "device": "YU AO5510",
           "platforms": [
@@ -39,7 +39,7 @@
           ]
         },
         {
-          "match": "UCWEB\/*(#PLATFORM#) U2\/* UCBrowser*",
+          "match": "UCWEB/*(#PLATFORM#) U2/* UCBrowser*",
           "engine": "U2",
           "device": "general Mobile Phone (Touch)",
           "platforms": [
@@ -51,27 +51,27 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#) UC AppleWebKit\/* (KHTML* like Gecko) *Safari\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#) UC AppleWebKit/* (KHTML* like Gecko) *Safari/*",
           "platforms": [
             "Android_2_3", "Android"
           ]
         },
         {
-          "match": "UCWEB\/*(Linux; U; Opera Mini\/*) U2\/* UCBrowser\/*",
+          "match": "UCWEB/*(Linux; U; Opera Mini/*) U2/* UCBrowser/*",
           "engine": "U2",
           "platforms": [
             "Android"
           ]
         },
         {
-          "match": "UCWEB\/*(Android; U; Opera Mini\/*) U2\/* UCBrowser\/*",
+          "match": "UCWEB/*(Android; U; Opera Mini/*) U2/* UCBrowser/*",
           "engine": "U2",
           "platforms": [
             "Android"
           ]
         },
         {
-          "match": "UCWEB\/*(Java*) U2\/* UCBrowser\/*",
+          "match": "UCWEB/*(Java*) U2/* UCBrowser/*",
           "engine": "U2",
           "device": "general Mobile Device",
           "platforms": [
@@ -79,7 +79,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (iPhone#PLATFORM#)*AppleWebKit\/*(*KHTML* like Gecko*)*UCBrowser\/*",
+          "match": "Mozilla/5.0 (iPhone#PLATFORM#)*AppleWebKit/*(*KHTML* like Gecko*)*UCBrowser/*",
           "engine": "WebKit",
           "device": "iPhone",
           "platforms": [
@@ -90,7 +90,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (#PLATFORM#)*AppleWebKit\/*(*KHTML* like Gecko*)*UCBrowser\/*",
+          "match": "Mozilla/5.0 (#PLATFORM#)*AppleWebKit/*(*KHTML* like Gecko*)*UCBrowser/*",
           "engine": "WebKit",
           "device": "general Mobile Device (Apple)",
           "platforms": [
@@ -101,7 +101,7 @@
           ]
         },
         {
-          "match": "Mozilla\/5.0 (Linux; U;* iphone 6s Build\/KVT49L) AppleWebKit\/* (KHTML* like Gecko) Version\/* UCBrowser\/* U3\/* Safari\/*",
+          "match": "Mozilla/5.0 (Linux; U;* iphone 6s Build/KVT49L) AppleWebKit/* (KHTML* like Gecko) Version/* UCBrowser/* U3/* Safari/*",
           "engine": "U3",
           "device": "Xianghe iphone 6s",
           "platforms": [


### PR DESCRIPTION
I’ve been working on these files for the device expansion changes, so
figured I’d do a quick PR to change the slashes (see #1250).

This commit doesn’t contain any other changes, except for a duplicate
pattern removal in uc-web-2.json.