### PR TITLE
Condensing devices in/cleaning up Android Browser files

### DIFF
--- a/resources/devices/mobile-phone/archos.json
+++ b/resources/devices/mobile-phone/archos.json
@@ -64,6 +64,19 @@
             "isTablet": "false"
         }
     },
+    "Archos A43": {
+        "standard": false,
+        "properties": {
+            "Device_Type": "Mobile Phone",
+            "Device_Code_Name": "A43",
+            "Device_Name": "A43",
+            "Device_Maker": "Archos",
+            "Device_Brand_Name": "Archos",
+            "Device_Pointing_Method": "unknown",
+            "isMobileDevice": "true",
+            "isTablet": "false"
+        }
+    },
     "Archos A70BH": {
         "standard": false,
         "properties": {
@@ -112,6 +125,19 @@
             "Device_Maker": "Archos",
             "Device_Brand_Name": "Archos",
             "Device_Pointing_Method": "unknown",
+            "isMobileDevice": "true",
+            "isTablet": "false"
+        }
+    },
+    "Archos A70S": {
+        "standard": false,
+        "properties": {
+            "Device_Type": "Mobile Phone",
+            "Device_Code_Name": "A70S",
+            "Device_Name": "A70S",
+            "Device_Maker": "Archos",
+            "Device_Brand_Name": "Archos",
+            "Device_Pointing_Method": "touchscreen",
             "isMobileDevice": "true",
             "isTablet": "false"
         }

--- a/resources/devices/mobile-phone/htc.json
+++ b/resources/devices/mobile-phone/htc.json
@@ -324,6 +324,19 @@
             "isTablet": "false"
         }
     },
+    "HTC A6277": {
+        "standard": false,
+        "properties": {
+            "Device_Type": "Mobile Phone",
+            "Device_Code_Name": "A6277",
+            "Device_Name": "Hero (Sprint)",
+            "Device_Maker": "HTC",
+            "Device_Brand_Name": "HTC",
+            "Device_Pointing_Method": "touchscreen",
+            "isMobileDevice": "true",
+            "isTablet": "false"
+        }
+    },
     "HTC A6366": {
         "standard": false,
         "properties": {
@@ -369,6 +382,45 @@
             "Device_Type": "Mobile Phone",
             "Device_Code_Name": "A810e",
             "Device_Name": "ChaCha",
+            "Device_Maker": "HTC",
+            "Device_Brand_Name": "HTC",
+            "Device_Pointing_Method": "touchscreen",
+            "isMobileDevice": "true",
+            "isTablet": "false"
+        }
+    },
+    "HTC A8181": {
+        "standard": false,
+        "properties": {
+            "Device_Type": "Mobile Phone",
+            "Device_Code_Name": "A8181",
+            "Device_Name": "Desire",
+            "Device_Maker": "HTC",
+            "Device_Brand_Name": "HTC",
+            "Device_Pointing_Method": "touchscreen",
+            "isMobileDevice": "true",
+            "isTablet": "false"
+        }
+    },
+    "HTC ADR6200": {
+        "standard": false,
+        "properties": {
+            "Device_Type": "Mobile Phone",
+            "Device_Code_Name": "ADR6200",
+            "Device_Name": "Droid Eris",
+            "Device_Maker": "HTC",
+            "Device_Brand_Name": "HTC",
+            "Device_Pointing_Method": "touchscreen",
+            "isMobileDevice": "true",
+            "isTablet": "false"
+        }
+    },
+    "HTC ADR6300": {
+        "standard": false,
+        "properties": {
+            "Device_Type": "Mobile Phone",
+            "Device_Code_Name": "ADR6300",
+            "Device_Name": "Droid Incredible",
             "Device_Maker": "HTC",
             "Device_Brand_Name": "HTC",
             "Device_Pointing_Method": "touchscreen",

--- a/resources/devices/mobile-phone/huawei.json
+++ b/resources/devices/mobile-phone/huawei.json
@@ -389,6 +389,32 @@
             "isTablet": "false"
         }
     },
+    "Huawei U8110 RBM3": {
+        "standard": false,
+        "properties": {
+            "Device_Type": "Mobile Phone",
+            "Device_Code_Name": "U8110",
+            "Device_Name": "RBM3",
+            "Device_Maker": "Huawei",
+            "Device_Brand_Name": "Red Bull Mobile",
+            "Device_Pointing_Method": "unknown",
+            "isMobileDevice": "true",
+            "isTablet": "false"
+        }
+    },
+    "Huawei U8150": {
+        "standard": false,
+        "properties": {
+            "Device_Type": "Mobile Phone",
+            "Device_Code_Name": "U8150",
+            "Device_Name": "Ideos",
+            "Device_Maker": "Huawei",
+            "Device_Brand_Name": "Huawei",
+            "Device_Pointing_Method": "unknown",
+            "isMobileDevice": "true",
+            "isTablet": "false"
+        }
+    },
     "Huawei U8180": {
         "standard": false,
         "properties": {
@@ -423,6 +449,19 @@
             "Device_Name": "U8230",
             "Device_Maker": "Huawei",
             "Device_Brand_Name": "Huawei",
+            "Device_Pointing_Method": "touchscreen",
+            "isMobileDevice": "true",
+            "isTablet": "false"
+        }
+    },
+    "Huawei U8230 RBM2": {
+        "standard": false,
+        "properties": {
+            "Device_Type": "Mobile Phone",
+            "Device_Code_Name": "U8230",
+            "Device_Name": "RBM2",
+            "Device_Maker": "Huawei",
+            "Device_Brand_Name": "Red Bull Mobile",
             "Device_Pointing_Method": "touchscreen",
             "isMobileDevice": "true",
             "isTablet": "false"

--- a/resources/devices/mobile-phone/lg.json
+++ b/resources/devices/mobile-phone/lg.json
@@ -2989,19 +2989,32 @@
             "isTablet": "false"
         }
     },
-  "LG LS997": {
-    "standard": false,
-    "properties": {
-      "Device_Type": "Mobile Phone",
-      "Device_Code_Name": "LS997",
-      "Device_Name": "V20 (Sprint)",
-      "Device_Maker": "LG",
-      "Device_Brand_Name": "LG",
-      "Device_Pointing_Method": "touchscreen",
-      "isMobileDevice": "true",
-      "isTablet": "false"
-    }
-  },
+    "LG LS997": {
+        "standard": false,
+        "properties": {
+            "Device_Type": "Mobile Phone",
+            "Device_Code_Name": "LS997",
+            "Device_Name": "V20 (Sprint)",
+            "Device_Maker": "LG",
+            "Device_Brand_Name": "LG",
+            "Device_Pointing_Method": "touchscreen",
+            "isMobileDevice": "true",
+            "isTablet": "false"
+        }
+    },
+    "LG LU2300": {
+        "standard": false,
+        "properties": {
+            "Device_Type": "Mobile Phone",
+            "Device_Code_Name": "LU2300",
+            "Device_Name": "Optimus Q",
+            "Device_Maker": "LG",
+            "Device_Brand_Name": "LG",
+            "Device_Pointing_Method": "touchscreen",
+            "isMobileDevice": "true",
+            "isTablet": "false"
+        }
+    },
     "LG LX150": {
         "standard": false,
         "properties": {
@@ -3054,32 +3067,32 @@
             "isTablet": "false"
         }
     },
-  "LG M210": {
-    "standard": false,
-    "properties": {
-      "Device_Type": "Mobile Phone",
-      "Device_Code_Name": "M210",
-      "Device_Name": "Aristo (T-Mobile)",
-      "Device_Maker": "LG",
-      "Device_Brand_Name": "LG",
-      "Device_Pointing_Method": "touchscreen",
-      "isMobileDevice": "true",
-      "isTablet": "false"
-    }
-  },
-  "LG MS210": {
-    "standard": false,
-    "properties": {
-      "Device_Type": "Mobile Phone",
-      "Device_Code_Name": "MS210",
-      "Device_Name": "Aristo (Metro PCS)",
-      "Device_Maker": "LG",
-      "Device_Brand_Name": "LG",
-      "Device_Pointing_Method": "touchscreen",
-      "isMobileDevice": "true",
-      "isTablet": "false"
-    }
-  },
+    "LG M210": {
+        "standard": false,
+        "properties": {
+            "Device_Type": "Mobile Phone",
+            "Device_Code_Name": "M210",
+            "Device_Name": "Aristo (T-Mobile)",
+            "Device_Maker": "LG",
+            "Device_Brand_Name": "LG",
+            "Device_Pointing_Method": "touchscreen",
+            "isMobileDevice": "true",
+            "isTablet": "false"
+        }
+    },
+    "LG MS210": {
+        "standard": false,
+        "properties": {
+            "Device_Type": "Mobile Phone",
+            "Device_Code_Name": "MS210",
+            "Device_Name": "Aristo (Metro PCS)",
+            "Device_Maker": "LG",
+            "Device_Brand_Name": "LG",
+            "Device_Pointing_Method": "touchscreen",
+            "isMobileDevice": "true",
+            "isTablet": "false"
+        }
+    },
     "LG M4410": {
         "standard": false,
         "properties": {
@@ -3827,6 +3840,19 @@
             "Device_Type": "Mobile Phone",
             "Device_Code_Name": "VS425PP",
             "Device_Name": "Optimus Zone 3 (Verizon)",
+            "Device_Maker": "LG",
+            "Device_Brand_Name": "LG",
+            "Device_Pointing_Method": "touchscreen",
+            "isMobileDevice": "true",
+            "isTablet": "false"
+        }
+    },
+    "LG VS740": {
+        "standard": false,
+        "properties": {
+            "Device_Type": "Mobile Phone",
+            "Device_Code_Name": "VS740",
+            "Device_Name": "Ally",
             "Device_Maker": "LG",
             "Device_Brand_Name": "LG",
             "Device_Pointing_Method": "touchscreen",

--- a/resources/devices/mobile-phone/micromax.json
+++ b/resources/devices/mobile-phone/micromax.json
@@ -103,6 +103,19 @@
             "isTablet": "false"
         }
     },
+    "Micromax A28": {
+        "standard": false,
+        "properties": {
+            "Device_Type": "Mobile Phone",
+            "Device_Code_Name": "A28",
+            "Device_Name": "Bolt",
+            "Device_Maker": "Micromax",
+            "Device_Brand_Name": "Micromax",
+            "Device_Pointing_Method": "touchscreen",
+            "isMobileDevice": "true",
+            "isTablet": "false"
+        }
+    },
     "Micromax A35": {
         "standard": false,
         "properties": {

--- a/resources/devices/tablet/cortex.json
+++ b/resources/devices/tablet/cortex.json
@@ -1,0 +1,15 @@
+{
+    "Cortex A8": {
+        "standard": true,
+        "properties": {
+            "Device_Type": "Tablet",
+            "Device_Code_Name": "A8",
+            "Device_Name": "APad",
+            "Device_Maker": "Cortex",
+            "Device_Brand_Name": "Cortex",
+            "Device_Pointing_Method": "touchscreen",
+            "isMobileDevice": "true",
+            "isTablet": "true"
+        }
+    }
+}

--- a/resources/devices/tablet/creative.json
+++ b/resources/devices/tablet/creative.json
@@ -1,0 +1,15 @@
+{
+    "Creative ZIIO7": {
+        "standard": true,
+        "properties": {
+            "Device_Type": "Tablet",
+            "Device_Name": "ZiiO 7",
+            "Device_Code_Name": "ZiiO7",
+            "Device_Maker": "Creative",
+            "Device_Pointing_Method": "touchscreen",
+            "Device_Brand_Name": "Creative",
+            "isMobileDevice": "true",
+            "isTablet": "true"
+        }
+    }
+}

--- a/resources/devices/tablet/debitel.json
+++ b/resources/devices/tablet/debitel.json
@@ -1,0 +1,15 @@
+{
+    "Debitel OneTab XST2": {
+        "standard": true,
+        "properties": {
+            "Device_Type": "Tablet",
+            "Device_Name": "OneTab Xst2",
+            "Device_Code_Name": "OneTab XST2",
+            "Device_Maker": "Debitel",
+            "Device_Pointing_Method": "touchscreen",
+            "Device_Brand_Name": "Debitel",
+            "isMobileDevice": "true",
+            "isTablet": "true"
+        }
+    }
+}

--- a/resources/devices/tablet/flytouch.json
+++ b/resources/devices/tablet/flytouch.json
@@ -1,0 +1,15 @@
+{
+    "Flytouch DISCO10": {
+        "standard": true,
+        "properties": {
+            "Device_Type": "Tablet",
+            "Device_Name": "Superpad 2",
+            "Device_Code_Name": "DISCO10",
+            "Device_Maker": "Flytouch",
+            "Device_Pointing_Method": "touchscreen",
+            "Device_Brand_Name": "Flytouch",
+            "isMobileDevice": "true",
+            "isTablet": "true"
+        }
+    }
+}

--- a/resources/devices/tablet/huawei.json
+++ b/resources/devices/tablet/huawei.json
@@ -1,4 +1,17 @@
 {
+    "Huawei IDEOS S7": {
+        "standard": true,
+        "properties": {
+            "Device_Type": "Tablet",
+            "Device_Code_Name": "IDEOS S7",
+            "Device_Name": "IDEOS S7",
+            "Device_Maker": "Huawei",
+            "Device_Brand_Name": "Huawei",
+            "Device_Pointing_Method": "touchscreen",
+            "isMobileDevice": "true",
+            "isTablet": "true"
+        }
+    },
     "Huawei Media Pad": {
         "standard": true,
         "properties": {

--- a/resources/devices/tablet/smartdevices.json
+++ b/resources/devices/tablet/smartdevices.json
@@ -1,0 +1,15 @@
+{
+    "SmartDevices SmartQ V7": {
+        "standard": true,
+        "properties": {
+            "Device_Type": "Tablet",
+            "Device_Name": "SmartQ V7",
+            "Device_Code_Name": "SmartQ V7",
+            "Device_Maker": "SmartDevices",
+            "Device_Pointing_Method": "touchscreen",
+            "Device_Brand_Name": "SmartDevices",
+            "isMobileDevice": "true",
+            "isTablet": "true"
+        }
+    }
+}

--- a/resources/devices/tablet/telechips.json
+++ b/resources/devices/tablet/telechips.json
@@ -1,0 +1,15 @@
+{
+    "Telechips TCC890": {
+        "standard": true,
+        "properties": {
+            "Device_Type": "Tablet",
+            "Device_Name": "Wince 6.0",
+            "Device_Code_Name": "TCC890",
+            "Device_Maker": "Telechips",
+            "Device_Pointing_Method": "touchscreen",
+            "Device_Brand_Name": "Telechips",
+            "isMobileDevice": "true",
+            "isTablet": "true"
+        }
+    }
+}

--- a/resources/devices/tablet/tendak.json
+++ b/resources/devices/tablet/tendak.json
@@ -1,0 +1,15 @@
+{
+    "Tendak DFP7002": {
+        "standard": true,
+        "properties": {
+            "Device_Type": "Tablet",
+            "Device_Name": "DFP7002",
+            "Device_Code_Name": "DFP7002",
+            "Device_Maker": "Tendak",
+            "Device_Pointing_Method": "touchscreen",
+            "Device_Brand_Name": "Tendak",
+            "isMobileDevice": "true",
+            "isTablet": "true"
+        }
+    }
+}

--- a/resources/devices/tablet/toshiba.json
+++ b/resources/devices/tablet/toshiba.json
@@ -1,4 +1,17 @@
 {
+    "Toshiba AC100": {
+        "standard": true,
+        "properties": {
+            "Device_Type": "Tablet",
+            "Device_Code_Name": "AC100",
+            "Device_Name": "Smartbook",
+            "Device_Maker": "Toshiba",
+            "Device_Brand_Name": "Toshiba",
+            "Device_Pointing_Method": "touchscreen",
+            "isMobileDevice": "true",
+            "isTablet": "true"
+        }
+    },
     "Toshiba AT10-A": {
         "standard": true,
         "properties": {

--- a/resources/devices/tablet/vimicro.json
+++ b/resources/devices/tablet/vimicro.json
@@ -1,0 +1,15 @@
+{
+    "ViMicro Vortex": {
+        "standard": true,
+        "properties": {
+            "Device_Type": "Tablet",
+            "Device_Code_Name": "Vortex",
+            "Device_Name": "Vortex",
+            "Device_Maker": "ViMicro",
+            "Device_Brand_Name": "ViMicro",
+            "Device_Pointing_Method": "touchscreen",
+            "isMobileDevice": "true",
+            "isTablet": "true"
+        }
+    }
+}

--- a/resources/user-agents/browsers/android-browser/android-browser-3-0.json
+++ b/resources/user-agents/browsers/android-browser/android-browser-3-0.json
@@ -28,85 +28,26 @@
       },
       "children": [
         {
-          "match": "*Mozilla/5.0 (#PLATFORM#GT-I5700 Build/*)*applewebkit*(*khtml*like*gecko*)*Version/#MAJORVER#.#MINORVER#*Safari/*",
-          "device": "Samsung GT-I5700",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*)*applewebkit*(*khtml*like*gecko*)*Version/#MAJORVER#.#MINORVER#*Safari/*",
+          "devices": {
+            "GT-I5700": "Samsung GT-I5700"
+          },
           "platforms": [
             "Android_4_1"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#A70BH Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari/*",
-          "device": "Archos A70BH",
-          "platforms": [
-            "Android_1_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#A70BHT Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari/*",
-          "device": "Archos A70BHT",
-          "platforms": [
-            "Android_1_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#A70CHT Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari/*",
-          "device": "Archos A70CHT",
-          "platforms": [
-            "Android_1_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#A70HB Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari/*",
-          "device": "Archos A70HB",
-          "platforms": [
-            "Android_1_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#A7EB Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari/*",
-          "device": "Archos 70c",
-          "platforms": [
-            "Android_1_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#A80KSC Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari/*",
-          "device": "Archos A80KSC",
-          "platforms": [
-            "Android_1_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_Dream Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari/*",
-          "device": "HTC Dream",
-          "platforms": [
-            "Android_1_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#dream Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari/*",
-          "device": "HTC Dream",
-          "platforms": [
-            "Android_1_0", "Android_1_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Mobii 7 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari/*",
-          "device": "Point of View Mobii 7",
-          "platforms": [
-            "Android_1_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#STM7UC Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari/*",
-          "device": "general Mobile Phone",
-          "platforms": [
-            "Android_1_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#STM7UH Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari/*",
-          "device": "general Mobile Phone",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari/*",
+          "devices": {
+            "A70BH": "Archos A70BH",
+            "A70BHT": "Archos A70BHT",
+            "A70CHT": "Archos A70CHT",
+            "A70HB": "Archos A70HB",
+            "A7EB": "Archos 70c",
+            "A80KSC": "Archos A80KSC",
+            "HTC_Dream": "HTC Dream",
+            "Mobii 7": "Point of View Mobii 7"
+          },
           "platforms": [
             "Android_1_0"
           ]
@@ -118,21 +59,34 @@
           ]
         },
         {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari/*",
+          "devices": {
+            "dream": "HTC Dream"
+          },
+          "platforms": [
+            "Android_1_0", "Android_1_1"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari/*",
+          "devices": {
+            "A101B": "Archos A101B"
+          },
+          "platforms": [
+            "Android_1_1"
+          ]
+        },
+        {
           "match": "Mozilla/5.0 (#PLATFORM#applewebkit* (*khtml*like*gecko*) Version/*Safari/#MAJORVER#.#MINORVER#*",
           "platforms": [
             "Android_1_0", "Android_1_1"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#A101B Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari/*",
-          "device": "Archos A101B",
-          "platforms": [
-            "Android_1_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#dream*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari/*",
-          "device": "HTC Dream",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE#*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari/*",
+          "devices": {
+            "dream": "HTC Dream"
+          },
           "platforms": [
             "Android_1_0", "Android_1_1"
           ]

--- a/resources/user-agents/browsers/android-browser/android-browser-3-1-3-2.json
+++ b/resources/user-agents/browsers/android-browser/android-browser-3-1-3-2.json
@@ -58,8 +58,10 @@
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#desirec) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari/*",
-          "device": "HTC Desire C",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE#) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari/*",
+          "devices": {
+            "desirec": "HTC Desire C"
+          },
           "platforms": [
             "Android_1_5"
           ]

--- a/resources/user-agents/browsers/android-browser/android-browser-4-0.json
+++ b/resources/user-agents/browsers/android-browser/android-browser-4-0.json
@@ -28,18 +28,35 @@
       },
       "children": [
         {
-          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*)*applewebkit*(*khtml*like*gecko*)*Version/#MAJORVER#.#MINORVER#*Safari*",
+          "match": "*Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit*khtml*like gecko) Version/#MAJORVER#.#MINORVER#*Safari*",
           "devices": {
-            "HTCA510e*": "HTC A510e",
-            "HTCS510e*": "HTC S510e",
-            "HTCS710e*": "HTC S710E",
-            "Micromax A27": "Micromax A27",
-            "Micromax A35": "Micromax A35",
-            "Micromax A40": "Micromax A40",
-            "sprd-B51+*": "sprd B51+"
+            "INM8002KP": "Intenso INM8002KP"
           },
           "platforms": [
-            "Android_2_3"
+            "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
+            "Android_3_2", "Android_3_1", "Android_3_0",
+            "Android_2_3", "Android_2_2", "Android_2_1", "Android_2_0",
+            "Android_1_6", "Android_1_5", "Android_1_1", "Android_1_0"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*)*applewebkit*(*khtml*like*gecko*)*Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "HTC_One_X*": "HTC PJ83100"
+          },
+          "platforms": [
+            "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*)*applewebkit*(*khtml*like*gecko*)*Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "FP1": "Fairphone FP1",
+            "FP1U": "Fairphone FP1U",
+            "LG-D805": "LG D805"
+          },
+          "platforms": [
+            "Android_4_2"
           ]
         },
         {
@@ -55,34 +72,23 @@
         {
           "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*)*applewebkit*(*khtml*like*gecko*)*Version/#MAJORVER#.#MINORVER#*Safari*",
           "devices": {
-            "LG-D805": "LG D805",
-            "FP1": "Fairphone FP1",
-            "FP1U": "Fairphone FP1U"
+            "HTCA510e*": "HTC A510e",
+            "HTCS510e*": "HTC S510e",
+            "HTCS710e*": "HTC S710E",
+            "Micromax A27": "Micromax A27",
+            "Micromax A35": "Micromax A35",
+            "Micromax A40": "Micromax A40",
+            "sprd-B51+*": "sprd B51+"
           },
           "platforms": [
-            "Android_4_2"
+            "Android_2_3"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_One_X* Build/*)*applewebkit*(*khtml*like*gecko*)*Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC PJ83100",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "*Mozilla/5.0 (#PLATFORM#INM8002KP Build/*) applewebkit*khtml*like gecko) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Intenso INM8002KP",
-          "platforms": [
-            "Android_1_0", "Android_1_1", "Android_1_5", "Android_1_6",
-            "Android_2_0", "Android_2_1", "Android_2_2", "Android_2_3",
-            "Android_3_0", "Android_3_1", "Android_3_2",
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#sprd-B51+* Android/* Release/* Browser/applewebkit* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "sprd B51+",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Android/* Release/* Browser/applewebkit* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "sprd-B51+*": "sprd B51+"
+          },
           "platforms": [
             "Android_2_3"
           ]
@@ -90,178 +96,54 @@
         {
           "match": "Mozilla/5.0 (#PLATFORM# Android/* Release/* Browser/applewebkit* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
           "platforms": [
-            "Android_1_0", "Android_1_1", "Android_1_5", "Android_1_6",
-            "Android_2_0", "Android_2_1", "Android_2_2", "Android_2_3", "Android_B_2_3",
-            "Android_3_0", "Android_3_1", "Android_3_2",
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4"
+            "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
+            "Android_3_2", "Android_3_1", "Android_3_0",
+            "Android_B_2_3", "Android_2_3", "Android_2_2", "Android_2_1", "Android_2_0",
+            "Android_1_6", "Android_1_5", "Android_1_1", "Android_1_0"
           ]
         },
         {
-          "match": "Mastone_G9_TD/* Release/* Mozilla/5.0 (#PLATFORM#)*applewebkit*(*khtml*like*gecko*)*Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Mastone G9",
+          "match": "#DEVICE#/* Release/* Mozilla/5.0 (#PLATFORM#)*applewebkit*(*khtml*like*gecko*)*Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Mastone_G9_TD": "Mastone G9"
+          },
           "platforms": [
             "Android_2_3"
           ]
         },
         {
-          "match": "Mozilla/5.0 (Macintosh; *Mac OS X*; HTC/DesireHD/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "match": "Mozilla/5.0 (Macintosh; *Mac OS X*; #DEVICE#/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
           "properties": {
             "Browser_Modus": "Desktop Mode"
           },
-          "device": "HTC Desire HD",
+          "devices": {
+            "HTC/DesireHD": "HTC Desire HD",
+            "HTC/DesireS": "HTC Desire S",
+            "HTC/WildfireS": "HTC Wildfire S"
+          },
           "platforms": [
             "Android"
           ]
         },
         {
-          "match": "Mozilla/5.0 (Macintosh; *Mac OS X*; HTC/DesireS/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "match": "Mozilla/5.0 (Macintosh; *Mac OS X*; #DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
           "properties": {
             "Browser_Modus": "Desktop Mode"
           },
-          "device": "HTC Desire S",
-          "platforms": [
-            "Android"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (Macintosh; *Mac OS X*; HTC/Sensation/*) applewebkit* (*khtml*like*gecko*) Version/5.0*Safari*",
-          "properties": {
-            "Browser_Modus": "Desktop Mode"
+          "devices": {
+            "HTC_Flyer_P510e": "HTC P510e"
           },
-          "device": "HTC Z710",
           "platforms": [
             "Android"
           ]
         },
         {
-          "match": "Mozilla/5.0 (Macintosh; *Mac OS X*; HTC/WildfireS/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Wildfire S",
-          "platforms": [
-            "Android"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (Macintosh; *Mac OS X*; HTC_DesireHD_A9191; *) applewebkit* (*khtml*like*gecko*) Version/5.0*Safari*",
-          "device": "HTC Desire HD A9191",
-          "platforms": [
-            "Android"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (Macintosh; *Mac OS X*; HTC_EVO3D_X515m; *) applewebkit* (*khtml*like*gecko*) Version/5.0*Safari*",
-          "properties": {
-            "Browser_Modus": "Desktop Mode"
+          "match": "Mozilla/5.0 (#PLATFORM#;#DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER# Safari*",
+          "devices": {
+            "HTC_Flyer_P510e": "HTC P510e"
           },
-          "device": "HTC X515m",
-          "platforms": [
-            "Android"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (Macintosh; *Mac OS X*; HTC_EVO3D_X515m; *) applewebkit* (*khtml*like*gecko*) Version/5.1*Safari*",
-          "properties": {
-            "Browser_Modus": "Desktop Mode"
-          },
-          "device": "HTC X515m",
-          "platforms": [
-            "Android"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (Macintosh; *Mac OS X*; HTC_Flyer_P510e Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "properties": {
-            "Browser_Modus": "Desktop Mode"
-          },
-          "device": "HTC P510e",
-          "platforms": [
-            "Android"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (Macintosh; *Mac OS X*; HTC_Flyer_P510e; *) applewebkit* (*khtml*like*gecko*) Version/5.0*Safari*",
-          "properties": {
-            "Browser_Modus": "Desktop Mode"
-          },
-          "device": "HTC P510e",
-          "platforms": [
-            "Android"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#;HTC_Flyer_P510e Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER# Safari*",
-          "device": "HTC P510e",
           "platforms": [
             "Android_3_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (Macintosh; *Mac OS X*; HTC_Flyer_P512; *) applewebkit* (*khtml*like*gecko*) Version/5.0*Safari*",
-          "properties": {
-            "Browser_Modus": "Desktop Mode"
-          },
-          "device": "HTC P512",
-          "platforms": [
-            "Android"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (Macintosh; *Mac OS X*; HTC_IncredibleS_S710e; *) applewebkit* (*khtml*like*gecko*) Version/5.0*Safari*",
-          "properties": {
-            "Browser_Modus": "Desktop Mode"
-          },
-          "device": "HTC S710E",
-          "platforms": [
-            "Android"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (Macintosh; *Mac OS X*; HTC_Runnymede; *) applewebkit* (*khtml*like*gecko*) Version/5.0 Safari*",
-          "properties": {
-            "Browser_Modus": "Desktop Mode"
-          },
-          "device": "HTC Runnymede",
-          "platforms": [
-            "Android"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (Macintosh; *Mac OS X*; HTC_Sensation; *) applewebkit* (*khtml*like*gecko*) Version/5.0*Safari*",
-          "properties": {
-            "Browser_Modus": "Desktop Mode"
-          },
-          "device": "HTC Z710",
-          "platforms": [
-            "Android"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (Macintosh; *Mac OS X*; HTC_SensationXL_Beats_X315e; *) applewebkit* (*khtml*like*gecko*) Version/5.0 Safari*",
-          "properties": {
-            "Browser_Modus": "Desktop Mode"
-          },
-          "device": "HTC X315e",
-          "platforms": [
-            "Android"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (Macintosh; *Mac OS X*; HTC_Sensation_Z710e; *) applewebkit* (*khtml*like*gecko*) Version/5.0*Safari*",
-          "properties": {
-            "Browser_Modus": "Desktop Mode"
-          },
-          "device": "HTC Z710e",
-          "platforms": [
-            "Android"
-          ]
-        },
-        {
-          "match": "Mozilla/5.2 (Macintosh; *Mac OS X*; HTC_EVO3D_X515m; *) applewebkit* (*khtml*like*gecko*) Version/5.2*Safari*",
-          "properties": {
-            "Browser_Modus": "Desktop Mode"
-          },
-          "device": "HTC X515m",
-          "platforms": [
-            "Android"
           ]
         },
         {
@@ -271,3983 +153,1173 @@
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC Desire S Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Desire S",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Nexus 7": "Asus Nexus 7"
+          },
           "platforms": [
+            "Android_5_1", "Android_5_0",
+            "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "LG-D856": "LG D856",
+            "Redmi Note 3": "Xiaomi Redmi Note 3"
+          },
+          "platforms": [
+            "Android_5_0"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Nexus 4": "LG Nexus 4"
+          },
+          "platforms": [
+            "Android_5_0",
+            "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "GT-I9505G": "Samsung GT-I9505G"
+          },
+          "platforms": [
+            "Android_5_0",
+            "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "AT1010-T": "Lenovo AT1010-T"
+          },
+          "platforms": [
+            "Android_4_5"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Lenovo A328": "Lenovo A328",
+            "Lenovo A5500-H": "Lenovo A5500-H",
+            "Lenovo B6000-H": "Lenovo B6000-H",
+            "LG-D325": "LG D325",
+            "LG-D405": "LG D405",
+            "Oysters Pacific 800": "Oysters Pacific 800",
+            "SGH-I467": "Samsung SGH-I467",
+            "SM-G355H": "Samsung SM-G355H",
+            "SM-G800F*": "Samsung SM-G800F",
+            "SM-G900F*": "Samsung SM-G900F",
+            "TAB917QC-8GB": "Sunstech TAB917QC 8GB"
+          },
+          "platforms": [
+            "Android_4_4"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "C6903": "Sony C6903"
+          },
+          "platforms": [
+            "Android_4_4", "Android_4_3"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "A1-810": "Acer A1-810",
+            "GT-P5220*": "Samsung GT-P5220",
+            "HUAWEI P6-U06": "Huawei P6-U06",
+            "LG-D802*": "LG D802",
+            "SM-T310": "Samsung SM-T310",
+            "SM-T315*": "Samsung SM-T315"
+          },
+          "platforms": [
+            "Android_4_4", "Android_4_3", "Android_4_2"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "PadFone 2": "Asus A68"
+          },
+          "platforms": [
+            "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "C6603": "Sony C6603",
+            "GT-I9505*": "Samsung GT-I9505",
+            "GT-N5100": "Samsung GT-N5100",
+            "GT-N5110": "Samsung GT-N5110",
+            "GT-N7105*": "Samsung GT-N7105",
+            "GT-N8020*": "Samsung GT-N8020",
+            "GT-P5200": "Samsung GT-P5200",
+            "GT-P5210*": "Samsung GT-P5210",
+            "GT-S7562": "Samsung GT-S7562",
+            "HTC One": "HTC M7",
+            "HTC?One?mini*": "HTC One Mini",
+            "HTC_One": "HTC M7",
+            "HTC_One*": "HTC M7",
+            "HTC_One_M8*": "HTC M8",
+            "LG-L160L": "LG L160L",
+            "Nexus 10": "Samsung Nexus 10",
+            "SCH-I605": "Samsung SCH-I605"
+          },
+          "platforms": [
+            "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "GT-N7100*": "Samsung GT-N7100",
+            "GT-N8000": "Samsung GT-N8000"
+          },
+          "platforms": [
+            "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android_2_3"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-P6800 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-P6800",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "GT-S5660": "Samsung GT-S5660"
+          },
           "platforms": [
-            "Android_3_2", "Android_4_0"
+            "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
+            "Android_2_3", "Android_2_2"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#KFTT Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "6036Y": "Alcatel OT-6036Y",
+            "HUAWEI Y530-U00": "Huawei Y530-U00",
+            "K1 turbo": "Kingzone KZ-168",
+            "NokiaX2DS": "Nokia X2DS",
+            "Prime S": "Highscreen Omega Prime S",
+            "SPH-L710": "Samsung SPH-L710",
+            "XT926": "Motorola XT926"
+          },
+          "platforms": [
+            "Android_4_3"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "BN NookHD+": "Barnes & Noble Nook HD+",
+            "IdeaTab A3000-H": "Lenovo A3000-H",
+            "Lenovo S6000L-F": "Lenovo S6000L-F"
+          },
+          "platforms": [
+            "Android_4_3", "Android_4_2"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "C6503": "SonyEricsson C6503",
+            "Galaxy Nexus": "Samsung Galaxy Nexus",
+            "GT-I8190N": "Samsung GT-I8190N",
+            "GT-i9300": "Samsung GT-I9300",
+            "GT-N8013": "Samsung GT-N8013",
+            "ME301T": "Asus ME301T",
+            "SGP321": "Sony SGP321"
+          },
+          "platforms": [
+            "Android_4_3", "Android_4_2", "Android_4_1"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "A511": "Acer A511",
+            "ALCATEL ONE TOUCH 6010D": "Alcatel OT-6010D",
+            "ALCATEL ONE TOUCH 6030D": "Alcatel OT-6030D",
+            "ALCATEL ONE TOUCH 6033X": "Alcatel OT-6033X",
+            "Archos 80 Xenon": "Archos 80 Xenon",
+            "ARCHOS FAMILYPAD 2": "Archos Family Pad 2",
+            "ASUS Transformer Pad TF300TG": "Asus TF300TG",
+            "ASUS Transformer Pad TF700T": "Asus TF700T",
+            "C1505": "Sony C1505",
+            "C2105": "Sony C2105",
+            "GT-I8730": "Samsung GT-I8730",
+            "GT-I9082L": "Samsung GT-I9082L",
+            "GT-I9100": "Samsung GT-I9100",
+            "GT-I9192": "Samsung GT-I9192",
+            "GT-I9205": "Samsung GT-I9205",
+            "GT-I9300*": "Samsung GT-I9300",
+            "GT-I9305*": "Samsung GT-I9305",
+            "GT-I9500": "Samsung GT-I9500",
+            "GT-I9505X*": "Samsung GT-I9505X",
+            "GT-N7108": "Samsung GT-N7108",
+            "GT-P3100": "Samsung GT-P3100",
+            "GT-P3113": "Samsung GT-P3113",
+            "GT-P5110": "Samsung GT-P5110",
+            "GT-S7710": "Samsung GT-S7710",
+            "HTC Desire X": "HTC T328E",
+            "HTC One S*": "HTC PJ401",
+            "HTC One X": "HTC PJ83100",
+            "HTC One X+": "HTC PM63100",
+            "HTC6435LVW": "HTC HTC6435LVW",
+            "HTC_Desire_X*": "HTC T328E",
+            "HTC_One_S*": "HTC PJ401",
+            "HTC_One_V*": "HTC One V",
+            "HTC_One_X*": "HTC PJ83100",
+            "HTC_OneSV": "HTC One SV",
+            "HTC_OneXplus": "HTC PM63100",
+            "HUAWEI G510-*": "Huawei G510",
+            "HUAWEI U8950D": "Huawei U8950D",
+            "IdeaTabA2109A": "Lenovo A2109A",
+            "IdeaTabS2110AF": "Lenovo S2110AF",
+            "LG-E610*": "LG E610",
+            "LG-E975*": "LG E975",
+            "LG-F100L": "LG F100L",
+            "LG-P700*": "LG P700",
+            "LG-P895*": "LG P895",
+            "LT25i": "Sony LT25i",
+            "LT28h": "SonyEricsson LT28h",
+            "ME302C": "Asus ME302C",
+            "ME371MG": "Asus ME371MG",
+            "MediaPad 10 LINK": "Huawei MediaPad 10",
+            "N90FHDRK": "YUANDAO N90FHDRK",
+            "NOON": "Odys Noon",
+            "One S*": "HTC PJ401",
+            "PadFone": "Asus PadFone",
+            "PJ83100*": "HTC PJ83100",
+            "S500": "Acer S500",
+            "SGPT13": "Sony SGPT13",
+            "SonyC1505": "Sony C1505",
+            "SonyST26i*": "Sony ST26i",
+            "ST21i": "Sony ST21i",
+            "ST26i*": "Sony ST26i",
+            "TouchPad": "HP Touchpad",
+            "Transformer Prime TF201": "Asus TF201",
+            "U30GT 2": "Cube U30GT2",
+            "U30GT-H": "Cube U30GT",
+            "U9200": "Huawei U9200",
+            "VS840 4G": "LG VS840 4G",
+            "X10.Dual+": "Pearl X10.Dual+",
+            "Xelio 10 Pro": "Odys Xelio 10 Pro",
+            "XELIO7PRO": "Odys Xelio 7 Pro",
+            "XENO10": "Odys Xeno 10",
+            "XT907": "Motorola XT907",
+            "XT910": "Motorola XT910",
+            "ZP900": "ZOPO ZP900"
+          },
+          "platforms": [
+            "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Sony Tablet S": "Sony Tablet S"
+          },
+          "platforms": [
+            "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
+            "Android_3_2"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "GT-P7310": "Samsung GT-P7310",
+            "K1": "Lenovo K1",
+            "MZ604": "Motorola MZ604"
+          },
+          "platforms": [
+            "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
+            "Android_3_2", "Android_3_1"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "GT-P7500": "Samsung GT-P7500",
+            "MZ601": "Motorola MZ601",
+            "Xoom": "Motorola Xoom"
+          },
+          "platforms": [
+            "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
+            "Android_3_2", "Android_3_1", "Android_3_0"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "GT-I8190*": "Samsung GT-I8190",
+            "GT-I9100*": "Samsung GT-I9100",
+            "GT-I9100G": "Samsung GT-I9100G",
+            "GT-I9100P": "Samsung GT-I9100P",
+            "GT-I9103": "Samsung GT-I9103",
+            "GT-I9105P*": "Samsung GT-I9105P",
+            "GT-N7000*": "Samsung GT-N7000",
+            "GT-N8010": "Samsung GT-N8010",
+            "LT22i": "SonyEricsson LT22i",
+            "MOT-XT910": "Motorola XT910",
+            "MT11i": "SonyEricsson MT11i",
+            "Nexus S": "Samsung NexusS",
+            "SonyEricssonMT11i": "SonyEricsson MT11i",
+            "SonyLT26i": "SonyEricsson LT26i",
+            "ST18i": "SonyEricsson ST18i",
+            "ST27i": "SonyEricsson ST27i"
+          },
+          "platforms": [
+            "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
+            "Android_2_3"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
           "properties": {
             "Browser_Modus": "Desktop Mode"
           },
-          "device": "Amazon KFTT",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#1000ET Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Elonex eTouch",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#2808A+ Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Apad MID Rockchip 2808A+ Tablet",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#A* Build/*)applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#A101IT Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Archos A101IT",
-          "platforms": [
-            "Android_2_1", "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#A28 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#A43 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#A6277 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#A70S Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ADM901 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ADR6200 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ADR6300 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#AIRIS Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#AOSP on XDANDROID MSM Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Ally Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Android for Telechips TCC890* Build/*)*applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#BASE lutea Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "ZTE Blade",
-          "platforms": [
-            "Android_2_1", "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#DFP7002 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#DROIDX Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola DroidX",
-          "platforms": [
-            "Android_2_1", "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Dell Streak Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Dell Streak",
-          "platforms": [
-            "Android_2_1", "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Desire_A8181 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Desire A8181",
-          "platforms": [
-            "Android_2_1", "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Droid Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola Droid",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#E10i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson E10i",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyEricssonE10iv Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson E10iv",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Eris A50 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Eris",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Eris Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Eris",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I5500 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I5500",
-          "platforms": [
-            "Android_2_1", "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I5503 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I5503",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I5700 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I5700",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I5800 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I5800",
-          "platforms": [
-            "Android_2_1", "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I5801 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I5801",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I9000T Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9000T",
-          "platforms": [
-            "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I9000* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9000",
-          "platforms": [
-            "Android_2_1", "Android_2_2", "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT540 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG GT540",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Garmin-Asus A10 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Garmin-Asus A10",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Garmin-Asus A50 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Garmin-Asus A50",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC Desire * Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Desire",
-          "platforms": [
-            "Android_2_1", "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC Desire Build*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Desire",
-          "platforms": [
-            "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC G1 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "T-Mobile G1",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC Hero* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Hero",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (Linux*; Android VillainROM*; HTC Hero Build/ERE27) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Hero",
-          "platforms": [
-            "Android_1_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC Legend* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Legend",
-          "platforms": [
-            "Android_2_1", "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC Magic Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Magic",
-          "platforms": [
-            "Android_2_1", "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC Wildfire S* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Wildfire S A510",
-          "platforms": [
-            "Android_2_1", "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC Wildfire* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Wildfire",
-          "platforms": [
-            "Android_2_1", "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC-A6366* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC A6366",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_A3335* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC A3335",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_Aria_A6380 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Aria A6380",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_Desire-orange-LS Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Desire",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_Wildfire_A3333 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Wildfire A3333",
-          "platforms": [
-            "Android_2_1", "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#IS03 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "KDDI IS03",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Ideos S7 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "general Mobile Phone",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LU2300 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "general Mobile Phone",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LogicPD Zoom2 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LogicPD Zoom2",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#M82VG Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "general Mobile Phone",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#M860 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei M860",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MB508 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola MB508",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MB525 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola MB525",
-          "platforms": [
-            "Android_2_1", "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MB632 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola MB632",
-          "platforms": [
-            "Android_2_1", "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MB860 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola MB860",
-          "platforms": [
-            "Android_2_1", "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MID Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "general Mobile Phone",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MOT-XT615 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola XT615",
-          "platforms": [
-            "Android_2_1", "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Milestone Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola Milestone",
-          "platforms": [
-            "Android_2_0", "Android_2_1", "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Milestone XT720 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola XT720",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MotoMB511 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola MB511",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Nexus One Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Nexus One",
-          "platforms": [
-            "Android_2_1", "Android_2_2", "Android_2_3", "Android_3_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#NexusOne Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Nexus One",
-          "platforms": [
+          "devices": {
+            "GT-I9100T": "Samsung GT-I9100"
+          },
+          "platforms": [
+            "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android_2_3"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#OP070 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Olivetti Olipad 70",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "GT-I9003": "Samsung GT-I9003",
+            "GT-P1000*": "Samsung GT-P1000",
+            "GT-S5830*": "Samsung GT-S5830",
+            "LG-P990*": "LG P990"
+          },
           "platforms": [
-            "Android_2_1", "Android_2_2"
+            "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
+            "Android_2_3", "Android_2_2"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#OYO *) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "GT-I9000*": "Samsung GT-I9000"
+          },
           "platforms": [
-            "Android_2_1"
+            "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
+            "Android_2_3", "Android_2_2", "Android_2_1"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#Orange San Francisco Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "ZTE Orange",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Orange_Boston Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "ZTE Orange",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#POV Mobii 7 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Point of View Mobii 7",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Pulse Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "T-Mobile Pulse",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#RBM2 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#RBM3 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#S7 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SAMSUNG-SGH-I896 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SGH-I896",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SAMSUNG-SGH-I897* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SGH-I897",
-          "platforms": [
-            "Android_2_1", "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SCH-I500 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SCH-I500",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SCH-R880 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SCH-R880",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SGH-T959 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SGH-T959",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SHW-M110S Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SHW-M110S",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SPH-D700 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SPH-D700",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SPH-M900 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SPH-M900",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SPH-M910 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SPH-M910",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#San Francisco Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "ZTE Orange",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SmartQ V7 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyEricssonE10a Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson E10a",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyEricssonE15i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson E15i",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyEricssonE15iv Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson E15iv",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyEricssonSO-01B Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson SO-01B",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyEricssonU20i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson U20i",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyEricssonU20iv Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson U20iv",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyEricssonX10i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson X10i",
-          "platforms": [
-            "Android_2_1", "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyEricssonX10iv Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson X10iv",
-          "platforms": [
-            "Android_2_1", "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Stream Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Acer Stream",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#T-Mobile_Espresso Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "T-Mobile Espresso",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#T-Mobile_G2_Touch Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "T-Mobile G2 Touch",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#TOSHIBA_AC_AND_AZ) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Toshiba Folio 100",
-          "platforms": [
-            "Android_2_1", "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#TSB_CLOUD_COMPANION;TOSHIBA_AC_AND_AZ) applewebkit*(*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Toshiba Folio 100",
-          "platforms": [
-            "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0(#PLATFORM#ZTE Grand X2 Build/*) applewebkit*(*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "ZTE Grand X2",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "A1-811": "Acer A1-811",
+            "A3-A10": "Acer A3-A10",
+            "A66A": "Evercoss A66A",
+            "AC0732C": "3Q AC0732C",
+            "AFTB": "Amazon AFTB",
+            "Alcor Zest Q813IS": "Alcor Q813IS",
+            "ANKA-SX5": "Anka SX5",
+            "Archos 101 Neon": "Archos 101 Neon",
+            "Archos 50 Titanium": "Archos 50 Titanium",
+            "ARNOVA 101 G4": "Arnova 101G4",
+            "CAPTIVA PAD 10.1 Quad FHD": "Captiva PAD 10.1 Quad FHD 3G",
+            "CUBOT P9": "Cubot U30GT",
+            "Cynus E1": "Mobistel Cynus E1",
+            "Cynus F4": "Mobistel MT-7521S",
+            "Cynus T5": "Mobistel Cynus T5",
+            "DM015K": "Kyocera DM015K",
+            "DNS S5701": "DNS S5701",
+            "Endeavour 1010": "Blaupunkt Endeavour 1010",
+            "GT-I8200N": "Samsung GT-I8200N",
+            "GT-I9060": "Samsung GT-I9060",
+            "GT-I9082": "Samsung GT-I9082",
+            "GT-S7580": "Samsung GT-S7580",
+            "HUAWEI G700-U10": "Huawei G700-U10",
+            "HUAWEI Y330-U01": "Huawei Y330-U01",
+            "IdeaTab S6000-F": "Lenovo S6000-F",
+            "IdeaTab S6000-H": "Lenovo S6000-H",
+            "ImPAD 0413": "Impression ImPAD 0413",
+            "ImPAD 9708": "Impression ImPAD 9708",
+            "IQ4404": "Fly IQ4404",
+            "IRULU U1": "iRulu U1",
+            "KFSOWI": "Amazon KFSOWI",
+            "Lenovo Pad A4": "Lenovo Pad A4",
+            "Lenovo S920_ROW": "Lenovo S920_ROW",
+            "LenovoA3300-GV": "Lenovo A3300-GV",
+            "LIFETAB_E10312": "Medion LifeTab E10312",
+            "LIFETAB_E10316": "Medion LifeTab E10316",
+            "LIFETAB_E10320": "Medion E10320",
+            "LIFETAB_E7312": "Medion LifeTab E7312",
+            "LIFETAB_E7316": "Medion LifeTab E7316",
+            "ME173X": "Asus ME173X",
+            "ME302KL": "Asus ME302KL",
+            "MEDIA PAD": "Huawei Media Pad",
+            "MediaPad M1 8.0": "Huawei MediaPad M1 8.0",
+            "Micromax A120": "Micromax A120",
+            "N-06E": "NEC N-06E",
+            "NEO_QUAD10": "Odys Neo Quad 10",
+            "NX501": "ZTE NX501",
+            "OYSTERS T80 3G": "Oysters T80 3G",
+            "P200S": "JXD P200S",
+            "PAP3350DUO": "Prestigio PAP3350DUO",
+            "PAP7600DUO": "Prestigio PAP7600DUO",
+            "Plane 10.3 3G PS1043MG": "Digma PS1043MG",
+            "PMP5297C_QUAD": "Prestigio PMP5297C_QUAD",
+            "PMP5785C3G_QUAD": "Prestigio PMP5785C3G_QUAD",
+            "PMP7079D3G_QUAD": "Prestigio PMP7079D3G_QUAD",
+            "PMSmart450": "PMEDIA PMSmart450",
+            "RAINBOW": "Wiko Rainbow",
+            "SGH-T999": "Samsung SGH-T999",
+            "SH-01F": "Sharp SH-01F",
+            "SM-G350": "Samsung SM-G350",
+            "SM-T110": "Samsung SM-T110",
+            "SM-T111": "Samsung SM-T111",
+            "SM-T311": "Samsung SM-T311",
+            "Symphony W82": "Symphony W82",
+            "T9666-1": "Telsda T9666-1",
+            "TAB785DUAL": "Sunstech TAB785DUAL",
+            "TAD-70112 PO8292": "Denver TAD-70112",
+            "tolino tab 7": "Tolino Tab 7",
+            "tolino tab 8.9": "Tolino Tab 8.9",
+            "TX97": "Irbis TX97",
+            "UNO_X10": "Odys Uno X10",
+            "Vodafone Smart 4G": "Vodafone Smart 4G",
+            "Vodafone Smart Tab III 10": "Lenovo Smart Tab III 10",
+            "VT10416-1": "TrekStor VT10416-1",
+            "VT10416-2": "TrekStor VT10416-2",
+            "Xperia S": "Sony Xperia S",
+            "ZP980": "ZOPO ZP980",
+            "ZTE V808": "ZTE V808"
+          },
           "platforms": [
             "Android_4_2"
           ]
         },
         {
-          "match": "Mozilla/5.0(#PLATFORM#) applewebkit*(*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "platforms": [
-            "Android_4_2", "Android"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#TOSHIBA_FOLIO_AND_A Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Toshiba Folio 100",
-          "platforms": [
-            "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#TSB_CLOUD_COMPANION;FOLIO_AND_A) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Toshiba Folio 100",
-          "platforms": [
-            "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#folio100 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Toshiba Folio 100",
-          "platforms": [
-            "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#U20i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson U20i",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#U8100 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei U8100",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#U8180 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei U8180",
-          "platforms": [
-            "Android_2_1", "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#U8220 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei U8220",
-          "platforms": [
-            "Android_2_1", "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#U8500 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei U8500",
-          "platforms": [
-            "Android_2_1", "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#USCCADR6275US Carrier ID 45 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Vodafone 845 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Vodafone 845",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#WX445 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola WX445",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#X10i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson X10i",
-          "platforms": [
-            "Android_2_1", "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#XST2 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#XT610 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola XT610",
-          "platforms": [
-            "Android_2_1", "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#XT615 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola XT615",
-          "platforms": [
-            "Android_2_1", "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#XT701 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola XT701",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ZTE-BLADE Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "ZTE Blade",
-          "platforms": [
-            "Android_2_1", "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ZTE-RACER Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "ZTE Racer",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ZiiO7 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#jv02 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#liquid Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Acer Liquid",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#p7901a Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Epad P7901A",
-          "platforms": [
-            "Android_2_1", "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#sdk Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#v9 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ALCATEL one touch 890D Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Alcatel OT-890D",
-          "platforms": [
-            "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ALCATEL_one_touch_990 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Alcatel OT-990",
-          "platforms": [
-            "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#BASE Tab Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "ZTE BASE Tab",
-          "platforms": [
-            "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#DISCO10 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "platforms": [
-            "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#htc?Desire HD Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Desire HD",
-          "platforms": [
-            "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Desire HD Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Desire HD",
-          "platforms": [
-            "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_DesireHD_A9191 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Desire HD A9191",
-          "platforms": [
-            "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC Desire HD A9191 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Desire HD A9191",
-          "platforms": [
-            "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#E140 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Acer E140",
-          "platforms": [
-            "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#E310 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Acer E310",
-          "platforms": [
-            "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I5510 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I5510",
-          "platforms": [
-            "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I9003 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9003",
-          "platforms": [
-            "Android_2_2", "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I9010 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9010",
-          "platforms": [
-            "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-P1000* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-P1000",
-          "platforms": [
-            "Android_2_2", "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-P1010 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-P1010",
-          "platforms": [
-            "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-S5570I Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-S5570I",
-          "platforms": [
-            "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-S5570* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-S5570",
-          "platforms": [
-            "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-S5660 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-S5660",
-          "platforms": [
-            "Android_2_2", "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-S5670 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-S5670",
-          "platforms": [
-            "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-S5830C Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-S5830C",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-S5830i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-S5830i",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-S5830* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-S5830",
-          "platforms": [
-            "Android_2_2", "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC Incredible S Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER# *",
-          "device": "HTC S710E",
-          "platforms": [
-            "Android_2_2", "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC Incredible S Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC S710E",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC Vision Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Vision",
-          "platforms": [
-            "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_Desire Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Desire",
-          "platforms": [
-            "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_Gratia_A6380 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC A6380",
-          "platforms": [
-            "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Ideos Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "general Mobile Phone",
-          "platforms": [
-            "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-E720*; Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG E720",
-          "platforms": [
-            "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-E730*; Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG E730",
-          "platforms": [
-            "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-P350* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG P350",
-          "platforms": [
-            "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-P500* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG P500",
-          "platforms": [
-            "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-P720* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG P720",
-          "platforms": [
-            "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-P920* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG P920",
-          "platforms": [
-            "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-P925* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG P925",
-          "platforms": [
-            "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-P940* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG P940",
-          "platforms": [
-            "Android_2_2", "Android_2_3", "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-P970* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG P970",
-          "platforms": [
-            "Android_2_2", "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-P990* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG P990",
-          "platforms": [
-            "Android_2_2", "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Liquid Metal Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Acer Liquid Metal",
-          "platforms": [
-            "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MotoA953 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola A953",
-          "platforms": [
-            "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MotoroiX Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola MotoroiX",
-          "platforms": [
-            "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#NBPC724 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Coby NBPC724",
-          "platforms": [
-            "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ODYS Space Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Odys Space",
-          "platforms": [
-            "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ODYS Xtreme Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Odys Xtreme",
-          "platforms": [
-            "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SMARTBOOK* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "platforms": [
-            "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ViewPad7 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "ViewSonic ViewPad7",
-          "platforms": [
-            "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ViewSonic-ViewPad7e Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "ViewSonic ViewPad7e",
-          "platforms": [
-            "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Vodafone 858 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei Vodafone 858",
-          "platforms": [
-            "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#XT320 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola XT320",
-          "platforms": [
-            "Android_2_2", "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#imx51_bbg Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "platforms": [
-            "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#meizu_m9 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Meizu M9",
-          "platforms": [
-            "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#NGM Miracle Build/*) applewebkit*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "NGM WeMove Miracle",
-          "platforms": [
-            "Android_2_2", "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (Linux*; Android RCMix_v2.2_WWE*; HTC_HERO Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Hero",
-          "platforms": [
-            "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I9100 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9100",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I9100T Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "properties": {
-            "Browser_Modus": "Desktop Mode"
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "ADM816KC": "Odys ADM816KC",
+            "PMP7280C3G": "Prestigio PMP7280C3G"
           },
-          "device": "Samsung GT-I9100",
           "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
+            "Android_4_2", "Android_4_1"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I9100G Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9100G",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "A700": "Acer A700",
+            "ARCHOS 101G10": "Archos 101 G10",
+            "ASUS Transformer Pad TF300T": "Asus TF300T",
+            "B1-710": "Acer B1-710",
+            "C6602": "SonyEricsson C6602",
+            "GT-I9195*": "Samsung GT-I9195",
+            "GT-P3110": "Samsung GT-P3110",
+            "GT-P5100*": "Samsung GT-P5100",
+            "GT-S5301": "Samsung GT-S5301",
+            "HTC?One_XL*": "HTC One XL",
+            "HUAWEI Y300*": "Huawei Y300",
+            "LG-P880*": "LG P880",
+            "SCH-I200": "Samsung SCH-I200",
+            "SGH-I777": "Samsung SGH-I777"
+          },
           "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
+            "Android_4_2", "Android_4_1", "Android_4_0"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I9100P Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9100P",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "LT18i": "SonyEricsson LT18i"
+          },
           "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I9100* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9100",
-          "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (*GT-I9100#PLATFORM#)*applewebkit*(*khtml*like*gecko*)*Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9100",
-          "platforms": [
-            "Android_B_2_3"
-          ]
-        },
-        {
-          "match": "*Mozilla/5.0 (*GT-I9100#PLATFORM#) applewebkit*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9100",
-          "platforms": [
-            "Android_B_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#A1_07 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo IdeaPad A1",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ALCATEL ONE TOUCH 903D Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Alcatel OT-903D",
-          "platforms": [
+            "Android_4_2", "Android_4_1", "Android_4_0",
             "Android_2_3"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#ALCATEL ONE TOUCH 918D Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Alcatel OT-918D",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ALCATEL ONE TOUCH 991 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Alcatel OT-991",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ALCATEL ONE TOUCH 991D Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Alcatel OT-991D",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ALCATEL ONE TOUCH 991T Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Alcatel OT-991T",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ALCATEL ONE TOUCH 997D Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Alcatel OT-997D",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ALCATEL_one_touch_918D Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Alcatel OT-918D",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ALCATEL_one_touch_995 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Alcatel OT-995",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#AN7CG2 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Arnova 7CG2",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Acer E320 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Acer E320",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#BASE Lutea 2 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "ZTE Lutea 2",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#BASE Tab 7.1 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "ZTE BASE Tab",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#CAT NOVA Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "CatSound Nova",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Cat Tablet Galactica X* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "CatSound Galactica X",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Cat Tablet* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "CatSound Tablet",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#CatNova8 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "CatSound Cat Nova 8",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Kinder-Tablet-1.0-Weltbild-Mozilla/5.0 (#PLATFORM#EOS10 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Weltbild Kinder-Tablet",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#FX2-PAD10 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Faktor Zwei FX2 PAD10",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I8150 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I8150",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I8160 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I8160",
-          "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I8160P Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I8160P",
-          "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I8190N Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I8190N",
-          "platforms": [
-            "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I8190* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I8190",
-          "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I8530 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I8530",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I9001* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9001",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I9070 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9070",
-          "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I9070P* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9070P",
-          "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I9103 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9103",
-          "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I9105P* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9105P",
-          "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-N7000* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-N7000",
-          "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-N7100* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-N7100",
-          "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-N8000 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-N8000",
-          "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Cakemix/* Mozilla/5.0 (#PLATFORM#GT-N8000 Build/*) applewebkit* (*khtml*like*gecko*) Version/?.0*Safari*",
-          "device": "Samsung GT-N8000",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "ALCATEL ONE TOUCH 5020D": "Alcatel OT-5020D",
+            "Archos 50 Platinum": "Archos 50 Platinum",
+            "AT300SE": "Toshiba AT300SE",
+            "B15": "Caterpillar Cat B15",
+            "CINK PEAX 2": "Wiko Cink Peax 2",
+            "Cynus F3": "Mobistel Cynus F3",
+            "Cynus F5": "Mobistel Cynus F5",
+            "DROID RAZR": "Motorola Razr",
+            "E-TAB IVORY": "Lava E-Tab IVORY",
+            "FUNC TITAN-01A": "DFunc Func Titan-01A",
+            "GT-I8262": "Samsung GT-I8262",
+            "GT-S5280": "Samsung GT-S5280",
+            "GT-S5310": "Samsung GT-S5310",
+            "GT-S6310": "Samsung GT-S6310",
+            "GT-S6310N": "Samsung GT-S6310N",
+            "GT-S6312": "Samsung GT-S6312",
+            "GT-S6810P": "Samsung GT-S6810P",
+            "HTC Desire 400 dual sim": "HTC Desire 400",
+            "HTC_Amaze": "HTC Amaze 4G",
+            "HTC_Desire_500": "HTC Desire 500",
+            "HUAWEI G525-U00": "Huawei G525-U00",
+            "HUAWEI MT1-U06": "Huawei MT1-U06",
+            "IM-A850K*": "Pantech IM-A850K",
+            "LG-D605": "LG D605",
+            "LG-E430": "LG E430",
+            "LG-E440": "LG E440",
+            "LG-E460": "LG E460",
+            "LG-E612": "LG E612",
+            "LG-P710": "LG P710",
+            "LIFETAB_E10310": "Medion E10310",
+            "LT26w": "Sony LT26w",
+            "ME172V": "Asus ME172V",
+            "MEDION X4701": "Medion X4701",
+            "MODECOM FreeTAB 8001 IPS X23G": "MODECOM FreeTAB 8001 IPS X2 3G",
+            "PATG7506HD": "Perfeo PATG7506HD",
+            "PolyPad 1010IPS": "PolyPad 1010IPS",
+            "POV_TAB-PI1045": "Point of View PI1045",
+            "RC9724C": "3Q RC9724C",
+            "SGH-I317": "Samsung SGH-I317",
+            "SGH-T889": "Samsung SGH-T889",
+            "SHV-E160S": "Samsung SHV-E160S",
+            "SM-T210": "Samsung SM-T210",
+            "SM-T211": "Samsung SM-T211",
+            "ST10216-2": "TrekStor ST10216-2",
+            "Surfer 8.31 3G": "Explay Surfer 8.31 3G",
+            "TechniPad_10-3G": "TechniSat TechniPad 10 3G",
+            "TOUAREG8_3G": "Accent Touareg8 3G",
+            "TP10.1-1500DC-metal": "I-ONIK TP10",
+            "Xelio 7 pro": "Odys Xelio 7 Pro"
+          },
           "platforms": [
             "Android_4_1"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-N8010 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-N8010",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "folio100": "Toshiba Folio 100",
+            "MK16i": "SonyEricsson MK16i",
+            "ST25i": "SonyEricsson ST25i",
+            "A210": "Acer A210",
+            "A211": "Acer A211",
+            "A510": "Acer A510",
+            "A701": "Acer A701",
+            "ASUS Transformer Pad TF300TL": "Asus TF300TL",
+            "AT300": "Toshiba AT300",
+            "B1-A71": "Acer B1-A71",
+            "Cynus T2": "Mobistel Cynus T2",
+            "DROID RAZR 4G": "Motorola XT912B",
+            "GT-P5113": "Samsung GT-P5113",
+            "HTC One SV*": "HTC One SV",
+            "LG-P760*": "LG P760",
+            "LIFETAB_S9512": "Medion LifeTab S9512",
+            "LIFETAB_S9714": "Medion LifeTab S9714",
+            "LOOX Plus": "Odys Loox Plus",
+            "LT30p": "Sony LT30p",
+            "ODYS-NOON": "Odys Noon",
+            "SGPT12": "Sony SGPT12",
+            "SonyEricssonST21i": "Sony ST21i",
+            "SonyST21i": "Sony ST21i",
+            "SonyST21i2": "Sony ST21i2",
+            "SonyST21iv": "Sony ST21iv",
+            "ST23i": "Sony ST23i",
+            "U8825*": "Huawei U8825",
+            "X10.Dual": "Pearl X10.Dual",
+            "XT890": "Motorola XT890",
+            "M532": "Fujitsu M532"
+          },
           "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
+            "Android_4_1", "Android_4_0"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-S5300 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-S5300",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "ARCHOS 101G9": "Archos 101 G9",
+            "AT200": "Toshiba AT200",
+            "LIFETAB_P9514": "Medion LifeTab P9514",
+            "MD_LIFETAB_P9516": "Medion LifeTab P9516"
+          },
           "platforms": [
+            "Android_4_1", "Android_4_0",
+            "Android_3_2"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "GT-P7500*": "Samsung GT-P7500",
+            "GT-P7510": "Samsung GT-P7510"
+          },
+          "platforms": [
+            "Android_4_1", "Android_4_0",
+            "Android_3_2", "Android_3_1"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "A100": "Acer A100",
+            "A500": "Acer A500",
+            "A501": "Acer A501"
+          },
+          "platforms": [
+            "Android_4_1", "Android_4_0",
+            "Android_3_2", "Android_3_1", "Android_3_0"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "GT-I8160": "Samsung GT-I8160",
+            "GT-I8160P": "Samsung GT-I8160P",
+            "GT-I9070": "Samsung GT-I9070",
+            "GT-I9070P*": "Samsung GT-I9070P",
+            "LT26i": "SonyEricsson LT26i",
+            "MID1125": "Coby MID1125",
+            "MID1126": "Coby MID1126",
+            "MID7022": "Coby MID7022",
+            "MID8127": "Coby MID8127",
+            "POV_TAB-PROTAB30-IPS10": "Point of View Protab 3 XXL",
+            "SonyEricssonLT26i": "SonyEricsson LT26i",
+            "SonyEricssonST25i": "SonyEricsson ST25i"
+          },
+          "platforms": [
+            "Android_4_1", "Android_4_0",
             "Android_2_3"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-S5300B Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-S5300B",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-S5360 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-S5360",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-S5363 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-S5363",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-S5369* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-S5369",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-S5690* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-S5690",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-S5839i* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-S5839i",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-S6102 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-S6102",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-S6102B Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-S6102B",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-S6500* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-S6500",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-S6802 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-S6802",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-S7500* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-S7500",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC Desire HD * Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Desire HD",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC Flyer P510e Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Flyer P510e",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC HD2 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC HD2",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC Sensation XE with Beats Audio Z715e Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Z715e",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC Sensation XL with Beats Audio X315e Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC X315e",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC Sensation Z710e Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Z710e",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC/Explorer* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC A310e",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC/Sensation/* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Z710",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC/Velocity 4G* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Velocity 4G",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC/WildfireS* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Wildfire S A510",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_ChaCha_A810e Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC A810e",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_DesireHD Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Desire HD",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_DesireS Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Desire S",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_DesireS_S510e Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Mobile*",
-          "device": "HTC S510e",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "HTC_DesireS_S510e?Mozilla/5.0(#PLATFORM#Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC S510e",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_DesireZ_A7272 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC A7272",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_Explorer_A310e Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC A310e",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_IncredibleS_S710e Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC S710E",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_Rhyme_S510b Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC S510B",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_Sensation Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Z710",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_WildfireS Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Wildfire S A510",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_WildfireS_A510e Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC A510e",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC?Desire* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Desire",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HUAWEI SONIC Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei U8650",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#U8650* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei U8650",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HUAWEI U8666E Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei U8666E",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HUAWEI U8950N-1 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei U8950N",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#INM803HC Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lalsoft INM803HC",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#IncredibleS_S710e Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC S710E",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-E400* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG E400",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-E510* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG E510",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-P690* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG P690",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LT18i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson LT18i",
-          "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyEricssonLT18iv Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson LT18iv",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LT22i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson LT22i",
-          "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyEricssonLT26i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson LT26i",
-          "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyLT26i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson LT26i",
-          "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LT26i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson LT26i",
-          "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MotoMB526 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola MB526",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MB526 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola MB526",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MEDION LIFE P4310 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Medion LifeTab P4310",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MEDION Smartphone LIFE E3501 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Medion Life E3501",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MID1125 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Coby MID1125",
-          "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MID1126 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Coby MID1126",
-          "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MID7022 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Coby MID7022",
-          "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MID8127 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Coby MID8127",
-          "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MID_Serials Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MOT-XT910 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola XT910",
-          "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#XT910 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola XT910",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MT15i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson MT15i",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyEricssonMT15iv Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson MT15iv",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyEricssonMT27i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson MT27i",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MT27i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson MT27i",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MT791 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Keen High MT791",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Nexus S Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung NexusS",
-          "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#NexusHD2 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC HD2",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Odys-Loox Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Odys Loox",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#PMP5080B Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Multipad PMP5080B",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#POV_TAB-PROTAB30-IPS10 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Point of View Protab 3 XXL",
-          "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#R800i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson R800i",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyEricssonR800iv Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson R800iv",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I9070* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9070",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I9210* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9210",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SH80F Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Sharp SH80F",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SK17i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson SK17i",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyEricssonSK17iv Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson SK17iv",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SPX-5 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Simvalley SPX-5",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SPX-5_3G Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Simvalley SPX-5 3G",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ST18i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson ST18i",
-          "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyEricssonST18iv Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson ST18iv",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyEricssonLT15i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson LT15i",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LT15i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson LT15i",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "LG-P940*": "LG P940",
+            "SCH-I535*": "Samsung SCH-I535"
+          },
+          "platforms": [
+            "Android_4_1", "Android_4_0",
+            "Android_2_3", "Android_2_2"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "A101": "Acer A101",
+            "A200": "Acer A200",
+            "ADM816HC": "Odys ADM816HC",
+            "ALCATEL ONE TOUCH 992D": "Alcatel OT-992D",
+            "AN10BG3": "Arnova AN10BG3",
+            "AN9G2I": "Arnova 9G2",
+            "ARCHOS 97 CARBON": "Archos 97 carbon",
+            "AX540": "Bmobile AX540",
+            "BASE_Lutea_3": "ZTE Lutea 3",
+            "blaze": "Samsung SGH-T769",
+            "bq Edison": "BQ Edison",
+            "CAL21": "GzOne CAL21",
+            "Cat Tablet Galactica X*": "CatSound Galactica X",
+            "cm_tenderloin": "HP Touchpad",
+            "Cynus T1": "Mobistel Cynus T1",
+            "DROID BIONIC 4G": "Motorola XT875",
+            "EVO3D_X515m": "HTC X515m",
+            "GOCLEVER TAB A93.2": "GOCLEVER A93.2",
+            "GT-P7100": "Samsung GT-P7100",
+            "GT-S7560": "Samsung GT-S7560",
+            "HTC EVO 3D X515m": "HTC X515m",
+            "HTC Incredible S": "HTC S710E",
+            "HTC One V*": "HTC One V",
+            "HTC Sensation": "HTC Z710",
+            "HTC/EVO_3D*": "HTC X515m",
+            "HTC_Desire_C*": "HTC Desire C",
+            "HTC_Sensation_Z710e": "HTC Z710e",
+            "HTC_SensationXE_Beats": "HTC Z710",
+            "HTC_SensationXL_Beats*": "HTC X315e",
+            "HUAWEI U9508": "Huawei U9508",
+            "IdeaTab A2107A-H": "Lenovo A2107A-H",
+            "iDxD7_3G": "Digma iDxD7 3G",
+            "KFOT": "Amazon KFOT",
+            "Lenovo A660": "Lenovo IdeaPad A660",
+            "LG-E615": "LG E615",
+            "LG-LS860": "LG LS860",
+            "LT15i": "SonyEricsson LT15i",
+            "M83g": "PiPO M8 3G",
+            "ME-701": "Marshal ME-701",
+            "MediaPad 7 Lite": "Huawei MediaPad 7 Lite",
+            "MEDION LIFE P4012": "Medion LifeTab P4012",
+            "NEXT": "Nextbook Next",
+            "ODYS-EVO": "Odys Evo",
+            "ODYS-Q": "Odys Q",
+            "ONDA MID": "ONDA MID",
+            "PMP5080CPRO": "Prestigio PMP5080CPRO",
+            "PMP5580C": "Prestigio PMP5580C",
+            "PMP5770D": "Prestigio PMP5770D",
+            "PMP7100D3G": "Prestigio PMP7100D3G",
+            "S20": "Karbonn S20",
+            "SCH-I815 4G": "Samsung SCH-I815",
+            "Sensation_Z710e": "HTC Z710e",
+            "SensationXE_Beats_Z715e": "HTC Z715e",
+            "SensationXL_Beats_X315e": "HTC X315e",
+            "SHW-M380W": "Samsung SHW-M380W",
+            "Slider SL101": "Asus SL101",
+            "SmartTabII10": "Lenovo SmartTab II 10",
+            "SO-01E": "SonyEricsson SO-01E",
+            "SonyEricssonST25a": "SonyEricsson ST25a",
+            "SPH-D710": "Samsung SPH-D710",
+            "SPH-D710BST": "Samsung SPH-D710BST",
+            "Sprint APX515CKT": "HTC X515",
+            "SurfTab_7.0": "TrekStor ST701041",
+            "SXZ-PDX0-01": "SXZ PDX0-01",
+            "ThL W7": "ThL W7",
+            "Vodafone SmartTab II 10": "Lenovo SmartTab II 10",
+            "X10": "SonyEricsson X10",
+            "XOOM 2 ME": "Motorola MZ608",
+            "XOOM 2": "Motorola Xoom 2",
+            "ZP910": "ZOPO ZP910"
+          },
           "platforms": [
             "Android_4_0"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyEricssonLT15iv Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson LT15iv",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyEricssonMK16i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson MK16i",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MK16i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson MK16i",
-          "platforms": [
-            "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyEricssonMT11i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson MT11i",
-          "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MT11i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson MT11i",
-          "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyEricssonMT15a Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson MT15a",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyEricssonST15i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson ST15i",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyEricssonST17i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson ST17i",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyEricssonST25i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson ST25i",
-          "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyEricssonST25a Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson ST25a",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "properties": {
+            "Browser_Modus": "Desktop Mode"
+          },
+          "devices": {
+            "KFTT": "Amazon KFTT"
+          },
           "platforms": [
             "Android_4_0"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#ST25i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson ST25i",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "ARCHOS 80G9": "Archos 80 G9",
+            "GT-P6201": "Samsung GT-P6201",
+            "GT-P6800": "Samsung GT-P6800",
+            "GT-P7501*": "Samsung GT-P7501",
+            "GT-P7511": "Samsung GT-P7511",
+            "HUAWEI MediaPad": "Huawei S7-301w",
+            "Transformer TF101G": "Asus TF101G"
+          },
           "platforms": [
-            "Android_4_0", "Android_4_1"
+            "Android_4_0",
+            "Android_3_2"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#ST27i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson ST27i",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "AT100": "Toshiba AT100",
+            "ThinkPad Tablet": "Lenovo 1838",
+            "Transformer TF101": "Asus TF101"
+          },
           "platforms": [
-            "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
+            "Android_4_0",
+            "Android_3_2", "Android_3_1"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#WT19i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson WT19i",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "A1_07": "Lenovo IdeaPad A1",
+            "ALCATEL ONE TOUCH 997D": "Alcatel OT-997D",
+            "ALCATEL_one_touch_995": "Alcatel OT-995",
+            "Cat Tablet*": "CatSound Tablet",
+            "dL1": "Panasonic dL1",
+            "GT-I9001*": "Samsung GT-I9001",
+            "HTC Sensation XE with Beats Audio Z715e": "HTC Z715e",
+            "HTC Sensation XL with Beats Audio X315e": "HTC X315e",
+            "HTC Sensation Z710e": "HTC Z710e",
+            "HTC/Sensation/*": "HTC Z710",
+            "HTC_DesireS": "HTC Desire S",
+            "HTC_Sensation": "HTC Z710",
+            "HUAWEI U8666E": "Huawei U8666E",
+            "HUAWEI U8950N-1": "Huawei U8950N",
+            "IncredibleS_S710e": "HTC S710E",
+            "LG-E510*": "LG E510",
+            "LG-P690*": "LG P690",
+            "MEDION LIFE P4310": "Medion LifeTab P4310",
+            "MT15i": "SonyEricsson MT15i",
+            "MT27i": "SonyEricsson MT27i",
+            "SK17i": "SonyEricsson SK17i",
+            "SonyEricssonLT15i": "SonyEricsson LT15i",
+            "SonyEricssonLT15iv": "SonyEricsson LT15iv",
+            "SonyEricssonLT18iv": "SonyEricsson LT18iv",
+            "SonyEricssonMK16i": "SonyEricsson MK16i",
+            "SonyEricssonMT15iv": "SonyEricsson MT15iv",
+            "SonyEricssonMT27i": "SonyEricsson MT27i",
+            "SonyEricssonSK17iv": "SonyEricsson SK17iv",
+            "SonyEricssonST15i": "SonyEricsson ST15i",
+            "SonyEricssonST17i": "SonyEricsson ST17i",
+            "SonyEricssonST18iv": "SonyEricsson ST18iv",
+            "U8860": "Huawei U8860",
+            "WT19i": "SonyEricsson WT19i"
+          },
           "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyEricssonWT19iv Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson WT19iv",
-          "platforms": [
+            "Android_4_0",
             "Android_2_3"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#U8510 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei S41HW",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "LG-P970*": "LG P970"
+          },
           "platforms": [
-            "Android_2_3"
+            "Android_4_0",
+            "Android_2_3", "Android_2_2"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#U8600 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei U8600",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Dell Streak 7": "Dell Streak 7",
+            "G100W": "Acer G100W",
+            "GT-P6211": "Samsung GT-P6211",
+            "GT-P7300B": "Samsung GT-P7300B",
+            "GT-P7320*": "Samsung GT-P7320"
+          },
           "platforms": [
-            "Android_2_3"
+            "Android_3_2"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#U8655-1 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei U8655",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "GT-P7300": "Samsung GT-P7300"
+          },
           "platforms": [
-            "Android_2_3"
+            "Android_3_2", "Android_3_1"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#U8860 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei U8860",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ViewSonic-V350 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "ViewSonic V350",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Vodafone Smart II Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo v860",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Vodafone Smart Tab III 10 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo Smart Tab III 10",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Vodafone SmartTab II 10 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo SmartTab II 10",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#X7G Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Pearl Touchlet X7G",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#YP-G1 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung YP-G1",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#YP-G70 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung YP-G70",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#YP-GI1 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung YP-GI1",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#YP-GS1 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung YP-GS1",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#dL1 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Panasonic dL1",
-          "platforms": [
-            "Android_2_3", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#generic_vortex Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#A100 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Acer A100",
-          "platforms": [
-            "Android_3_0", "Android_3_1", "Android_3_2", "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#A500 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Acer A500",
-          "platforms": [
-            "Android_3_0", "Android_3_1", "Android_3_2", "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#A501 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Acer A501",
-          "platforms": [
-            "Android_3_0", "Android_3_1", "Android_3_2", "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-P7500 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-P7500",
-          "platforms": [
-            "Android_3_0", "Android_3_1", "Android_3_2", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SAMSUNG-GT-P7500* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-P7500",
-          "platforms": [
-            "Android_3_1", "Android_3_2", "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-V900* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG V900",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "LG-V900*": "LG V900",
+            "Xoom MZ604": "Motorola MZ604"
+          },
           "platforms": [
             "Android_3_0"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#MZ601 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola MZ601",
-          "platforms": [
-            "Android_3_0", "Android_3_1", "Android_3_2", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Xoom Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola Xoom",
-          "platforms": [
-            "Android_3_0", "Android_3_1", "Android_3_2", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Xoom MZ604 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola MZ604",
-          "platforms": [
-            "Android_3_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MZ604 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola MZ604",
-          "platforms": [
-            "Android_3_1", "Android_3_2", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#XOOM 2 Build/*MZ616*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola MZ616",
-          "platforms": [
-            "Android_3_2", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#XOOM 2 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola Xoom 2",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#XOOM 2 ME Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola MZ608",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#AT100 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Toshiba AT100",
-          "platforms": [
-            "Android_3_1", "Android_3_2", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-P7300 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-P7300",
-          "platforms": [
-            "Android_3_1", "Android_3_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-P7310 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-P7310",
-          "platforms": [
-            "Android_3_1", "Android_3_2", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-P7510 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-P7510",
-          "platforms": [
-            "Android_3_1", "Android_3_2", "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#K1 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo K1",
-          "platforms": [
-            "Android_3_1", "Android_3_2", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ThinkPad Tablet Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo 1838",
-          "platforms": [
-            "Android_3_1", "Android_3_2", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Transformer TF101 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Asus TF101",
-          "platforms": [
-            "Android_3_1", "Android_3_2", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Transformer TF101G Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Asus TF101G",
-          "platforms": [
-            "Android_3_2", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ARCHOS 101G9 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Archos 101 G9",
-          "platforms": [
-            "Android_3_2", "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ARCHOS 80G9 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Archos 80 G9",
-          "platforms": [
-            "Android_3_2", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#AT200 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Toshiba AT200",
-          "platforms": [
-            "Android_3_2", "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Dell Streak 7 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Dell Streak 7",
-          "platforms": [
-            "Android_3_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#G100W Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Acer G100W",
-          "platforms": [
-            "Android_3_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-P6201 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-P6201",
-          "platforms": [
-            "Android_3_2", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-P6211 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-P6211",
-          "platforms": [
-            "Android_3_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-P7300B Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-P7300B",
-          "platforms": [
-            "Android_3_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-P7501* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-P7501",
-          "platforms": [
-            "Android_3_2", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-P7511 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-P7511",
-          "platforms": [
-            "Android_3_2", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HUAWEI MediaPad Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei S7-301w",
-          "platforms": [
-            "Android_3_2", "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LIFETAB_P9514 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Medion LifeTab P9514",
-          "platforms": [
-            "Android_3_2", "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MD_LIFETAB_P9516 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Medion LifeTab P9516",
-          "platforms": [
-            "Android_3_2", "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Sony Tablet S Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Sony Tablet S",
-          "platforms": [
-            "Android_3_2", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Sony Tablet P Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*",
-          "device": "Sony Tablet P",
-          "platforms": [
-            "Android_3_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#A101 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Acer A101",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#A200 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Acer A200",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#A210 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Acer A210",
-          "platforms": [
-            "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#A211 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Acer A211",
-          "platforms": [
-            "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#A510 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Acer A510",
-          "platforms": [
-            "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#A511 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Acer A511",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#A700 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Acer A700",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#A701 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Acer A701",
-          "platforms": [
-            "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ALCATEL ONE TOUCH 6010D Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Alcatel OT-6010D",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ALCATEL ONE TOUCH 6030D Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Alcatel OT-6030D",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ALCATEL ONE TOUCH 6033X Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Alcatel OT-6033X",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ALCATEL ONE TOUCH 992D Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Alcatel OT-992D",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ALCATEL ONE TOUCH 5020D Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Alcatel OT-5020D",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#C6903 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Sony C6903",
-          "platforms": [
-            "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-P710 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG P710",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-E460 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG E460",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ARCHOS 101G10 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Archos 101 G10",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ARCHOS 97 CARBON Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Archos 97 carbon",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ARCHOS FAMILYPAD 2 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Archos Family Pad 2",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ASUS Transformer Pad TF300T Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Asus TF300T",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ASUS Transformer Pad TF300TG Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Asus TF300TG",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ASUS Transformer Pad TF300TL Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Asus TF300TL",
-          "platforms": [
-            "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ASUS Transformer Pad TF700T Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Asus TF700T",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#AT300 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Toshiba AT300",
-          "platforms": [
-            "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Archos 80 Xenon Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Archos 80 Xenon",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#B1-710 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Acer B1-710",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#A1-810 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Acer A1-810",
-          "platforms": [
-            "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#B1-A71 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Acer B1-A71",
-          "platforms": [
-            "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#BASE_Lutea_3 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "ZTE Lutea 3",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#C2105 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Sony C2105",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#C6602 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson C6602",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#C6603 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Sony C6603",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#C6603 Build/*) applewebkit* (*khtml*like*gecko*)",
-          "device": "Sony C6603",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Cynus T1 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Mobistel Cynus T1",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Cynus T2 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Mobistel Cynus T2",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#DROID RAZR 4G Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola XT912B",
-          "platforms": [
-            "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#DROID X2 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola Droid X2",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Nexus One": "HTC Nexus One"
+          },
+          "platforms": [
+            "Android_3_0",
+            "Android_2_3", "Android_2_2", "Android_2_1"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Acer E320": "Acer E320",
+            "ALCATEL ONE TOUCH 903D": "Alcatel OT-903D",
+            "ALCATEL ONE TOUCH 918D": "Alcatel OT-918D",
+            "ALCATEL ONE TOUCH 991": "Alcatel OT-991",
+            "ALCATEL ONE TOUCH 991D": "Alcatel OT-991D",
+            "ALCATEL ONE TOUCH 991T": "Alcatel OT-991T",
+            "ALCATEL_one_touch_918D": "Alcatel OT-918D",
+            "AN7CG2": "Arnova 7CG2",
+            "BASE Lutea 2": "ZTE Lutea 2",
+            "BASE Tab 7.1": "ZTE BASE Tab",
+            "CAT NOVA": "CatSound Nova",
+            "CatNova8": "CatSound Cat Nova 8",
+            "DROID X2": "Motorola Droid X2",
+            "FWS610_EU": "Phicomm FWS610",
+            "FX2-PAD10": "Faktor Zwei FX2 PAD10",
+            "generic_vortex": "ViMicro Vortex",
+            "GT-I8150": "Samsung GT-I8150",
+            "GT-I8530": "Samsung GT-I8530",
+            "GT-I9070*": "Samsung GT-I9070",
+            "GT-I9210*": "Samsung GT-I9210",
+            "GT-S5300": "Samsung GT-S5300",
+            "GT-S5300B": "Samsung GT-S5300B",
+            "GT-S5360": "Samsung GT-S5360",
+            "GT-S5363": "Samsung GT-S5363",
+            "GT-S5369*": "Samsung GT-S5369",
+            "GT-S5690*": "Samsung GT-S5690",
+            "GT-S5830C": "Samsung GT-S5830C",
+            "GT-S5830i": "Samsung GT-S5830i",
+            "GT-S5839i*": "Samsung GT-S5839i",
+            "GT-S6102": "Samsung GT-S6102",
+            "GT-S6102B": "Samsung GT-S6102B",
+            "GT-S6500*": "Samsung GT-S6500",
+            "GT-S6802": "Samsung GT-S6802",
+            "GT-S7500*": "Samsung GT-S7500",
+            "HTC Desire HD *": "HTC Desire HD",
+            "HTC Desire S": "HTC Desire S",
+            "HTC Flyer P510e": "HTC Flyer P510e",
+            "HTC HD2": "HTC HD2",
+            "HTC/Explorer*": "HTC A310e",
+            "HTC/Velocity 4G*": "HTC Velocity 4G",
+            "HTC/WildfireS*": "HTC Wildfire S A510",
+            "HTC?Desire*": "HTC Desire",
+            "HTC_ChaCha_A810e": "HTC A810e",
+            "HTC_DesireHD": "HTC Desire HD",
+            "HTC_DesireZ_A7272": "HTC A7272",
+            "HTC_Explorer_A310e": "HTC A310e",
+            "HTC_IncredibleS_S710e": "HTC S710E",
+            "HTC_Rhyme_S510b": "HTC S510B",
+            "HTC_WildfireS": "HTC Wildfire S A510",
+            "HTC_WildfireS_A510e": "HTC A510e",
+            "HUAWEI SONIC": "Huawei U8650",
+            "HUAWEI-U8850": "Huawei U8850",
+            "INM803HC": "Lalsoft INM803HC",
+            "KIS PLUS": "ZTE V788D",
+            "LG-E400*": "LG E400",
+            "Magic W700": "Magic W700",
+            "MB526": "Motorola MB526",
+            "MEDION Smartphone LIFE E3501": "Medion Life E3501",
+            "MID7016": "Coby MID7016",
+            "MotoMB526": "Motorola MB526",
+            "MT791": "Keen High MT791",
+            "NexusHD2": "HTC HD2",
+            "NexusOne": "HTC Nexus One",
+            "Odys-Loox": "Odys Loox",
+            "pcdadr6350": "HTC ADR6350",
+            "PMP5080B": "Multipad PMP5080B",
+            "R800i": "SonyEricsson R800i",
+            "SCH-I510 4G": "Samsung SCH-I510",
+            "SCH-R720": "Samsung SCH-R720",
+            "SGH-T989": "Samsung SGH-T989",
+            "SH80F": "Sharp SH80F",
+            "SO-03C": "Sony SO-03C",
+            "SonyEricssonMT15a": "SonyEricsson MT15a",
+            "SonyEricssonR800iv": "SonyEricsson R800iv",
+            "SonyEricssonWT19iv": "SonyEricsson WT19iv",
+            "Spice Mi-424": "Spice Mi-424",
+            "Sprint APA9292KT": "HTC 9292",
+            "SPX-5": "Simvalley SPX-5",
+            "SPX-5_3G": "Simvalley SPX-5 3G",
+            "U8510": "Huawei S41HW",
+            "U8600": "Huawei U8600",
+            "U8650*": "Huawei U8650",
+            "U8655-1": "Huawei U8655",
+            "ViewSonic-V350": "ViewSonic V350",
+            "Vodafone Smart II": "Lenovo v860",
+            "X7G": "Pearl Touchlet X7G",
+            "YP-G1": "Samsung YP-G1",
+            "YP-G70": "Samsung YP-G70",
+            "YP-GI1": "Samsung YP-GI1",
+            "YP-GS1": "Samsung YP-GS1",
+            "ZTE Skate": "ZTE Skate"
+          },
           "platforms": [
             "Android_2_3"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#EVO3D_X515m Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC X515m",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I8730 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I8730",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I9082L Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9082L",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I9192 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9192",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I9195* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9195",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I9205 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9205",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I9300* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9300",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-i9300 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9300",
-          "platforms": [
-            "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I9305* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9305",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I9500 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9500",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I9505G Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9505G",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4", "Android_5_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I9505X* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9505X",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I9505* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9505",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-N5100 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-N5100",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-N5110 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-N5110",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-N7105* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-N7105",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-N7108 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-N7108",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-N8020* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-N8020",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-P3100 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-P3100",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-P3110 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-P3110",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-P3113 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-P3113",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-P5100* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-P5100",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-P5110 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-P5110",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-P5113 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-P5113",
-          "platforms": [
-            "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-P5200 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-P5200",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-P5210* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-P5210",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-P7100 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-P7100",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-S7562 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-S7562",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-S7710 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-S7710",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC Desire X Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC T328E",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SGH-T989 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SGH-T989",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Cynus F4 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Mobistel MT-7521S",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC EVO 3D X515m Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC X515m",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Vodafone Smart 4G Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Vodafone Smart 4G",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC One Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC M7",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC One S* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC PJ401",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#One S* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC PJ401",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#pcdadr6350 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC ADR6350",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC One V* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC One V",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC One X Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC PJ83100",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#PJ83100* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC PJ83100",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#VS840 4G Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG VS840 4G",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC One X+ Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC PM63100",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC Sensation Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Z710",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC/EVO_3D* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC X515m",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC6435LVW Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC HTC6435LVW",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_Desire_C* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Desire C",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_Desire_X* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC T328E",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_One Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC M7",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_OneSV Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC One SV",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_OneXplus Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC PM63100",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC One SV* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC One SV",
-          "platforms": [
-            "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_One_S* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC PJ401",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_One_V* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC One V",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#DROID BIONIC 4G Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola XT875",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC?One_XL* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC One XL",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_One_X* Build/*)*applewebkit*(*khtml*like*gecko*)*Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC PJ83100",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_One_X* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC PJ83100",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC?One?mini* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC One Mini",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_One_M8* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC M8",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_One* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC M7",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_SensationXE_Beats Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Z710",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_SensationXL_Beats* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC X315e",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_Sensation_Z710e Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Z710e",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Sensation_Z710e Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Z710e",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HUAWEI G510-* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei G510",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HUAWEI U8950D Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei U8950D",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HUAWEI U9508 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei U9508",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HUAWEI Y300* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei Y300",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#IdeaTab A2107A-H Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo A2107A-H",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#IdeaTabA2109A Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo A2109A",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#IdeaTabS2110AF Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo S2110AF",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#IdeaTab S6000-H Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo S6000-H",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Lenovo S6000L-F Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo S6000L-F",
-          "platforms": [
-            "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#IdeaTab S6000-F Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo S6000-F",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#IdeaTab A3000-H Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo A3000-H",
-          "platforms": [
-            "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-E610* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG E610",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-E975* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG E975",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-F100L Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG F100L",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-LS860 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG LS860",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-P700* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG P700",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-P760* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG P760",
-          "platforms": [
-            "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-P880* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG P880",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-P895* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG P895",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LIFETAB_S9512 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Medion LifeTab S9512",
-          "platforms": [
-            "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LIFETAB_S9714 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Medion LifeTab S9714",
-          "platforms": [
-            "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LOOX Plus Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Odys Loox Plus",
-          "platforms": [
-            "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LT25i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Sony LT25i",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LT28h Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson LT28h",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LT30p Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Sony LT30p",
-          "platforms": [
-            "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A660 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo IdeaPad A660",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ME302C Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Asus ME302C",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ME371MG Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Asus ME371MG",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MEDION LIFE P4012 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Medion LifeTab P4012",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MediaPad 10 LINK Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei MediaPad 10",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MediaPad 7 Lite Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei MediaPad 7 Lite",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#N90FHDRK Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "YUANDAO N90FHDRK",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ODYS-NOON Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Odys Noon",
-          "platforms": [
-            "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#NOON Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Odys Noon",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Nexus 10 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung Nexus 10",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Nexus 7 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Asus Nexus 7",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4", "Android_5_0", "Android_5_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ODYS-Q Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Odys Q",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#PMP5080CPRO Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Prestigio PMP5080CPRO",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#PMP5580C Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Prestigio PMP5580C",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#S500 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Acer S500",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SCH-I200 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SCH-I200",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SCH-I605 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SCH-I605",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SGH-I777 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SGH-I777",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SGPT12 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Sony SGPT12",
-          "platforms": [
-            "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SGPT13 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Sony SGPT13",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SHW-M380W Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SHW-M380W",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SPH-D710 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SPH-D710",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SPH-D710BST Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SPH-D710BST",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyEricssonST21i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Sony ST21i",
-          "platforms": [
-            "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyST21i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Sony ST21i",
-          "platforms": [
-            "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ST21i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Sony ST21i",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyST21i2 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Sony ST21i2",
-          "platforms": [
-            "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyST21iv Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Sony ST21iv",
-          "platforms": [
-            "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ST23i Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Sony ST23i",
-          "platforms": [
-            "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SensationXE_Beats_Z715e Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Z715e",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SensationXL_Beats_X315e Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC X315e",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Slider SL101 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Asus SL101",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SmartTabII10 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo SmartTab II 10",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyC1505 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Sony C1505",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#C1505 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Sony C1505",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyST26i* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Sony ST26i",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ST26i* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Sony ST26i",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Sprint APX515CKT Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC X515",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#TouchPad Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HP Touchpad",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#cm_tenderloin Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HP Touchpad",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Transformer Prime TF201 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Asus TF201",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#U30GT 2 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Cube U30GT2",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#U30GT-H Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Cube U30GT",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#U8825* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei U8825",
-          "platforms": [
-            "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#U9200 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei U9200",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#UNO_X10 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Odys Uno X10",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#X10 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson X10",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#X10.Dual Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Pearl X10.Dual",
-          "platforms": [
-            "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#X10.Dual+ Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Pearl X10.Dual+",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#XELIO7PRO Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Odys Xelio 7 Pro",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#XENO10 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Odys Xeno 10",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#XT890 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola XT890",
-          "platforms": [
-            "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#XT907 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola XT907",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Xelio 10 Pro Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Odys Xelio 10 Pro",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Xelio 7 pro Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Odys Xelio 7 Pro",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ZP900 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "ZOPO ZP900",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ZP910 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "ZOPO ZP910",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#KFOT Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Amazon KFOT",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#TechniPad_10-3G Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "TechniSat TechniPad 10 3G",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Tablet-PC-4 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER# Safari*",
-          "device": "CatSound Tablet PC 4",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Tablet-PC-4.1-Mozilla/5.0 (#PLATFORM#ADM8000KP_A Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER# Safari*",
-          "device": "CatSound Tablet PC 4",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Tablet-PC-4.1-Mozilla/5.0 (#PLATFORM#ADM8000KP_B Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER# Safari*",
-          "device": "CatSound Tablet PC 4",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#C6503 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson C6503",
-          "platforms": [
-            "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-N8013 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-N8013",
-          "platforms": [
-            "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Galaxy Nexus Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung Galaxy Nexus",
-          "platforms": [
-            "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Nexus 4 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG Nexus 4",
-          "platforms": [
-            "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4", "Android_5_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SGH-T889 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SGH-T889",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SGP321 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Sony SGP321",
-          "platforms": [
-            "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ME173X Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Asus ME173X",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#A1-811 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Acer A1-811",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-S6312 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-S6312",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SCH-R720 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SCH-R720",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HUAWEI G700-U10 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei G700-U10",
-          "platforms": [
-            "Android_4_2"
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "ALCATEL_one_touch_990": "Alcatel OT-990",
+            "BASE Tab": "ZTE BASE Tab",
+            "Desire HD": "HTC Desire HD",
+            "E310": "Acer E310",
+            "GT-I5510": "Samsung GT-I5510",
+            "GT-S5570*": "Samsung GT-S5570",
+            "GT-S5570I": "Samsung GT-S5570I",
+            "GT-S5670": "Samsung GT-S5670",
+            "HTC Desire HD A9191": "HTC Desire HD A9191",
+            "HTC Vision": "HTC Vision",
+            "htc?Desire HD": "HTC Desire HD",
+            "HTC_DesireHD_A9191": "HTC Desire HD A9191",
+            "LG-E730*;": "LG E730",
+            "LG-P500*": "LG P500",
+            "LG-P720*": "LG P720",
+            "LG-P920*": "LG P920",
+            "MotoA953": "Motorola A953",
+            "ODYS Space": "Odys Space",
+            "ViewSonic-ViewPad7e": "ViewSonic ViewPad7e",
+            "XT320": "Motorola XT320"
+          },
+          "platforms": [
+            "Android_2_3", "Android_2_2"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Desire_A8181": "HTC Desire A8181",
+            "DROIDX": "Motorola DroidX",
+            "HTC Legend*": "HTC Legend",
+            "HTC Wildfire S*": "HTC Wildfire S A510",
+            "MB525": "Motorola MB525",
+            "MB632": "Motorola MB632",
+            "MB860": "Motorola MB860",
+            "MOT-XT615": "Motorola XT615",
+            "SonyEricssonX10i": "SonyEricsson X10i",
+            "SonyEricssonX10iv": "SonyEricsson X10iv",
+            "X10i": "SonyEricsson X10i",
+            "XT610": "Motorola XT610",
+            "XT615": "Motorola XT615"
+          },
+          "platforms": [
+            "Android_2_3", "Android_2_2", "Android_2_1"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Milestone": "Motorola Milestone"
+          },
+          "platforms": [
+            "Android_2_3", "Android_2_2", "Android_2_1", "Android_2_0"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "ALCATEL one touch 890D": "Alcatel OT-890D",
+            "E140": "Acer E140",
+            "DISCO10": "Flytouch DISCO10",
+            "GT-I9000T": "Samsung GT-I9000T",
+            "GT-I9010": "Samsung GT-I9010",
+            "GT-P1010": "Samsung GT-P1010",
+            "HTC_Desire": "HTC Desire",
+            "HTC_Gratia_A6380": "HTC A6380",
+            "imx51_bbg": "Cortex A8",
+            "Ideos": "Huawei U8150",
+            "LG-E720*;": "LG E720",
+            "LG-P350*": "LG P350",
+            "LG-P925*": "LG P925",
+            "Liquid Metal": "Acer Liquid Metal",
+            "MB612": "Motorola MB612",
+            "meizu_m9": "Meizu M9",
+            "MotoroiX": "Motorola MotoroiX",
+            "NBPC724": "Coby NBPC724",
+            "ODYS Xtreme": "Odys Xtreme",
+            "SMARTBOOK*": "Toshiba AC100",
+            "TOSHIBA_FOLIO_AND_A": "Toshiba Folio 100",
+            "ViewPad7": "ViewSonic ViewPad7",
+            "Vodafone 858": "Huawei Vodafone 858"
+          },
+          "platforms": [
+            "Android_2_2"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "A101IT": "Archos A101IT",
+            "BASE lutea": "ZTE Blade",
+            "Dell Streak": "Dell Streak",
+            "GT-I5500": "Samsung GT-I5500",
+            "GT-I5800": "Samsung GT-I5800",
+            "HTC Desire *": "HTC Desire",
+            "HTC Magic": "HTC Magic",
+            "HTC Wildfire*": "HTC Wildfire",
+            "HTC_Wildfire_A3333": "HTC Wildfire A3333",
+            "OP070": "Olivetti Olipad 70",
+            "p7901a": "Epad P7901A",
+            "SAMSUNG-SGH-I897*": "Samsung SGH-I897",
+            "U8180": "Huawei U8180",
+            "U8220": "Huawei U8220",
+            "U8500": "Huawei U8500",
+            "ZTE-BLADE": "ZTE Blade"
+          },
+          "platforms": [
+            "Android_2_2", "Android_2_1"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "1000ET": "Elonex eTouch",
+            "2808A+": "Apad MID Rockchip 2808A+ Tablet",
+            "A28": "Micromax A28",
+            "A43": "Archos A43",
+            "A6277": "HTC A6277",
+            "A70S": "Archos A70S",
+            "ADR6200": "HTC ADR6200",
+            "ADR6300": "HTC ADR6300",
+            "Ally": "LG VS740",
+            "DFP7002": "Tendak DFP7002",
+            "Droid": "Motorola Droid",
+            "E10i": "SonyEricsson E10i",
+            "Eris A50": "HTC Eris",
+            "Eris": "HTC Eris",
+            "Garmin-Asus A10": "Garmin-Asus A10",
+            "Garmin-Asus A50": "Garmin-Asus A50",
+            "GT-I5503": "Samsung GT-I5503",
+            "GT-I5700": "Samsung GT-I5700",
+            "GT-I5801": "Samsung GT-I5801",
+            "GT540": "LG GT540",
+            "HTC G1": "T-Mobile G1",
+            "HTC Hero*": "HTC Hero",
+            "HTC-A6366*": "HTC A6366",
+            "HTC_A3335*": "HTC A3335",
+            "HTC_Aria_A6380": "HTC Aria A6380",
+            "HTC_Desire-orange-LS": "HTC Desire",
+            "Ideos S7": "Huawei IDEOS S7",
+            "IS03": "KDDI IS03",
+            "liquid": "Acer Liquid",
+            "LogicPD Zoom2": "LogicPD Zoom2",
+            "LU2300": "LG LU2300",
+            "M82VG": "general Tablet",
+            "M860": "Huawei M860",
+            "MB508": "Motorola MB508",
+            "MID": "general Mobile Phone",
+            "Milestone XT720": "Motorola XT720",
+            "MotoMB511": "Motorola MB511",
+            "Orange San Francisco": "ZTE Orange",
+            "Orange_Boston": "ZTE Orange",
+            "PMP3074BRU": "Prestigio PMP3074BRU",
+            "POV Mobii 7": "Point of View Mobii 7",
+            "Pulse": "T-Mobile Pulse",
+            "RBM2": "Huawei U8230 RBM2",
+            "RBM3": "Huawei U8110 RBM3",
+            "Rooted Eris 2.1 v0.3": "HTC Eris",
+            "S7": "Huawei IDEOS S7",
+            "SGH-I896": "Samsung SGH-I896",
+            "San Francisco": "ZTE Orange",
+            "SCH-I500": "Samsung SCH-I500",
+            "SCH-R880": "Samsung SCH-R880",
+            "SGH-T959": "Samsung SGH-T959",
+            "SHW-M110S": "Samsung SHW-M110S",
+            "SmartQ V7": "SmartDevices SmartQ V7",
+            "SonyEricssonE10a": "SonyEricsson E10a",
+            "SonyEricssonE10iv": "SonyEricsson E10iv",
+            "SonyEricssonE15i": "SonyEricsson E15i",
+            "SonyEricssonE15iv": "SonyEricsson E15iv",
+            "SonyEricssonSO-01B": "SonyEricsson SO-01B",
+            "SonyEricssonU20i": "SonyEricsson U20i",
+            "SonyEricssonU20iv": "SonyEricsson U20iv",
+            "SPH-D700": "Samsung SPH-D700",
+            "SPH-M900": "Samsung SPH-M900",
+            "SPH-M910": "Samsung SPH-M910",
+            "Stream": "Acer Stream",
+            "T-Mobile_Espresso": "T-Mobile Espresso",
+            "T-Mobile_G2_Touch": "T-Mobile G2 Touch",
+            "U20i": "SonyEricsson U20i",
+            "U8100": "Huawei U8100",
+            "USCCADR6275US Carrier ID 45": "HTC A8181",
+            "Vodafone 845": "Vodafone 845",
+            "WX445": "Motorola WX445",
+            "XST2": "Debitel OneTab XST2",
+            "XT701": "Motorola XT701",
+            "ZiiO7": "Creative ZIIO7",
+            "ZTE-RACER": "ZTE Racer"
+          },
+          "platforms": [
+            "Android_2_1"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "A5000": "Sony A5000"
+          },
+          "platforms": [
+            "Android"
           ]
         },
         {
@@ -4279,80 +1351,255 @@
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#sprd-B51+* Android/* Release/* Browser/applewebkit* Build/*) applewebkit* (*khtml*like*gecko*)*Version/#MAJORVER#.#MINORVER#*Chrome*Safari*",
-          "device": "sprd B51+",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*)*applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Android for Telechips TCC890*": "Telechips TCC890"
+          },
           "platforms": [
-            "Android_2_3"
+            "Android_2_1"
           ]
         },
         {
-          "match": "MT6515M#PLATFORM# Release* Browser?applewebkit*",
-          "device": "United MT6515M",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "HTC Desire": "HTC Desire"
+          },
           "platforms": [
-            "Android_2_3"
+            "Android_2_3", "Android_2_2"
           ]
         },
         {
-          "match": "Lenovo-A288t#PLATFORM# Release* Browser?applewebkit*",
-          "device": "Lenovo A288t",
+          "match": "Mozilla/5.0 (Linux*; Android VillainROM*; #DEVICE# Build/ERE27) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "HTC Hero": "HTC Hero"
+          },
           "platforms": [
-            "Android_2_3"
+            "Android_1_0"
           ]
         },
         {
-          "match": "Lenovo-A820#PLATFORM# Release* Browser?applewebkit*",
-          "device": "Lenovo A820",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE#) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "TOSHIBA_AC_AND_AZ": "Toshiba Folio 100"
+          },
           "platforms": [
-            "Android_4_1"
+            "Android_2_2", "Android_2_1"
           ]
         },
         {
-          "match": "Lenovo-A850#PLATFORM# Release* Browser?applewebkit*",
-          "device": "Lenovo A850",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE#) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "TSB_CLOUD_COMPANION;FOLIO_AND_A": "Toshiba Folio 100"
+          },
+          "platforms": [
+            "Android_2_2"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM#XOOM 2 Build/*#DEVICE#) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "MZ616*": "Motorola MZ616"
+          },
+          "platforms": [
+            "Android_4_0",
+            "Android_3_2"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE#) applewebkit*(*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "TSB_CLOUD_COMPANION;TOSHIBA_AC_AND_AZ": "Toshiba Folio 100"
+          },
+          "platforms": [
+            "Android_2_2"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0(#PLATFORM##DEVICE# Build/*) applewebkit*(*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "ZTE Grand X2": "ZTE Grand X2"
+          },
           "platforms": [
             "Android_4_2"
           ]
         },
         {
-          "match": "Lenovo A789#PLATFORM# Release* Browser?applewebkit*",
-          "device": "Lenovo A789",
+          "match": "Mozilla/5.0(#PLATFORM#) applewebkit*(*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
           "platforms": [
-            "Android_4_0"
+            "Android_4_2",
+            "Android"
           ]
         },
         {
-          "match": "MALATA I50#PLATFORM# Release* Browser?applewebkit*",
-          "device": "Malata I50",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER# *",
+          "devices": {
+            "HTC Incredible S": "HTC S710E"
+          },
+          "platforms": [
+            "Android_4_0",
+            "Android_2_3", "Android_2_2"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "NGM Miracle": "NGM WeMove Miracle"
+          },
+          "platforms": [
+            "Android_4_0",
+            "Android_2_3", "Android_2_2"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (Linux*; Android RCMix_v2.2_WWE*; #DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "HTC_HERO": "HTC Hero"
+          },
+          "platforms": [
+            "Android_2_2"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (*#DEVICE##PLATFORM#)*applewebkit*(*khtml*like*gecko*)*Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "GT-I9100": "Samsung GT-I9100"
+          },
+          "platforms": [
+            "Android_B_2_3"
+          ]
+        },
+        {
+          "match": "*Mozilla/5.0 (*#DEVICE##PLATFORM#) applewebkit*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "GT-I9100": "Samsung GT-I9100"
+          },
+          "platforms": [
+            "Android_B_2_3"
+          ]
+        },
+        {
+          "match": "#DEVICE#-Mozilla/5.0 (#PLATFORM#EOS10 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Kinder-Tablet-1.0-Weltbild": "Weltbild Kinder-Tablet"
+          },
+          "platforms": [
+            "Android_4_2"
+          ]
+        },
+        {
+          "match": "Cakemix/* Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/?.0*Safari*",
+          "devices": {
+            "GT-N8000": "Samsung GT-N8000"
+          },
+          "platforms": [
+            "Android_4_1"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Mobile*",
+          "devices": {
+            "HTC_DesireS_S510e": "HTC S510e"
+          },
           "platforms": [
             "Android_2_3"
           ]
         },
         {
-          "match": "MALATA I50#PLATFORM# Release* Browser?applewebkit*",
-          "device": "Malata I50",
+          "match": "#DEVICE#?Mozilla/5.0(#PLATFORM#Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "HTC_DesireS_S510e": "HTC S510e"
+          },
           "platforms": [
             "Android_2_3"
           ]
         },
         {
-          "match": "OPPO_R813T#PLATFORM# Release* Browser?applewebkit*",
-          "device": "OPPO R813T",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*",
+          "devices": {
+            "Sony Tablet P": "Sony Tablet P"
+          },
+          "platforms": [
+            "Android_3_2"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*)",
+          "devices": {
+            "C6603": "Sony C6603"
+          },
           "platforms": [
             "Android_4_0"
           ]
         },
         {
-          "match": "Lenovo-A288t#PLATFORM# Release* Browser?applewebkit*Safari*",
-          "device": "Lenovo A288t",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER# Safari*",
+          "devices": {
+            "Tablet-PC-4": "CatSound Tablet PC 4"
+          },
+          "platforms": [
+            "Android_4_0"
+          ]
+        },
+        {
+          "match": "Tablet-PC-4.1-Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER# Safari*",
+          "devices": {
+            "ADM8000KP_A": "CatSound Tablet PC 4",
+            "ADM8000KP_B": "CatSound Tablet PC 4"
+          },
+          "platforms": [
+            "Android_4_1"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Android/* Release/* Browser/applewebkit* Build/*) applewebkit* (*khtml*like*gecko*)*Version/#MAJORVER#.#MINORVER#*Chrome*Safari*",
+          "devices": {
+            "sprd-B51+*": "sprd B51+"
+          },
           "platforms": [
             "Android_2_3"
           ]
         },
         {
-          "match": "ultrafone 303#PLATFORM# Release* Browser?applewebkit*",
-          "device": "ultrafone 303",
+          "match": "#DEVICE##PLATFORM# Release* Browser?applewebkit*",
+          "devices": {
+            "Lenovo-A850": "Lenovo A850",
+            "MT6572_TD/V1": "Cubot GT 95 3G"
+          },
+          "platforms": [
+            "Android_4_2"
+          ]
+        },
+        {
+          "match": "#DEVICE##PLATFORM# Release* Browser?applewebkit*",
+          "devices": {
+            "I9300": "Samsung GT-I9300",
+            "Lenovo-A820": "Lenovo A820"
+          },
+          "platforms": [
+            "Android_4_1"
+          ]
+        },
+        {
+          "match": "#DEVICE##PLATFORM# Release* Browser?applewebkit*",
+          "devices": {
+            "AT-AS40SE": "Wolgang AT-AS40SE",
+            "Lenovo A789": "Lenovo A789",
+            "OPPO_R813T": "OPPO R813T",
+            "ultrafone 303": "ultrafone 303"
+          },
           "platforms": [
             "Android_4_0"
+          ]
+        },
+        {
+          "match": "#DEVICE##PLATFORM# Release* Browser?applewebkit*",
+          "devices": {
+            "Lenovo-A288t": "Lenovo A288t",
+            "MALATA I50": "Malata I50",
+            "MT6515M": "United MT6515M"
+          },
+          "platforms": [
+            "Android_2_3"
           ]
         },
         {
@@ -4362,1750 +1609,220 @@
           ]
         },
         {
-          "match": "I9300#PLATFORM# Release* Browser?applewebkit*",
-          "device": "Samsung GT-I9300",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "AT-AS40SE#PLATFORM# Release* Browser?applewebkit*",
-          "device": "Wolgang AT-AS40SE",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "MT6572_TD/V1#PLATFORM# Release* Browser?applewebkit*",
-          "device": "Cubot GT 95 3G",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
           "match": "#PLATFORM# Release* Browser?applewebkit*",
           "platforms": [
-            "Android_2_2", "Android_2_3", "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4", "Android_5_0"
+            "Android_5_0",
+            "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
+            "Android_2_3", "Android_2_2"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#LIFETAB_E10312 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Medion LifeTab E10312",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LIFETAB_E10316 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Medion LifeTab E10316",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ST10216-1*Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "TrekStor ST10216",
-          "platforms": [
-            "Android_4_1", "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HUAWEI P6-U06 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei P6-U06",
-          "platforms": [
-            "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SM-T210 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SM-T210",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SM-T310 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SM-T310",
-          "platforms": [
-            "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#BN NookHD+ Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Barnes & Noble Nook HD+",
-          "platforms": [
-            "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#NookColor*)*applewebkit*(*khtml*like*gecko*)*Version/4.*Safari/*",
-          "device": "Barnes & Noble Nook Color",
-          "platforms": [
-            "Android_2_2", "Android_2_3", "Android"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#NOOK BNRV200*)*Apple*WebKit/*(*khtml*like*gecko*)*Version/4.*Safari/*",
-          "device": "Barnes & Noble BNRV200",
-          "platforms": [
-            "Android_2_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#NOOK*)*applewebkit*(*khtml*like*gecko*)*Version/4.*Safari/*",
-          "device": "Barnes & Noble Nook",
-          "platforms": [
-            "Android_2_2", "Android_2_3", "Android"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ME301T Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Asus ME301T",
-          "platforms": [
-            "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ME172V Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Asus ME172V",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#PadFone 2 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Asus A68",
-          "platforms": [
-            "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#PadFone Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Asus PadFone",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SurfTab_7.0 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "TrekStor ST701041",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-D802* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG D802",
-          "platforms": [
-            "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-L160L Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG L160L",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Cynus T2 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Mobistel Cynus T2",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SM-T110 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SM-T110",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LIFETAB_E7312 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Medion LifeTab E7312",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SCH-I535* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SCH-I535",
-          "platforms": [
-            "Android_2_2", "Android_2_3", "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#TP10.1-1500DC-metal Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "I-ONIK TP10",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SM-T211 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SM-T211",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LIFETAB_E7316 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Medion LifeTab E7316",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SM-T315* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SM-T315",
-          "platforms": [
-            "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SM-T311 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SM-T311",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#AT300SE Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Toshiba AT300SE",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-S6310N Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-S6310N",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-S6310 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-S6310",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Cynus F3 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Mobistel Cynus F3",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Cynus T5 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Mobistel Cynus T5",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-S5301 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-S5301",
-          "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-N8010 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-N8010",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Redmi Note 3 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Xiaomi Redmi Note 3",
-          "platforms": [
-            "Android_5_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#VT10416-1 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "TrekStor VT10416-1",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#VT10416-2 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "TrekStor VT10416-2",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#NEXT Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Nextbook Next",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LIFETAB_E10320 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Medion E10320",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LIFETAB_E10310 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Medion E10310",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#PMP7100D3G Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Prestigio PMP7100D3G",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Sprint APA9292KT Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC 9292",
+          "match": "#DEVICE##PLATFORM# Release* Browser?applewebkit*Safari*",
+          "devices": {
+            "Lenovo-A288t": "Lenovo A288t"
+          },
           "platforms": [
             "Android_2_3"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#A3-A10 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Acer A3-A10",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE#*Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "ST10216-1": "TrekStor ST10216"
+          },
           "platforms": [
-            "Android_4_2"
+            "Android_4_2", "Android_4_1"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#Lenovo B8000-F/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo B8000-F",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-P5220* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-P5220",
-          "platforms": [
-            "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ST10216-2 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "TrekStor ST10216-2",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE#*Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "TAB10-400": "Yarvik TAB10-400"
+          },
           "platforms": [
             "Android_4_1"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#HUAWEI G525-U00 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei G525-U00",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE#*)*applewebkit*(*khtml*like*gecko*)*Version/4.*Safari/*",
+          "devices": {
+            "NOOK": "Barnes & Noble Nook",
+            "NookColor": "Barnes & Noble Nook Color"
+          },
           "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HUAWEI Y530-U00 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei Y530-U00",
-          "platforms": [
-            "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_Desire_500 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Desire 500",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#AN9G2I Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Arnova 9G2",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ARNOVA 101 G4 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Arnova 101G4",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-S6810P Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-S6810P",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#AX540 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Bmobile AX540",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#TAB10-400*Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Yarvik TAB10-400",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A328 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo A328",
-          "platforms": [
-            "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SM-G900F* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SM-G900F",
-          "platforms": [
-            "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I8200N Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I8200N",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#PMP7280C3G Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Prestigio PMP7280C3G",
-          "platforms": [
-            "Android_4_1", "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ADM816KC Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Odys ADM816KC",
-          "platforms": [
-            "Android_4_1", "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ADM816HC Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Odys ADM816HC",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#tolino tab 8.9 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Tolino Tab 8.9",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-E440 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG E440",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SM-G350 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SM-G350",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Archos 101 Neon Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Archos 101 Neon",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Archos 50 Platinum Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Archos 50 Platinum",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#RAINBOW Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Wiko Rainbow",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HUAWEI Y330-U01 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei Y330-U01",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ME302KL Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Asus ME302KL",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-E430 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG E430",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ODYS-EVO Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Odys Evo",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#tolino tab 7 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Tolino Tab 7",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#M532 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Fujitsu M532",
-          "platforms": [
-            "Android_4_0", "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#blaze Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SGH-T769",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-S5280 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-S5280",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-S7580 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-S7580",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ZTE Skate Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "ZTE Skate",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HUAWEI MT1-U06 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei MT1-U06",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HUAWEI-U8850 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei U8850",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-P7320* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-P7320",
-          "platforms": [
-            "Android_3_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-S5310 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-S5310",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-S7560 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-S7560",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Cynus F5 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Mobistel Cynus F5",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Endeavour 1010 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Blaupunkt Endeavour 1010",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SM-T111 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SM-T111",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MEDION X4701 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Medion X4701",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Cynus E1 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Mobistel Cynus E1",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SPH-L710 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SPH-L710",
-          "platforms": [
-            "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#KIS PLUS Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "ZTE V788D",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#AN10BG3 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Arnova AN10BG3",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Archos 50 Titanium Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Archos 50 Titanium",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#KFSOWI Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Amazon KFSOWI",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#PMP5770D Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Prestigio PMP5770D",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MediaPad M1 8.0 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei MediaPad M1 8.0",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SM-G800F* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SM-G800F",
-          "platforms": [
-            "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#FWS610_EU Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Phicomm FWS610",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#DROID RAZR Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola Razr",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#A5000 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Sony A5000",
-          "platforms": [
+            "Android_2_3", "Android_2_2",
             "Android"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#Lenovo S920_ROW Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo S920_ROW",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#IQ4404 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Fly IQ4404",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#PMP3074BRU Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Prestigio PMP3074BRU",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Magic W700 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Magic W700",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SXZ-PDX0-01 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SXZ PDX0-01",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#iDxD7_3G Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Digma iDxD7 3G",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#POV_TAB-PI1045 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Point of View PI1045",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#CINK PEAX 2 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Wiko Cink Peax 2",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I8262 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I8262",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#B15 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Caterpillar Cat B15",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#PMSmart450 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "PMEDIA PMSmart450",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Micromax A120 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Micromax A120",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ImPAD 9708 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Impression ImPAD 9708",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ImPAD 0413 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Impression ImPAD 0413",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#AC0732C Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "3Q AC0732C",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#IRULU U1 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "iRulu U1",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#NX501 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "ZTE NX501",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#PMP5785C3G_QUAD Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Prestigio PMP5785C3G_QUAD",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Symphony W82 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Symphony W82",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#TAD-70112 PO8292 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Denver TAD-70112",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ZTE V808 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "ZTE V808",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#K1 turbo Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Kingzone KZ-168",
-          "platforms": [
-            "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#XT926 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola XT926",
-          "platforms": [
-            "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#TAB917QC-8GB Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Sunstech TAB917QC 8GB",
-          "platforms": [
-            "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#NEO_QUAD10 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Odys Neo Quad 10",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#CUBOT P9 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Cubot U30GT",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#PMP5297C_QUAD Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Prestigio PMP5297C_QUAD",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#AFTB Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Amazon AFTB",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Rooted Eris 2.1 v0.3 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Eris",
-          "platforms": [
-            "Android_2_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#CAL21 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "GzOne CAL21",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LT26w Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Sony LT26w",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#E-TAB IVORY Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lava E-Tab IVORY",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GOCLEVER TAB A93.2 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "GOCLEVER A93.2",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#6036Y Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Alcatel OT-6036Y",
-          "platforms": [
-            "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SO-03C Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Sony SO-03C",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SGH-T999 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SGH-T999",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SGH-T999 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SGH-T999",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#NokiaX2DS Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Nokia X2DS",
-          "platforms": [
-            "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Prime S Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Highscreen Omega Prime S",
-          "platforms": [
-            "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Plane 10.3 3G PS1043MG Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Digma PS1043MG",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-E612 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG E612",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#TOUAREG8_3G Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Accent Touareg8 3G",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC_Amaze Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Amaze 4G",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Spice Mi-424 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Spice Mi-424",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#PAP7600DUO Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Prestigio PAP7600DUO",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-D325 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG D325",
-          "platforms": [
-            "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A5500-H Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo A5500-H",
-          "platforms": [
-            "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MB612 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Motorola MB612",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE#*)*Apple*WebKit/*(*khtml*like*gecko*)*Version/4.*Safari/*",
+          "devices": {
+            "NOOK BNRV200": "Barnes & Noble BNRV200"
+          },
           "platforms": [
             "Android_2_2"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#Xperia S Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Sony Xperia S",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE#/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Lenovo B8000-F": "Lenovo B8000-F"
+          },
           "platforms": [
             "Android_4_2"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#ANKA-SX5 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Anka SX5",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-D605 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG D605",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LenovoA3300-GV Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo A3300-GV",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SH-01F Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Sharp SH-01F",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-D856 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG D856",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "LG-V700": "LG V700"
+          },
           "platforms": [
             "Android_5_0"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#T9666-1 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Telsda T9666-1",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#N-06E Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "NEC N-06E",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SM-G355H Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SM-G355H",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "D6603": "Sony D6603",
+            "Lenovo A536": "Lenovo A536",
+            "Lenovo A6000": "Lenovo A6000",
+            "N909": "ZTE N909",
+            "P7-L10": "Huawei P7-L10"
+          },
           "platforms": [
             "Android_4_4"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#Lenovo B6000-H Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo B6000-H",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Lenovo A3500-FL": "Lenovo A3500-FL",
+            "Lenovo A3500-H": "Lenovo A3500-H",
+            "Lenovo A5500-H": "Lenovo A5500-H",
+            "Lenovo A7600-H": "Lenovo A7600-H"
+          },
           "platforms": [
-            "Android_4_4"
+            "Android_4_4", "Android_4_3", "Android_4_2"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#TAB785DUAL Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Sunstech TAB785DUAL",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#AT1010-T Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo AT1010-T",
-          "platforms": [
-            "Android_4_5"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#DNS S5701 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "DNS S5701",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SCH-I815 4G Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SCH-I815",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SHV-E160S Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SHV-E160S",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SO-01E Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson SO-01E",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ThL W7 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "ThL W7",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SCH-I510 4G Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SCH-I510",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#DM015K Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Kyocera DM015K",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I9060 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9060",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#M83g Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "PiPO M8 3G",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Oysters Pacific 800 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Oysters Pacific 800",
-          "platforms": [
-            "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#A66A Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Evercoss A66A",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#PAP3350DUO Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Prestigio PAP3350DUO",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-E615 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG E615",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ME-701 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Marshal ME-701",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MEDIA PAD Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei Media Pad",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#GT-I9082 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9082",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HTC Desire 400 dual sim Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC Desire 400",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#PATG7506HD Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Perfeo PATG7506HD",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MODECOM FreeTAB 8001 IPS X23G Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "MODECOM FreeTAB 8001 IPS X2 3G",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MID7016 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Coby MID7016",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#OYSTERS T80 3G Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Oysters T80 3G",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#RC9724C Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "3Q RC9724C",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ONDA MID Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "ONDA MID",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Alcor Zest Q813IS Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Alcor Q813IS",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#S20 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Karbonn S20",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Surfer 8.31 3G Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Explay Surfer 8.31 3G",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#bq Edison Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "BQ Edison",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SGH-I317 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SGH-I317",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#P200S Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "JXD P200S",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#FUNC TITAN-01A Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "DFunc Func Titan-01A",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Lenovo Pad A4 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo Pad A4",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#CAPTIVA PAD 10.1 Quad FHD Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Captiva PAD 10.1 Quad FHD 3G",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#IM-A850K* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Pantech IM-A850K",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#TX97 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Irbis TX97",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#PolyPad 1010IPS Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "PolyPad 1010IPS",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#PMP7079D3G_QUAD Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Prestigio PMP7079D3G_QUAD",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SGH-I467 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung SGH-I467",
-          "platforms": [
-            "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-D405 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG D405",
-          "platforms": [
-            "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#ZP980 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "ZOPO ZP980",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SH-10D Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Sharp SH-10D",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#HP 8 Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HP 8",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#2013022 Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Xiaomi 2013022",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MID-721 Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Mystery MID-721",
-          "platforms": [
-            "Android_4_1"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-V700 Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG V700",
-          "platforms": [
-            "Android_5_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Utok 350D Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Utok 350D",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#9200N Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SPCinternet 9200N",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#X9007 Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "OPPO X9007",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Orange Gova": "Orange Gova",
+            "SonyL36h": "Sony L36h",
+            "X9007": "OPPO X9007"
+          },
           "platforms": [
             "Android_4_3"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#N909 Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "ZTE N909",
-          "platforms": [
-            "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#P7-L10 Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei P7-L10",
-          "platforms": [
-            "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#9103W Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Perfeo 9103W",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#D6603 Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Sony D6603",
-          "platforms": [
-            "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#BLU STUDIO 5.0 II Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "BLU STUDIO 5.0 II",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "2013022": "Xiaomi 2013022",
+            "BLU STUDIO 5.0 II": "BLU STUDIO 5.0 II",
+            "HP 8": "HP 8",
+            "Lenovo A3000-H": "Lenovo A3000-H",
+            "Lenovo A3500-F": "Lenovo A3500-F",
+            "Lenovo A3500-HV": "Lenovo A3500-HV",
+            "Lenovo A369i": "Lenovo A369i",
+            "Lenovo A516": "Lenovo A516",
+            "Lenovo A526": "Lenovo A526",
+            "Lenovo A5500-F": "Lenovo A5500-F",
+            "Lenovo A678t": "Lenovo A678t",
+            "Lenovo A680_ROW": "Lenovo A680",
+            "Lenovo A7600-F": "Lenovo A7600-F",
+            "MOMO20S": "Ployer Momo20s",
+            "NEO-X5-116A": "Minix NEO X5",
+            "PMP5101C3G_QUAD": "Prestigio PMP5101C3G_QUAD",
+            "SO-02E": "Sony SO-02E",
+            "Starpad": "Cambridge Sciences StarPAD",
+            "teXet_X-medium_plus": "TeXet TM-4872",
+            "UN020": "Bephone UN020",
+            "Utok 350D": "Utok 350D",
+            "Vodafone 785": "Vodafone 785"
+          },
           "platforms": [
             "Android_4_2"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#Novo10 Hero Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Ainol Novo 10 Hero",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "MID-721": "Mystery MID-721",
+            "Novo10 Hero": "Ainol Novo 10 Hero",
+            "PER5274B": "Prestigio PER5274B"
+          },
           "platforms": [
             "Android_4_1"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#PER5274B Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Prestigio PER5274B",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "9103W": "Perfeo 9103W",
+            "9200N": "SPCinternet 9200N",
+            "Aurora-II": "Ainol Aurora-II",
+            "SH-10D": "Sharp SH-10D"
+          },
           "platforms": [
-            "Android_4_1"
+            "Android_4_0"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#X8 Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "SonyEricsson E15i",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "U8160": "Huawei Vodafone 858",
+            "X8": "SonyEricsson E15i"
+          },
           "platforms": [
             "Android_2_3"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#Aurora-II Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Ainol Aurora-II",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE#*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Lenovo A316i": "Lenovo A316i",
+            "Lenovo A859": "Lenovo A859"
+          },
+          "platforms": [
+            "Android_4_2"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE#*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Lenovo A390_ROW": "Lenovo A390",
+            "Lenovo A800": "Lenovo A800"
+          },
           "platforms": [
             "Android_4_0"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#teXet_X-medium_plus Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "TeXet TM-4872",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#MOMO20S Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Ployer Momo20s",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#U8160 Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Huawei Vodafone 858",
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SO-02E Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Sony SO-02E",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#PMP5101C3G_QUAD Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Prestigio PMP5101C3G_QUAD",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Starpad Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Cambridge Sciences StarPAD",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#UN020 Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Bephone UN020",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Orange Gova Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Orange Gova",
-          "platforms": [
-            "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#SonyL36h Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Sony L36h",
-          "platforms": [
-            "Android_4_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Vodafone 785 Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Vodafone 785",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A316i*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo A316i",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A516 Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo A516",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Lenovo A390*Mozilla/5.0 (#PLATFORM#Lenovo A390*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo A390",
+          "match": "#DEVICE#*Mozilla/5.0 (#PLATFORM##DEVICE#*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Lenovo A390": "Lenovo A390"
+          },
           "platforms": [
             "Android_4_0"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A7600-H Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo A7600-H",
-          "platforms": [
-            "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A369i Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo A369i",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A536 Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo A536",
-          "platforms": [
-            "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A6000 Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo A6000",
-          "platforms": [
-            "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A859*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo A859",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A3500-HV Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo A3500-HV",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A7600-F Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo A7600-F",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A526 Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo A526",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A3500-FL Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo A3500-FL",
-          "platforms": [
-            "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A3500-H Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo A3500-H",
-          "platforms": [
-            "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A680_ROW Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo A680",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A3500-F Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo A3500-F",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A800*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo A800",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A5500-F Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo A5500-F",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A3000-H Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo A3000-H",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A390_ROW*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo A390",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A5500-H Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo A5500-H",
-          "platforms": [
-            "Android_4_2", "Android_4_3", "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Lenovo A678t Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo A678t",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#NEO-X5-116A Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Minix NEO X5",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.? (#PLATFORM#Bmobile_AX810 Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Bmobile AX810",
+          "match": "Mozilla/5.? (#PLATFORM##DEVICE# Build/*) *applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Bmobile_AX810": "Bmobile AX810"
+          },
           "platforms": [
             "Android_5_1"
           ]
         },
         {
-          "match": "HTC_ChaCha_A810e/Mozilla/5.0(#PLATFORM#Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "HTC A810e",
+          "match": "#DEVICE#/Mozilla/5.0(#PLATFORM#Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "HTC_ChaCha_A810e": "HTC A810e"
+          },
           "platforms": [
             "Android_2_3"
           ]
@@ -6143,15 +1860,11 @@
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#Nuqleo; Zaffire 785*) applewebkit*(*kthml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Nuqleo Zaffire 785",
-          "platforms": [
-            "Android_4_2"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#Nuqleo; Zaffire 1010*) applewebkit*(*kthml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Nuqleo Zaffire 1010",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE#*) applewebkit*(*kthml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Nuqleo; Zaffire 1010": "Nuqleo Zaffire 1010",
+            "Nuqleo; Zaffire 785": "Nuqleo Zaffire 785"
+          },
           "platforms": [
             "Android_4_2"
           ]
@@ -6160,12 +1873,15 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit*(*kthml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
           "device": "general Tablet",
           "platforms": [
-            "Android_4_2", "Android"
+            "Android_4_2",
+            "Android"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#AX540 Build/*) applewebkit* (*khmtl*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Bmobile AX540",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khmtl*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "AX540": "Bmobile AX540"
+          },
           "platforms": [
             "Android_4_0"
           ]
@@ -6173,27 +1889,33 @@
         {
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khmtl*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
           "platforms": [
-            "Android_4_0", "Android"
+            "Android_4_0",
+            "Android"
           ]
         },
         {
-          "match": "Mozilla/5.0(#PLATFORM#NEC-0912 Build/*)applewebkit*(*khtml*like*gecko*)Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "NEC 0912",
-          "platforms": [
-            "Android_4_0"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0(#PLATFORM#BLU Studio 5.0 S II Build/*)applewebkit*(*khtml*like*gecko*)Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "BLU Studio 5.0 S II",
+          "match": "Mozilla/5.0(#PLATFORM##DEVICE# Build/*)applewebkit*(*khtml*like*gecko*)Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "BLU Studio 5.0 S II": "BLU Studio 5.0 S II"
+          },
           "platforms": [
             "Android_4_2"
           ]
         },
         {
+          "match": "Mozilla/5.0(#PLATFORM##DEVICE# Build/*)applewebkit*(*khtml*like*gecko*)Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "NEC-0912": "NEC 0912"
+          },
+          "platforms": [
+            "Android_4_0"
+          ]
+        },
+        {
           "match": "Mozilla/5.0(#PLATFORM#)applewebkit*(*khtml*like*gecko*)Version/#MAJORVER#.#MINORVER#*Safari*",
           "platforms": [
-            "Android_4_0", "Android_4_2", "Android"
+            "Android_4_2", "Android_4_0",
+            "Android"
           ]
         },
         {

--- a/resources/user-agents/browsers/android-browser/android-browser-4-1.json
+++ b/resources/user-agents/browsers/android-browser/android-browser-4-1.json
@@ -32,15 +32,9 @@
           "devices": {
             "Micromax A27": "Micromax A27",
             "Micromax A35": "Micromax A35",
-            "Micromax A40": "Micromax A40"
+            "Micromax A40": "Micromax A40",
+            "sprd-B51+*": "sprd B51+"
           },
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#sprd-B51+* Build/*)*applewebkit*(*khtml*like*gecko*)*Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "sprd B51+",
           "platforms": [
             "Android_2_3"
           ]
@@ -66,8 +60,10 @@
           ]
         },
         {
-          "match": "*Mozilla/5.0 (#PLATFORM#INM8002KP Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Intenso INM8002KP",
+          "match": "*Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "INM8002KP": "Intenso INM8002KP"
+          },
           "platforms": [
             "Android_1_0", "Android_1_1", "Android_1_5", "Android_1_6",
             "Android_2_0", "Android_2_1", "Android_2_2", "Android_2_3",
@@ -76,29 +72,37 @@
           ]
         },
         {
-          "match": "*Mozilla/5.0 (*GT-I9100#PLATFORM#) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9100",
+          "match": "*Mozilla/5.0 (*#DEVICE##PLATFORM#) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "GT-I9100": "Samsung GT-I9100"
+          },
           "platforms": [
             "Android_B_2_3"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-D802* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG D802",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "LG-D802*": "LG D802"
+          },
           "platforms": [
             "Android_4_2", "Android_4_3", "Android_4_4"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#Lenovo B8000-F/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo B8000-F",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE#/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Lenovo B8000-F": "Lenovo B8000-F"
+          },
           "platforms": [
             "Android_4_2"
           ]
         },
         {
-          "match": "Lenovo-A388t#PLATFORM# Release* Browser/applewebkit* Mobile Safari*",
-          "device": "Lenovo A388T",
+          "match": "#DEVICE##PLATFORM# Release* Browser/applewebkit* Mobile Safari*",
+          "devices": {
+            "Lenovo-A388t": "Lenovo A388T"
+          },
           "platforms": [
             "Android_4_1"
           ]
@@ -113,29 +117,37 @@
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#sprd-B51+* Android/* Release/* Browser/applewebkit* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "sprd B51+",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Android/* Release/* Browser/applewebkit* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "sprd-B51+*": "sprd B51+"
+          },
           "platforms": [
             "Android_2_3"
           ]
         },
         {
-          "match": "Mastone_G9_TD/* Release/* Mozilla/5.0 (#PLATFORM#)*applewebkit*(*khtml*like*gecko*)*Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Mastone G9",
+          "match": "#DEVICE#/* Release/* Mozilla/5.0 (#PLATFORM#)*applewebkit*(*khtml*like*gecko*)*Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Mastone_G9_TD": "Mastone G9"
+          },
           "platforms": [
             "Android_2_3"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#B1-A71 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Acer B1-A71",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "B1-A71": "Acer B1-A71"
+          },
           "platforms": [
             "Android_4_0", "Android_4_1"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#B1-710 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Acer B1-710",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "B1-710": "Acer B1-710"
+          },
           "platforms": [
             "Android_4_0", "Android_4_1", "Android_4_2"
           ]
@@ -154,15 +166,19 @@
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#B1-711 Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Acer B1-711",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "B1-711": "Acer B1-711"
+          },
           "platforms": [
             "Android_4_1", "Android_4_2"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#C6603 Build/*) applewebkit* (*khtml*like*gecko*)",
-          "device": "Sony C6603",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*)",
+          "devices": {
+            "C6603": "Sony C6603"
+          },
           "platforms": [
             "Android_4_1"
           ]

--- a/resources/user-agents/browsers/android-browser/android-browser-4-2.json
+++ b/resources/user-agents/browsers/android-browser/android-browser-4-2.json
@@ -32,15 +32,9 @@
           "devices": {
             "Micromax A27": "Micromax A27",
             "Micromax A35": "Micromax A35",
-            "Micromax A40": "Micromax A40"
+            "Micromax A40": "Micromax A40",
+            "sprd-B51+*": "sprd B51+"
           },
-          "platforms": [
-            "Android_2_3"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#sprd-B51+* Build/*)*applewebkit*(*khtml*like*gecko*)*Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "sprd B51+",
           "platforms": [
             "Android_2_3"
           ]
@@ -66,8 +60,10 @@
           ]
         },
         {
-          "match": "*Mozilla/5.0 (#PLATFORM#INM8002KP Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Intenso INM8002KP",
+          "match": "*Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "INM8002KP": "Intenso INM8002KP"
+          },
           "platforms": [
             "Android_1_0", "Android_1_1", "Android_1_5", "Android_1_6",
             "Android_2_0", "Android_2_1", "Android_2_2", "Android_2_3",
@@ -76,15 +72,19 @@
           ]
         },
         {
-          "match": "*Mozilla/5.0 (*GT-I9100#PLATFORM#) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Samsung GT-I9100",
+          "match": "*Mozilla/5.0 (*#DEVICE##PLATFORM#) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "GT-I9100": "Samsung GT-I9100"
+          },
           "platforms": [
             "Android_B_2_3"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#LG-D802* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "LG D802",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "LG-D802*": "LG D802"
+          },
           "platforms": [
             "Android_4_2", "Android_4_3", "Android_4_4"
           ]
@@ -128,8 +128,10 @@
           ]
         },
         {
-          "match": "Mozilla/5.0(#PLATFORM#MTC 982 Build/*) applewebkit*(*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "MTC 982",
+          "match": "Mozilla/5.0(#PLATFORM##DEVICE# Build/*) applewebkit*(*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "MTC 982": "MTC 982"
+          },
           "platforms": [
             "Android_4_2"
           ]
@@ -150,22 +152,28 @@
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#sprd-B51+* Android/* Release/* Browser/applewebkit* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "sprd B51+",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Android/* Release/* Browser/applewebkit* Build/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "sprd-B51+*": "sprd B51+"
+          },
           "platforms": [
             "Android_2_3"
           ]
         },
         {
-          "match": "Mastone_G9_TD/* Release/* Mozilla/5.0 (#PLATFORM#)*applewebkit*(*khtml*like*gecko*)*Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Mastone G9",
+          "match": "#DEVICE#/* Release/* Mozilla/5.0 (#PLATFORM#)*applewebkit*(*khtml*like*gecko*)*Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Mastone_G9_TD": "Mastone G9"
+          },
           "platforms": [
             "Android_2_3"
           ]
         },
         {
-          "match": "HUAWEI_G610-T00_TD/* Android/#MAJORVER#.#MINORVER#* (#PLATFORM#)*Release/*applewebkit*Safari*",
-          "device": "Huawei G610-T00",
+          "match": "#DEVICE#/* Android/#MAJORVER#.#MINORVER#* (#PLATFORM#)*Release/*applewebkit*Safari*",
+          "devices": {
+            "HUAWEI_G610-T00_TD": "Huawei G610-T00"
+          },
           "platforms": [
             "Android_4_2"
           ]
@@ -181,8 +189,10 @@
           ]
         },
         {
-          "match": "NGM Dynamic Racing 2/*Linux/* Android/4.2* Release/* Browser/applewebkit* Mobile Safari*",
-          "device": "NGM Dynamic Racing GP",
+          "match": "#DEVICE#/*Linux/* Android/4.2* Release/* Browser/applewebkit* Mobile Safari*",
+          "devices": {
+            "NGM Dynamic Racing 2": "NGM Dynamic Racing GP"
+          },
           "platforms": [
             "Android_4_2"
           ]
@@ -206,8 +216,10 @@
           ]
         },
         {
-          "match": "Mozilla/5.0(#PLATFORM#CCE SK352)/applewebkit* Mobile Safari*",
-          "device": "CCE SK352",
+          "match": "Mozilla/5.0(#PLATFORM##DEVICE#)/applewebkit* Mobile Safari*",
+          "devices": {
+            "CCE SK352": "CCE SK352"
+          },
           "platforms": [
             "Android_4_2"
           ]

--- a/resources/user-agents/browsers/android-browser/android-browser-4-3.json
+++ b/resources/user-agents/browsers/android-browser/android-browser-4-3.json
@@ -28,8 +28,10 @@
       },
       "children": [
         {
-          "match": "Mozilla/5.0 (#PLATFORM#Lenovo B8080-H/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo B8080-H",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE#/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Lenovo B8080-H": "Lenovo B8080-H"
+          },
           "platforms": [
             "Android_4_3"
           ]

--- a/resources/user-agents/browsers/android-browser/android-browser-4-4.json
+++ b/resources/user-agents/browsers/android-browser/android-browser-4-4.json
@@ -51,8 +51,10 @@
           ]
         },
         {
-          "match": "Mozilla/5.0(#PLATFORM#Lenovo A536 Build/*)applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
-          "device": "Lenovo A536",
+          "match": "Mozilla/5.0(#PLATFORM##DEVICE# Build/*)applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "devices": {
+            "Lenovo A536": "Lenovo A536"
+          },
           "platforms": [
             "Android_4_4"
           ]
@@ -66,21 +68,21 @@
         {
           "match": "Mozilla/5.0 (#PLATFORM##DEVICE#;*Release/*) *applewebkit* (*khtml*like*gecko*) Mobile Safari*",
           "devices": {
+            "8_96_Android": "O+ 8.96 Android",
+            "Andi 4F ARC3": "iBall Andi 4F ARC3",
+            "Aqua Q3": "Intex Aqua Q3",
+            "Aqua Star II HD": "Intex Aqua Star 2 HD",
+            "Aqua Star II": "Intex Aqua Star 2",
+            "Aqua_Life V": "Intex Aqua_Life V",
+            "AquaSense5.0": "Intex Aqua Sense 5.0",
+            "Atom 2": "Lava Iris Atom 2",
+            "era": "XOLO era",
             "itel it1701": "itel it1701",
             "itel_it1502": "itel it1502",
-            "AquaSense5.0": "Intex Aqua Sense 5.0",
-            "X1 Beats": "Lava Iris X1 Beats",
-            "X1 atom": "Lava Iris X1 Atom S",
-            "Andi 4F ARC3": "iBall Andi 4F ARC3",
-            "Aqua_Life V": "Intex Aqua_Life V",
-            "Aqua Q3": "Intex Aqua Q3",
-            "WOW": "Intex WOW",
             "PLAY Style": "Star PLAY Style",
-            "era": "XOLO era",
-            "Aqua Star II": "Intex Aqua Star 2",
-            "Atom 2": "Lava Iris Atom 2",
-            "8_96_Android": "O+ 8.96 Android",
-            "Aqua Star II HD": "Intex Aqua Star 2 HD"
+            "WOW": "Intex WOW",
+            "X1 atom": "Lava Iris X1 Atom S",
+            "X1 Beats": "Lava Iris X1 Beats"
           },
           "platforms": [
             "Android_4_4"

--- a/resources/user-agents/browsers/android-browser/android-browser-5-0.json
+++ b/resources/user-agents/browsers/android-browser/android-browser-5-0.json
@@ -32,6 +32,38 @@
           "platforms": [
             "Android_5_0", "Android"
           ]
+        },
+        {
+          "match": "Mozilla/5.0 (Macintosh; *Mac OS X*; #DEVICE#/*) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "properties": {
+            "Browser_Modus": "Desktop Mode"
+          },
+          "devices": {
+            "HTC/Sensation": "HTC Z710"
+          },
+          "platforms": [
+            "Android"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (Macintosh; *Mac OS X*; #DEVICE#; *) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "properties": {
+            "Browser_Modus": "Desktop Mode"
+          },
+          "devices": {
+            "HTC_DesireHD_A9191": "HTC Desire HD A9191",
+            "HTC_EVO3D_X515m": "HTC X515m",
+            "HTC_Flyer_P510e": "HTC P510e",
+            "HTC_Flyer_P512": "HTC P512",
+            "HTC_IncredibleS_S710e": "HTC S710E",
+            "HTC_Runnymede": "HTC Runnymede",
+            "HTC_Sensation": "HTC Z710",
+            "HTC_Sensation_Z710e": "HTC Z710e",
+            "HTC_SensationXL_Beats_X315e": "HTC X315e"
+          },
+          "platforms": [
+            "Android"
+          ]
         }
       ]
     }

--- a/resources/user-agents/browsers/android-browser/android-browser-5-1.json
+++ b/resources/user-agents/browsers/android-browser/android-browser-5-1.json
@@ -28,8 +28,10 @@
       },
       "children": [
         {
-          "match": "Mozilla/5.0 (#PLATFORM#Infinix X510 Build/* applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#* Mobile Safari*",
-          "device": "Infinix X510",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/* applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#* Mobile Safari*",
+          "devices": {
+            "Infinix X510": "Infinix X510"
+          },
           "platforms": [
             "Android_5_1"
           ]
@@ -38,6 +40,32 @@
           "match": "Mozilla/5.0 (#PLATFORM# Build/* applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#* Mobile Safari*",
           "platforms": [
             "Android_5_1", "Android"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (Macintosh; *Mac OS X*; #DEVICE#; *) applewebkit* (*khtml*like*gecko*) Version/#MAJORVER#.#MINORVER#*Safari*",
+          "properties": {
+            "Browser_Modus": "Desktop Mode"
+          },
+          "devices": {
+            "HTC_EVO3D_X515m": "HTC X515m"
+          },
+          "platforms": [
+            "Android"
+          ]
+        },
+        {
+          "match": "Mozilla/5.2 (Macintosh; *Mac OS X*; #DEVICE#; *) applewebkit* (*khtml*like*gecko*) Version/5.2*Safari*",
+          "properties": {
+            "Browser_Modus": "Desktop Mode",
+            "Version": "5.2",
+            "MinorVer": "2"
+          },
+          "devices": {
+            "HTC_EVO3D_X515m": "HTC X515m"
+          },
+          "platforms": [
+            "Android"
           ]
         }
       ]

--- a/tests/fixtures/issues/issue-323.php
+++ b/tests/fixtures/issues/issue-323.php
@@ -375,14 +375,14 @@ return [
     'issue-323-H' => [
         'ua' => 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; HTC_Sensation_Z710e; da-dk) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16',
         'properties' => [
-            'Comment' => 'Android Browser 4.0',
+            'Comment' => 'Android Browser 5.0',
             'Browser' => 'Android',
             'Browser_Type' => 'Browser',
             'Browser_Bits' => '32',
             'Browser_Maker' => 'Google Inc',
             'Browser_Modus' => 'Desktop Mode',
-            'Version' => '4.0',
-            'MajorVer' => '4',
+            'Version' => '5.0',
+            'MajorVer' => '5',
             'MinorVer' => '0',
             'Platform' => 'Android',
             'Platform_Version' => 'unknown',


### PR DESCRIPTION
This should wrap up device expansion for the Android Browser files. The
4.0 file was certainly the one with the most devices that were able to
be combined.

I did a little bit of cleanup to that file in particular, adding some
devices that were set as “general Mobile Device” or that didn’t have a
device at all.  There were a few patterns that were eligible for being
condensed into another pattern, but the device identifier was too
ambiguous to be able to determine what it was.  Ultimately I removed
these patterns entirely (I recall a few device ids: `A*`, `OYO`). I
didn’t see any particular reason for these patterns to be in the file
with no device defined, as they should just fall back to a default
pattern that would have “general Mobile Phone” as the device anyhow.
Unfortunately, none of the patterns like this (including the ones I
added devices for) are covered by tests.

The one test case I changed was because I moved a couple of patterns
that looked like they were meant for different versions of Android
Browser into their appropriate files, and replaced the hard-coded “5.0”
or “5.1” after the “Version/“ part with the respective version tokens.
One test covered these patterns and claimed that the android browser
version should be “4.0” when the “Version/5.0” part of the UA seemed to
claim otherwise (let me know if this is incorrect).