### PR TITLE
Adding version 7 of Firefox on iOS

### DIFF
--- a/resources/user-agents/browsers/firefox-on-ios/firefox-ios-2-on.json
+++ b/resources/user-agents/browsers/firefox-on-ios/firefox-ios-2-on.json
@@ -1,6 +1,6 @@
 {
   "division": "Firefox #MAJORVER#.#MINORVER# for iOS",
-  "versions": ["6.1", 6, "5.3", "5.2", "5.1", 5, 4, 3, "2.1", 2],
+  "versions": [7, "6.1", 6, "5.3", "5.2", "5.1", 5, 4, 3, "2.1", 2],
   "sortIndex": 1166,
   "lite": false,
   "standard": true,


### PR DESCRIPTION
Noticed that Firefox IOS bumped to 7 recently (was in my update list on
my phone).

No other changes here.