### PR TITLE
change phpunit configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
   - travis_retry composer update --optimize-autoloader --prefer-dist --prefer-stable --no-progress --no-interaction -vv $COMPOSER_FLAGS
 
 script:
-  - if [[ $COVERAGE == yes ]]; then vendor/bin/phpunit --exclude-group useragenttest --coverage-clover=coverage.clover; fi
+  - if [[ $COVERAGE == yes ]]; then vendor/bin/phpunit --exclude-group useragenttest --coverage-text --coverage-clover=coverage.clover; fi
   - if [[ $COVERAGE != yes && $COMPARE != yes ]]; then vendor/bin/phpunit --exclude-group useragenttest --no-coverage; fi
   - if [[ $COMPARE == yes ]]; then php -n vendor/bin/phpunit --no-coverage --colors --group useragenttest; fi
   - if [[ $EXECUTE_CS_CHECK == yes ]]; then php -n -d memory_limit=768M vendor/bin/phpcs; fi

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,8 @@
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/5.7/phpunit.xsd"
+    backupGlobals="false"
+    backupStaticAttributes="false"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
@@ -23,8 +25,4 @@
             <directory>./src</directory>
         </whitelist>
     </filter>
-
-    <logging>
-        <log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
-    </logging>
 </phpunit>


### PR DESCRIPTION
I was reading an article about PHPunit 6. There was said that disabling the Backup of globals would increase the speed of tests.
This PR disabled the Backup for Globals and removes Codecoverage from the default options.