### PR TITLE
change tests

### DIFF
--- a/tests/BrowscapTest/BrowscapTest.php
+++ b/tests/BrowscapTest/BrowscapTest.php
@@ -25,7 +25,7 @@ use Symfony\Component\Console\Application;
  * @category   BrowscapTest
  * @author     James Titcumb <james@asgrim.com>
  */
-class BrowscapTest extends \PHPUnit_Framework_TestCase
+class BrowscapTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @param \Symfony\Component\Console\Application $app

--- a/tests/BrowscapTest/Data/DataCollectionTest.php
+++ b/tests/BrowscapTest/Data/DataCollectionTest.php
@@ -26,7 +26,7 @@ use Monolog\Logger;
  * @category   BrowscapTest
  * @author     James Titcumb <james@asgrim.com>
  */
-class DataCollectionTest extends \PHPUnit_Framework_TestCase
+class DataCollectionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Psr\Log\LoggerInterface

--- a/tests/BrowscapTest/Data/DivisionTest.php
+++ b/tests/BrowscapTest/Data/DivisionTest.php
@@ -24,7 +24,7 @@ use Browscap\Data\Division;
  * @category   BrowscapTest
  * @author     James Titcumb <james@asgrim.com>
  */
-class DivisionTest extends \PHPUnit_Framework_TestCase
+class DivisionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * tests setter and getter

--- a/tests/BrowscapTest/Data/EngineTest.php
+++ b/tests/BrowscapTest/Data/EngineTest.php
@@ -24,7 +24,7 @@ use Browscap\Data\Engine;
  * @category   BrowscapTest
  * @author     James Titcumb <james@asgrim.com>
  */
-class EngineTest extends \PHPUnit_Framework_TestCase
+class EngineTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * tests setter and getter for the engine properties

--- a/tests/BrowscapTest/Data/ExpanderTest.php
+++ b/tests/BrowscapTest/Data/ExpanderTest.php
@@ -26,7 +26,7 @@ use Monolog\Logger;
  * @category   BrowscapTest
  * @author     Thomas Müller <t_mueller_stolzenhain@yahoo.de>
  */
-class ExpanderTest extends \PHPUnit_Framework_TestCase
+class ExpanderTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Psr\Log\LoggerInterface

--- a/tests/BrowscapTest/Data/Factory/EngineFactoryTest.php
+++ b/tests/BrowscapTest/Data/Factory/EngineFactoryTest.php
@@ -24,7 +24,7 @@ use Browscap\Data\Factory\EngineFactory;
  * @category   BrowscapTest
  * @author     James Titcumb <james@asgrim.com>
  */
-class EngineFactoryTest extends \PHPUnit_Framework_TestCase
+class EngineFactoryTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Browscap\Data\Factory\EngineFactory

--- a/tests/BrowscapTest/Data/Factory/PlatformFactoryTest.php
+++ b/tests/BrowscapTest/Data/Factory/PlatformFactoryTest.php
@@ -24,7 +24,7 @@ use Browscap\Data\Factory\PlatformFactory;
  * @category   BrowscapTest
  * @author     James Titcumb <james@asgrim.com>
  */
-class PlatformFactoryTest extends \PHPUnit_Framework_TestCase
+class PlatformFactoryTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Browscap\Data\Factory\PlatformFactory

--- a/tests/BrowscapTest/Data/PlatformTest.php
+++ b/tests/BrowscapTest/Data/PlatformTest.php
@@ -24,7 +24,7 @@ use Browscap\Data\Platform;
  * @category   BrowscapTest
  * @author     James Titcumb <james@asgrim.com>
  */
-class PlatformTest extends \PHPUnit_Framework_TestCase
+class PlatformTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * tests setter and getter for the match property

--- a/tests/BrowscapTest/Data/PropertyHolderTest.php
+++ b/tests/BrowscapTest/Data/PropertyHolderTest.php
@@ -24,7 +24,7 @@ use Browscap\Data\PropertyHolder;
  * @category   BrowscapTest
  * @author     James Titcumb <james@asgrim.com>
  */
-class PropertyHolderTest extends \PHPUnit_Framework_TestCase
+class PropertyHolderTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Browscap\Data\PropertyHolder

--- a/tests/BrowscapTest/Filter/CustomFilterTest.php
+++ b/tests/BrowscapTest/Filter/CustomFilterTest.php
@@ -24,7 +24,7 @@ use Browscap\Filter\CustomFilter;
  * @category   BrowscapTest
  * @author     Thomas Müller <t_mueller_stolzenhain@yahoo.de>
  */
-class CustomFilterTest extends \PHPUnit_Framework_TestCase
+class CustomFilterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Browscap\Filter\CustomFilter

--- a/tests/BrowscapTest/Filter/FullFilterTest.php
+++ b/tests/BrowscapTest/Filter/FullFilterTest.php
@@ -24,7 +24,7 @@ use Browscap\Filter\FullFilter;
  * @category   BrowscapTest
  * @author     Thomas Müller <t_mueller_stolzenhain@yahoo.de>
  */
-class FullFilterTest extends \PHPUnit_Framework_TestCase
+class FullFilterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Browscap\Filter\FullFilter

--- a/tests/BrowscapTest/Filter/LiteFilterTest.php
+++ b/tests/BrowscapTest/Filter/LiteFilterTest.php
@@ -24,7 +24,7 @@ use Browscap\Filter\LiteFilter;
  * @category   BrowscapTest
  * @author     Thomas Müller <t_mueller_stolzenhain@yahoo.de>
  */
-class LiteFilterTest extends \PHPUnit_Framework_TestCase
+class LiteFilterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Browscap\Filter\LiteFilter

--- a/tests/BrowscapTest/Filter/StandardFilterTest.php
+++ b/tests/BrowscapTest/Filter/StandardFilterTest.php
@@ -24,7 +24,7 @@ use Browscap\Filter\StandardFilter;
  * @category   BrowscapTest
  * @author     Thomas Müller <t_mueller_stolzenhain@yahoo.de>
  */
-class StandardFilterTest extends \PHPUnit_Framework_TestCase
+class StandardFilterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Browscap\Filter\StandardFilter

--- a/tests/BrowscapTest/Formatter/AspFormatterTest.php
+++ b/tests/BrowscapTest/Formatter/AspFormatterTest.php
@@ -24,7 +24,7 @@ use Browscap\Formatter\AspFormatter;
  * @category   BrowscapTest
  * @author     Thomas Müller <t_mueller_stolzenhain@yahoo.de>
  */
-class AspFormatterTest extends \PHPUnit_Framework_TestCase
+class AspFormatterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Browscap\Formatter\AspFormatter

--- a/tests/BrowscapTest/Formatter/CsvFormatterTest.php
+++ b/tests/BrowscapTest/Formatter/CsvFormatterTest.php
@@ -24,7 +24,7 @@ use Browscap\Formatter\CsvFormatter;
  * @category   BrowscapTest
  * @author     Thomas Müller <t_mueller_stolzenhain@yahoo.de>
  */
-class CsvFormatterTest extends \PHPUnit_Framework_TestCase
+class CsvFormatterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Browscap\Formatter\CsvFormatter

--- a/tests/BrowscapTest/Formatter/JsonFormatterTest.php
+++ b/tests/BrowscapTest/Formatter/JsonFormatterTest.php
@@ -24,7 +24,7 @@ use Browscap\Formatter\JsonFormatter;
  * @category   BrowscapTest
  * @author     Thomas Müller <t_mueller_stolzenhain@yahoo.de>
  */
-class JsonFormatterTest extends \PHPUnit_Framework_TestCase
+class JsonFormatterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Browscap\Formatter\JsonFormatter

--- a/tests/BrowscapTest/Formatter/PhpFormatterTest.php
+++ b/tests/BrowscapTest/Formatter/PhpFormatterTest.php
@@ -24,7 +24,7 @@ use Browscap\Formatter\PhpFormatter;
  * @category   BrowscapTest
  * @author     Thomas Müller <t_mueller_stolzenhain@yahoo.de>
  */
-class PhpFormatterTest extends \PHPUnit_Framework_TestCase
+class PhpFormatterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Browscap\Formatter\PhpFormatter

--- a/tests/BrowscapTest/Formatter/XmlFormatterTest.php
+++ b/tests/BrowscapTest/Formatter/XmlFormatterTest.php
@@ -24,7 +24,7 @@ use Browscap\Formatter\XmlFormatter;
  * @category   BrowscapTest
  * @author     Thomas Müller <t_mueller_stolzenhain@yahoo.de>
  */
-class XmlFormatterTest extends \PHPUnit_Framework_TestCase
+class XmlFormatterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Browscap\Formatter\XmlFormatter

--- a/tests/BrowscapTest/Generator/BuildCustomFileGeneratorTest.php
+++ b/tests/BrowscapTest/Generator/BuildCustomFileGeneratorTest.php
@@ -26,7 +26,7 @@ use Monolog\Logger;
  * @category   BrowscapTest
  * @author     James Titcumb <james@asgrim.com>
  */
-class BuildCustomFileGeneratorTest extends \PHPUnit_Framework_TestCase
+class BuildCustomFileGeneratorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var array

--- a/tests/BrowscapTest/Generator/BuildGeneratorTest.php
+++ b/tests/BrowscapTest/Generator/BuildGeneratorTest.php
@@ -26,7 +26,7 @@ use Monolog\Logger;
  * @category   BrowscapTest
  * @author     James Titcumb <james@asgrim.com>
  */
-class BuildGeneratorTest extends \PHPUnit_Framework_TestCase
+class BuildGeneratorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var array

--- a/tests/BrowscapTest/Generator/DiffGeneratorTest.php
+++ b/tests/BrowscapTest/Generator/DiffGeneratorTest.php
@@ -24,7 +24,7 @@ use Browscap\Generator\DiffGenerator;
  * @category   BrowscapTest
  * @author     James Titcumb <james@asgrim.com>
  */
-class DiffGeneratorTest extends \PHPUnit_Framework_TestCase
+class DiffGeneratorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Browscap\Generator\DiffGenerator

--- a/tests/BrowscapTest/Generator/GrepGeneratorTest.php
+++ b/tests/BrowscapTest/Generator/GrepGeneratorTest.php
@@ -25,7 +25,7 @@ use Browscap\Generator\GrepGenerator;
  * @category   BrowscapTest
  * @author     James Titcumb <james@asgrim.com>
  */
-class GrepGeneratorTest extends \PHPUnit_Framework_TestCase
+class GrepGeneratorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Browscap\Generator\GrepGenerator

--- a/tests/BrowscapTest/Generator/Helper/BuildHelperTest.php
+++ b/tests/BrowscapTest/Generator/Helper/BuildHelperTest.php
@@ -24,7 +24,7 @@ use Browscap\Generator\Helper\BuildHelper;
  * @category   BrowscapTest
  * @author     James Titcumb <james@asgrim.com>
  */
-class BuildHelperTest extends \PHPUnit_Framework_TestCase
+class BuildHelperTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * tests running a build

--- a/tests/BrowscapTest/Helper/CollectionCreatorTest.php
+++ b/tests/BrowscapTest/Helper/CollectionCreatorTest.php
@@ -26,7 +26,7 @@ use Monolog\Logger;
  * @category   BrowscapTest
  * @author     James Titcumb <james@asgrim.com>
  */
-class CollectionCreatorTest extends \PHPUnit_Framework_TestCase
+class CollectionCreatorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Psr\Log\LoggerInterface

--- a/tests/BrowscapTest/Helper/LoggerHelperTest.php
+++ b/tests/BrowscapTest/Helper/LoggerHelperTest.php
@@ -25,7 +25,7 @@ use Symfony\Component\Console\Output\NullOutput;
  * @category   BrowscapTest
  * @author     Thomas Müller <t_mueller_stolzenhain@yahoo.de>
  */
-class LoggerHelperTest extends \PHPUnit_Framework_TestCase
+class LoggerHelperTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * tests creating a logger instance

--- a/tests/BrowscapTest/Parser/IniParserTest.php
+++ b/tests/BrowscapTest/Parser/IniParserTest.php
@@ -24,7 +24,7 @@ use Browscap\Parser\IniParser;
  * @category   BrowscapTest
  * @author     James Titcumb <james@asgrim.com>
  */
-class IniParserTest extends \PHPUnit_Framework_TestCase
+class IniParserTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * tests creating the parser class

--- a/tests/BrowscapTest/UserAgentsTest.php
+++ b/tests/BrowscapTest/UserAgentsTest.php
@@ -33,7 +33,7 @@ use WurflCache\Adapter\File;
  * @author     James Titcumb <james@asgrim.com>
  * @group      useragenttest
  */
-class UserAgentsTest extends \PHPUnit_Framework_TestCase
+class UserAgentsTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \BrowscapPHP\Browscap

--- a/tests/BrowscapTest/Writer/CsvWriterTest.php
+++ b/tests/BrowscapTest/Writer/CsvWriterTest.php
@@ -25,7 +25,7 @@ use org\bovigo\vfs\vfsStream;
  * @category   BrowscapTest
  * @author     Thomas Müller <t_mueller_stolzenhain@yahoo.de>
  */
-class CsvWriterTest extends \PHPUnit_Framework_TestCase
+class CsvWriterTest extends \PHPUnit\Framework\TestCase
 {
     const STORAGE_DIR = 'storage';
 

--- a/tests/BrowscapTest/Writer/Factory/CustomWriterFactoryTest.php
+++ b/tests/BrowscapTest/Writer/Factory/CustomWriterFactoryTest.php
@@ -25,7 +25,7 @@ use org\bovigo\vfs\vfsStream;
  * @category   BrowscapTest
  * @author     Thomas Müller <t_mueller_stolzenhain@yahoo.de>
  */
-class CustomWriterFactoryTest extends \PHPUnit_Framework_TestCase
+class CustomWriterFactoryTest extends \PHPUnit\Framework\TestCase
 {
     const STORAGE_DIR = 'storage';
 

--- a/tests/BrowscapTest/Writer/Factory/FullCollectionFactoryTest.php
+++ b/tests/BrowscapTest/Writer/Factory/FullCollectionFactoryTest.php
@@ -25,7 +25,7 @@ use org\bovigo\vfs\vfsStream;
  * @category   BrowscapTest
  * @author     Thomas Müller <t_mueller_stolzenhain@yahoo.de>
  */
-class FullCollectionFactoryTest extends \PHPUnit_Framework_TestCase
+class FullCollectionFactoryTest extends \PHPUnit\Framework\TestCase
 {
     const STORAGE_DIR = 'storage';
 

--- a/tests/BrowscapTest/Writer/Factory/FullPhpWriterFactoryTest.php
+++ b/tests/BrowscapTest/Writer/Factory/FullPhpWriterFactoryTest.php
@@ -25,7 +25,7 @@ use org\bovigo\vfs\vfsStream;
  * @category   BrowscapTest
  * @author     Thomas Müller <t_mueller_stolzenhain@yahoo.de>
  */
-class FullPhpWriterFactoryTest extends \PHPUnit_Framework_TestCase
+class FullPhpWriterFactoryTest extends \PHPUnit\Framework\TestCase
 {
     const STORAGE_DIR = 'storage';
 

--- a/tests/BrowscapTest/Writer/IniWriterTest.php
+++ b/tests/BrowscapTest/Writer/IniWriterTest.php
@@ -25,7 +25,7 @@ use org\bovigo\vfs\vfsStream;
  * @category   BrowscapTest
  * @author     Thomas Müller <t_mueller_stolzenhain@yahoo.de>
  */
-class IniWriterTest extends \PHPUnit_Framework_TestCase
+class IniWriterTest extends \PHPUnit\Framework\TestCase
 {
     const STORAGE_DIR = 'storage';
 

--- a/tests/BrowscapTest/Writer/JsonWriterTest.php
+++ b/tests/BrowscapTest/Writer/JsonWriterTest.php
@@ -25,7 +25,7 @@ use org\bovigo\vfs\vfsStream;
  * @category   BrowscapTest
  * @author     Thomas Müller <t_mueller_stolzenhain@yahoo.de>
  */
-class JsonWriterTest extends \PHPUnit_Framework_TestCase
+class JsonWriterTest extends \PHPUnit\Framework\TestCase
 {
     const STORAGE_DIR = 'storage';
 

--- a/tests/BrowscapTest/Writer/WriterCollectionTest.php
+++ b/tests/BrowscapTest/Writer/WriterCollectionTest.php
@@ -25,7 +25,7 @@ use org\bovigo\vfs\vfsStream;
  * @category   BrowscapTest
  * @author     Thomas Müller <t_mueller_stolzenhain@yahoo.de>
  */
-class WriterCollectionTest extends \PHPUnit_Framework_TestCase
+class WriterCollectionTest extends \PHPUnit\Framework\TestCase
 {
     const STORAGE_DIR = 'storage';
 

--- a/tests/BrowscapTest/Writer/XmlWriterTest.php
+++ b/tests/BrowscapTest/Writer/XmlWriterTest.php
@@ -25,7 +25,7 @@ use org\bovigo\vfs\vfsStream;
  * @category   BrowscapTest
  * @author     Thomas Müller <t_mueller_stolzenhain@yahoo.de>
  */
-class XmlWriterTest extends \PHPUnit_Framework_TestCase
+class XmlWriterTest extends \PHPUnit\Framework\TestCase
 {
     const STORAGE_DIR = 'storage';
 


### PR DESCRIPTION
PHPUnit 6 switches to Namespaces and removes the old Testcase class. In PHPUnit 5.4+ it is also possible to use the namespaced version.