### PR TITLE
Adding "failOnWarning" to phpunit.xml

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,7 @@
     verbose="true"
     colors="auto"
     bootstrap="vendor/autoload.php"
+    failOnWarning="true"
     >
     <php>
         <ini name="error_reporting" value="-1"/>


### PR DESCRIPTION
Fixes #1330.

By default, it seems, PHPUnit does not return a > 0 exit status code
for tests that throw warnings:

```
There was 1 warning:

1) Warning
The data provider specified for
BrowscapTest\UserAgentsTest::testUserAgentsFull is invalid.
Test data is duplicated for key "issue-004"

WARNINGS!
Tests: 22, Assertions: 234, Warnings: 1.
MacBook-Pro:browscap jasonklehr$ echo $?
0
```

Compared to when there is a failure:

```
FAILURES!
Tests: 15580, Assertions: 801930, Failures: 2.
MacBook-Pro:browscap jasonklehr$ echo $?
1
```

By specifying this config in the XML, the exit status will change for
test runs that throw warnings:

```
There was 1 warning:

1) Warning
The data provider specified for
BrowscapTest\UserAgentsTest::testUserAgentsFull is invalid.
Test data is duplicated for key "issue-004"

WARNINGS!
Tests: 22, Assertions: 234, Warnings: 1.
MacBook-Pro:browscap jasonklehr$ echo $?
1
```

Which should fail the travis build.  This could be specified on just
the CLI, just for a specific run (like the useragent test run), but I
don’t think there really should be any test runs that are ok to be
throwing warnings (especially since they don’t currently).

NOTE, this is failing travis for 2 reasons (both related to the same issue).

1) master branch of browscap-php has php 7.1 syntax, so any builds that use php 7.0 are failing (which is all builds except the nightlies and the useragent test build).

2) changes in master branch of browscap-php make some classes final, which means they can’t be mocked, which is throwing a warning in a test in a nightly build (this may happen in regular builds of 7.1 too, but right now the only 7.1 build is the useragent test, which doesn’t run those tests).

Both of these (I believe) are fixed with #1336.