### PR TITLE
Fixing and preventing files from getting multiple platforms/devices without the #PLATFORM# or #DEVICE# token in the match

### DIFF
--- a/resources/user-agents/browsers/ie/ie-10-0.json
+++ b/resources/user-agents/browsers/ie/ie-10-0.json
@@ -189,7 +189,7 @@
           ]
         },
         {
-          "match": "Mozilla/4.0 (*MSIE 7.*Trident/6.0*)*",
+          "match": "Mozilla/4.0 (*MSIE 7.#PLATFORM#Trident/6.0*)*",
           "properties": {
             "Comment": "IE #MAJORVER#.#MINORVER# in IE 7.0 Compatibility Mode",
             "Browser_Modus": "IE 7.0 Compatibility Mode"
@@ -199,7 +199,7 @@
           ]
         },
         {
-          "match": "Mozilla/5.0 (*MSIE 7.*Trident/6.0*)*",
+          "match": "Mozilla/5.0 (*MSIE 7.#PLATFORM#Trident/6.0*)*",
           "properties": {
             "Comment": "IE #MAJORVER#.#MINORVER# in IE 7.0 Compatibility Mode",
             "Browser_Modus": "IE 7.0 Compatibility Mode"

--- a/resources/user-agents/browsers/uc-browser/uc-web-10.json
+++ b/resources/user-agents/browsers/uc-browser/uc-web-10.json
@@ -301,7 +301,9 @@
           "match": "Mozilla/5.0 (#PLATFORM# Build/*) applewebkit* (*khtml*like*gecko*) Version/* Safari/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile",
           "engine": "WebKit",
           "platforms": [
-            "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4", "Android_5_0", "Android_5_1", "Android_6_0", "Android_6_1", "Android_7_0", "Android_7_1", "Android"
+            "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4",
+            "Android_5_0", "Android_5_1", "Android_6_0", "Android_6_1",
+            "Android_7_0", "Android_7_1", "Android"
           ]
         },
         {
@@ -321,7 +323,7 @@
           "match": "UCWEB/2.0 (Linux; U; Opera Mini/*) U2/* UCBrowser/#MAJORVER#.#MINORVER#* Mobile*",
           "engine": "U2",
           "platforms": [
-            "Android_4_2", "Android"
+            "Android_4_2"
           ]
         },
         {

--- a/src/Browscap/Data/DataCollection.php
+++ b/src/Browscap/Data/DataCollection.php
@@ -384,6 +384,26 @@ class DataCollection
                         );
                     }
 
+                    if (isset($child['platforms'])
+                        && count($child['platforms']) > 1
+                        && strpos($child['match'], '#PLATFORM#') === false
+                    ) {
+                        throw new \LogicException(
+                            'the "platforms" entry contains multiple platforms but there is no #PLATFORM# token for key "'
+                            . $useragent['userAgent'] . '", for child data: ' . json_encode($child)
+                        );
+                    }
+
+                    if (isset($child['devices'])
+                        && count($child['devices']) > 1
+                        && strpos($child['match'], '#DEVICE#') === false
+                    ) {
+                        throw new \LogicException(
+                            'the "devices" entry contains multiple devices but there is no #DEVICE# token for key "'
+                            . $useragent['userAgent'] . '", for child data: ' . json_encode($child)
+                        );
+                    }
+
                     if (preg_match('/[\[\]]/', $child['match'])) {
                         throw new \UnexpectedValueException(
                             'key "' . $child['match'] . '" includes invalid characters'

--- a/tests/BrowscapTest/Data/DataCollectionTest.php
+++ b/tests/BrowscapTest/Data/DataCollectionTest.php
@@ -825,6 +825,34 @@ HERE;
     }
 
     /**
+     * checks if an exception is thrown if the devices entry has multiple items and there is no #DEVICE# token
+     *
+     * @expectedException \LogicException
+     * @expectedExceptionMessage the "devices" entry contains multiple devices but there is no #DEVICE# token for key
+     *
+     * @group data
+     * @group sourcetest
+     */
+    public function testAddSourceFileThrowsExceptionIfDevicesEntryHasMultipleDevicesAndNoDeviceToken()
+    {
+        $this->object->addSourceFile(__DIR__ . '/../../fixtures/ua/ua-with-children-with-devices-no-token.json');
+    }
+
+    /**
+     * checks if an exception is thrown if the platforms entry has multiple items and there is no #PLATFORM# token
+     *
+     * @expectedException \LogicException
+     * @expectedExceptionMessage the "platforms" entry contains multiple platforms but there is no #PLATFORM# token for key
+     *
+     * @group data
+     * @group sourcetest
+     */
+    public function testAddSourceFileThrowsExceptionIfPlatformsEntryHasMultiplePlatformsAndNoPlatformToken()
+    {
+        $this->object->addSourceFile(__DIR__ . '/../../fixtures/ua/ua-with-children-with-platforms-no-token.json');
+    }
+
+    /**
      * checks if a exception is thrown if a division is defined twice in the source files
      *
      * @expectedException \UnexpectedValueException

--- a/tests/fixtures/ua/ua-with-children-with-devices-no-token.json
+++ b/tests/fixtures/ua/ua-with-children-with-devices-no-token.json
@@ -1,0 +1,29 @@
+{
+  "division": "Division1",
+  "versions": ["1.0"],
+  "sortIndex": 200,
+  "lite": true,
+  "standard": true,
+  "userAgents": [
+    {
+      "userAgent": "UA1",
+      "properties": {
+        "Parent": "DefaultProperties",
+        "Comment": "UA1",
+        "Browser": "UA1",
+        "Version": "1.0",
+        "MajorVer": "1",
+        "MinorVer": "0"
+      },
+      "children": [
+        {
+          "match": "cde",
+          "devices": {
+            "efg": "efg",
+            "abc": "abc"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/ua/ua-with-children-with-platforms-no-token.json
+++ b/tests/fixtures/ua/ua-with-children-with-platforms-no-token.json
@@ -1,0 +1,25 @@
+{
+  "division": "Division1",
+  "sortIndex": 200,
+  "lite": true,
+  "standard": true,
+  "userAgents": [
+    {
+      "userAgent": "UA1",
+      "properties": {
+        "Parent": "DefaultProperties",
+        "Comment": "UA1",
+        "Browser": "UA1"
+      },
+      "children": [
+        {
+          "match": "cde",
+          "platforms": [
+            "def",
+            "ghi"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
I noticed this earlier with the WhatsApp file and fixed it then. Figured I’d do a quick scan to see if it happens anywhere else and found a few more instances.

This PR fixes those cases (one of them I added the #PLATFORM# token, the other one I removed the second platform since it didn’t really make sense there).  It also adds some checks to the `addSourceFile` processor to make sure the JSON file isn’t missing the #PLATFORM# or #DEVICE# token when the respective arrays contain more than one element.