### PR TITLE
Removing iOS < 3.2 for iPad

### DIFF
--- a/resources/platforms.json
+++ b/resources/platforms.json
@@ -653,33 +653,6 @@
       "standard": true,
       "inherits": "iOS"
     },
-    "iOS_C_2_0": {
-      "match": "*CPU OS 2* like Mac OS X*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "2.0"
-      }
-    },
-    "iOS_C_2_1": {
-      "match": "*CPU OS 2_1* like Mac OS X*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "2.1"
-      }
-    },
-    "iOS_C_2_2": {
-      "match": "*CPU OS 2_2* like Mac OS X*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "2.2"
-      }
-    },
     "iOS_C_3_0": {
       "match": "*CPU OS 3* like Mac OS X*",
       "lite": false,

--- a/resources/user-agents/apps/facebook/facebook-app.json
+++ b/resources/user-agents/apps/facebook/facebook-app.json
@@ -77,7 +77,7 @@
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
             "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
-            "iOS_C_3_2", "iOS_C_3_1", "iOS_C_3_0",
+            "iOS_C_3_2",
             "iOS_C"
           ]
         },

--- a/resources/user-agents/apps/facebook/facebook-app.json
+++ b/resources/user-agents/apps/facebook/facebook-app.json
@@ -60,7 +60,7 @@
             "iOS_A_6_1", "iOS_A_6_0",
             "iOS_A_5_1", "iOS_A_5_0",
             "iOS_A_4_3", "iOS_A_4_2", "iOS_A_4_1", "iOS_A_4_0",
-            "iOS_A_3_2", "iOS_A_3_1", "iOS_A_3_0",
+            "iOS_A_3_1", "iOS_A_3_0",
             "iOS_A"
           ]
         },
@@ -76,7 +76,7 @@
             "iOS_C_7_1", "iOS_C_7_0",
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
-            "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
+            "iOS_C_4_3", "iOS_C_4_2",
             "iOS_C_3_2",
             "iOS_C"
           ]

--- a/resources/user-agents/apps/google/google-app.json
+++ b/resources/user-agents/apps/google/google-app.json
@@ -261,7 +261,7 @@
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
             "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
-            "iOS_C_3_2", "iOS_C_3_1", "iOS_C_3_0",
+            "iOS_C_3_2",
             "iOS_C"
           ]
         },

--- a/resources/user-agents/apps/google/google-app.json
+++ b/resources/user-agents/apps/google/google-app.json
@@ -244,7 +244,7 @@
             "iOS_A_6_1", "iOS_A_6_0",
             "iOS_A_5_1", "iOS_A_5_0",
             "iOS_A_4_3", "iOS_A_4_2", "iOS_A_4_1", "iOS_A_4_0",
-            "iOS_A_3_2", "iOS_A_3_1", "iOS_A_3_0",
+            "iOS_A_3_1", "iOS_A_3_0",
             "iOS_A"
           ]
         },
@@ -260,7 +260,7 @@
             "iOS_C_7_1", "iOS_C_7_0",
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
-            "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
+            "iOS_C_4_3", "iOS_C_4_2",
             "iOS_C_3_2",
             "iOS_C"
           ]

--- a/resources/user-agents/apps/media-players/player-fm.json
+++ b/resources/user-agents/apps/media-players/player-fm.json
@@ -56,7 +56,7 @@
           "device": "iPad",
           "engine": "WebKit",
           "platforms": [
-            "iOS_C_4_0", "iOS_C_4_1", "iOS_C_4_2", "iOS_C_4_3", "iOS_C_5_0", "iOS_C_5_1", "iOS_C_6_1", "iOS_C_6_0",
+            "iOS_C_4_2", "iOS_C_4_3", "iOS_C_5_0", "iOS_C_5_1", "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_7_1", "iOS_C_7_0", "iOS_C_8_1", "iOS_C_8_0", "iOS_C"
           ]
         },

--- a/resources/user-agents/browsers/chrome/chrome-14-15.json
+++ b/resources/user-agents/browsers/chrome/chrome-14-15.json
@@ -78,7 +78,7 @@
             "iOS_A_6_1", "iOS_A_6_0",
             "iOS_A_5_1", "iOS_A_5_0",
             "iOS_A_4_3", "iOS_A_4_2", "iOS_A_4_1", "iOS_A_4_0",
-            "iOS_A_3_2", "iOS_A_3_1", "iOS_A_3_0",
+            "iOS_A_3_1", "iOS_A_3_0",
             "iOS_A"
           ]
         },
@@ -92,7 +92,7 @@
             "iOS_C_7_1", "iOS_C_7_0",
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
-            "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
+            "iOS_C_4_3", "iOS_C_4_2",
             "iOS_C_3_2",
             "iOS_C"
           ]

--- a/resources/user-agents/browsers/chrome/chrome-14-15.json
+++ b/resources/user-agents/browsers/chrome/chrome-14-15.json
@@ -93,7 +93,7 @@
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
             "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
-            "iOS_C_3_2", "iOS_C_3_1", "iOS_C_3_0",
+            "iOS_C_3_2",
             "iOS_C"
           ]
         },

--- a/resources/user-agents/browsers/chrome/chrome-16-17.json
+++ b/resources/user-agents/browsers/chrome/chrome-16-17.json
@@ -202,7 +202,7 @@
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
             "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
-            "iOS_C_3_2", "iOS_C_3_1", "iOS_C_3_0",
+            "iOS_C_3_2",
             "iOS_C"
           ]
         },

--- a/resources/user-agents/browsers/chrome/chrome-16-17.json
+++ b/resources/user-agents/browsers/chrome/chrome-16-17.json
@@ -187,7 +187,7 @@
             "iOS_A_6_1", "iOS_A_6_0",
             "iOS_A_5_1", "iOS_A_5_0",
             "iOS_A_4_3", "iOS_A_4_2", "iOS_A_4_1", "iOS_A_4_0",
-            "iOS_A_3_2", "iOS_A_3_1", "iOS_A_3_0",
+            "iOS_A_3_1", "iOS_A_3_0",
             "iOS_A"
           ]
         },
@@ -201,7 +201,7 @@
             "iOS_C_7_1", "iOS_C_7_0",
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
-            "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
+            "iOS_C_4_3", "iOS_C_4_2",
             "iOS_C_3_2",
             "iOS_C"
           ]

--- a/resources/user-agents/browsers/chrome/chrome-18.json
+++ b/resources/user-agents/browsers/chrome/chrome-18.json
@@ -330,7 +330,7 @@
             "iOS_A_6_1", "iOS_A_6_0",
             "iOS_A_5_1", "iOS_A_5_0",
             "iOS_A_4_3", "iOS_A_4_2", "iOS_A_4_1", "iOS_A_4_0",
-            "iOS_A_3_2", "iOS_A_3_1", "iOS_A_3_0",
+            "iOS_A_3_1", "iOS_A_3_0",
             "iOS_A"
           ]
         },
@@ -344,7 +344,7 @@
             "iOS_C_7_1", "iOS_C_7_0",
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
-            "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
+            "iOS_C_4_3", "iOS_C_4_2",
             "iOS_C_3_2",
             "iOS_C"
           ]

--- a/resources/user-agents/browsers/chrome/chrome-18.json
+++ b/resources/user-agents/browsers/chrome/chrome-18.json
@@ -345,7 +345,7 @@
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
             "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
-            "iOS_C_3_2", "iOS_C_3_1", "iOS_C_3_0",
+            "iOS_C_3_2",
             "iOS_C"
           ]
         },

--- a/resources/user-agents/browsers/chrome/chrome-19-24.json
+++ b/resources/user-agents/browsers/chrome/chrome-19-24.json
@@ -281,7 +281,7 @@
             "iOS_A_6_1", "iOS_A_6_0",
             "iOS_A_5_1", "iOS_A_5_0",
             "iOS_A_4_3", "iOS_A_4_2", "iOS_A_4_1", "iOS_A_4_0",
-            "iOS_A_3_2", "iOS_A_3_1", "iOS_A_3_0",
+            "iOS_A_3_1", "iOS_A_3_0",
             "iOS_A"
           ]
         },
@@ -295,7 +295,7 @@
             "iOS_C_7_1", "iOS_C_7_0",
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
-            "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
+            "iOS_C_4_3", "iOS_C_4_2",
             "iOS_C_3_2",
             "iOS_C"
           ]

--- a/resources/user-agents/browsers/chrome/chrome-19-24.json
+++ b/resources/user-agents/browsers/chrome/chrome-19-24.json
@@ -296,7 +296,7 @@
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
             "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
-            "iOS_C_3_2", "iOS_C_3_1", "iOS_C_3_0",
+            "iOS_C_3_2",
             "iOS_C"
           ]
         },

--- a/resources/user-agents/browsers/chrome/chrome-25-27.json
+++ b/resources/user-agents/browsers/chrome/chrome-25-27.json
@@ -334,7 +334,7 @@
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
             "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
-            "iOS_C_3_2", "iOS_C_3_1", "iOS_C_3_0",
+            "iOS_C_3_2",
             "iOS_C"
           ]
         },

--- a/resources/user-agents/browsers/chrome/chrome-25-27.json
+++ b/resources/user-agents/browsers/chrome/chrome-25-27.json
@@ -319,7 +319,7 @@
             "iOS_A_6_1", "iOS_A_6_0",
             "iOS_A_5_1", "iOS_A_5_0",
             "iOS_A_4_3", "iOS_A_4_2", "iOS_A_4_1", "iOS_A_4_0",
-            "iOS_A_3_2", "iOS_A_3_1", "iOS_A_3_0",
+            "iOS_A_3_1", "iOS_A_3_0",
             "iOS_A"
           ]
         },
@@ -333,7 +333,7 @@
             "iOS_C_7_1", "iOS_C_7_0",
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
-            "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
+            "iOS_C_4_3", "iOS_C_4_2",
             "iOS_C_3_2",
             "iOS_C"
           ]

--- a/resources/user-agents/browsers/chrome/chrome-28-29.json
+++ b/resources/user-agents/browsers/chrome/chrome-28-29.json
@@ -432,7 +432,7 @@
             "iOS_A_6_1", "iOS_A_6_0",
             "iOS_A_5_1", "iOS_A_5_0",
             "iOS_A_4_3", "iOS_A_4_2", "iOS_A_4_1", "iOS_A_4_0",
-            "iOS_A_3_2", "iOS_A_3_1", "iOS_A_3_0",
+            "iOS_A_3_1", "iOS_A_3_0",
             "iOS_A"
           ]
         },
@@ -446,7 +446,7 @@
             "iOS_C_7_1", "iOS_C_7_0",
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
-            "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
+            "iOS_C_4_3", "iOS_C_4_2",
             "iOS_C_3_2",
             "iOS_C"
           ]

--- a/resources/user-agents/browsers/chrome/chrome-28-29.json
+++ b/resources/user-agents/browsers/chrome/chrome-28-29.json
@@ -447,7 +447,7 @@
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
             "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
-            "iOS_C_3_2", "iOS_C_3_1", "iOS_C_3_0",
+            "iOS_C_3_2",
             "iOS_C"
           ]
         },

--- a/resources/user-agents/browsers/chrome/chrome-generic.json
+++ b/resources/user-agents/browsers/chrome/chrome-generic.json
@@ -89,7 +89,7 @@
             "iOS_A_6_1", "iOS_A_6_0",
             "iOS_A_5_1", "iOS_A_5_0",
             "iOS_A_4_3", "iOS_A_4_2", "iOS_A_4_1", "iOS_A_4_0",
-            "iOS_A_3_2", "iOS_A_3_1", "iOS_A_3_0",
+            "iOS_A_3_1", "iOS_A_3_0",
             "iOS_A"
           ]
         },
@@ -105,7 +105,7 @@
             "iOS_C_7_1", "iOS_C_7_0",
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
-            "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
+            "iOS_C_4_3", "iOS_C_4_2",
             "iOS_C_3_2",
             "iOS_C"
           ]

--- a/resources/user-agents/browsers/chrome/chrome-generic.json
+++ b/resources/user-agents/browsers/chrome/chrome-generic.json
@@ -106,7 +106,7 @@
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
             "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
-            "iOS_C_3_2", "iOS_C_3_1", "iOS_C_3_0",
+            "iOS_C_3_2",
             "iOS_C"
           ]
         },

--- a/resources/user-agents/browsers/mercury/mercury-7-0-on.json
+++ b/resources/user-agents/browsers/mercury/mercury-7-0-on.json
@@ -59,7 +59,7 @@
             "iOS_C_7_1", "iOS_C_7_0",
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
-            "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
+            "iOS_C_4_3", "iOS_C_4_2",
             "iOS_C"
           ]
         },

--- a/resources/user-agents/browsers/mercury/mercury-generic.json
+++ b/resources/user-agents/browsers/mercury/mercury-generic.json
@@ -307,7 +307,7 @@
             "iOS_C_7_1", "iOS_C_7_0",
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
-            "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
+            "iOS_C_4_3", "iOS_C_4_2",
             "iOS_C"
           ]
         },

--- a/resources/user-agents/browsers/mobile-safari-uiwebview/mobile-safari-uiwebview.json
+++ b/resources/user-agents/browsers/mobile-safari-uiwebview/mobile-safari-uiwebview.json
@@ -37,7 +37,7 @@
             "iOS_A_6_1", "iOS_A_6_0",
             "iOS_A_5_1", "iOS_A_5_0",
             "iOS_A_4_3", "iOS_A_4_1", "iOS_A_4_2", "iOS_A_4_0",
-            "iOS_A_3_2", "iOS_A_3_1", "iOS_A_3_0",
+            "iOS_A_3_1", "iOS_A_3_0",
             "iOS_A"
           ]
         },
@@ -53,7 +53,7 @@
             "iOS_C_7_1", "iOS_C_7_0",
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
-            "iOS_C_4_3", "iOS_C_4_1", "iOS_C_4_2", "iOS_C_4_0",
+            "iOS_C_4_3", "iOS_C_4_2",
             "iOS_C_3_2",
             "iOS_C"
           ]

--- a/resources/user-agents/browsers/mobile-safari-uiwebview/mobile-safari-uiwebview.json
+++ b/resources/user-agents/browsers/mobile-safari-uiwebview/mobile-safari-uiwebview.json
@@ -54,7 +54,7 @@
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
             "iOS_C_4_3", "iOS_C_4_1", "iOS_C_4_2", "iOS_C_4_0",
-            "iOS_C_3_2", "iOS_C_3_1", "iOS_C_3_0",
+            "iOS_C_3_2",
             "iOS_C"
           ]
         },

--- a/resources/user-agents/browsers/mobile-safari/mobile-safari-3-x.json
+++ b/resources/user-agents/browsers/mobile-safari/mobile-safari-3-x.json
@@ -39,7 +39,7 @@
             "iOS_A_6_1", "iOS_A_6_0",
             "iOS_A_5_1", "iOS_A_5_0",
             "iOS_A_4_3", "iOS_A_4_2", "iOS_A_4_1", "iOS_A_4_0",
-            "iOS_A_3_2", "iOS_A_3_1", "iOS_A_3_0",
+            "iOS_A_3_1", "iOS_A_3_0",
             "iOS_A_2_0",
             "iOS_A",
             "iOS_C"
@@ -55,7 +55,7 @@
             "iOS_C_7_1", "iOS_C_7_0",
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
-            "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
+            "iOS_C_4_3", "iOS_C_4_2",
             "iOS_C_3_2",
             "iOS_C"
           ]

--- a/resources/user-agents/browsers/mobile-safari/mobile-safari-3-x.json
+++ b/resources/user-agents/browsers/mobile-safari/mobile-safari-3-x.json
@@ -56,8 +56,7 @@
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
             "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
-            "iOS_C_3_2", "iOS_C_3_1", "iOS_C_3_0",
-            "iOS_C_2_0",
+            "iOS_C_3_2",
             "iOS_C"
           ]
         },

--- a/resources/user-agents/browsers/mobile-safari/mobile-safari-4-0.json
+++ b/resources/user-agents/browsers/mobile-safari/mobile-safari-4-0.json
@@ -55,7 +55,7 @@
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
             "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
-            "iOS_C_3_2", "iOS_C_3_1", "iOS_C_3_0",
+            "iOS_C_3_2",
             "iOS_C"
           ]
         },

--- a/resources/user-agents/browsers/mobile-safari/mobile-safari-4-0.json
+++ b/resources/user-agents/browsers/mobile-safari/mobile-safari-4-0.json
@@ -39,7 +39,7 @@
             "iOS_A_6_1", "iOS_A_6_0",
             "iOS_A_5_1", "iOS_A_5_0",
             "iOS_A_4_3", "iOS_A_4_2", "iOS_A_4_1", "iOS_A_4_0",
-            "iOS_A_3_2", "iOS_A_3_1", "iOS_A_3_0",
+            "iOS_A_3_1", "iOS_A_3_0",
             "iOS_A",
             "iOS_C"
           ]
@@ -54,7 +54,7 @@
             "iOS_C_7_1", "iOS_C_7_0",
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
-            "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
+            "iOS_C_4_3", "iOS_C_4_2",
             "iOS_C_3_2",
             "iOS_C"
           ]

--- a/resources/user-agents/browsers/mobile-safari/mobile-safari-5-0.json
+++ b/resources/user-agents/browsers/mobile-safari/mobile-safari-5-0.json
@@ -55,7 +55,7 @@
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
             "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
-            "iOS_C_3_2", "iOS_C_3_1", "iOS_C_3_0",
+            "iOS_C_3_2",
             "iOS_C"
           ]
         },
@@ -77,7 +77,7 @@
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
             "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
-            "iOS_C_3_2", "iOS_C_3_1", "iOS_C_3_0",
+            "iOS_C_3_2",
             "iOS_C"
           ]
         },

--- a/resources/user-agents/browsers/mobile-safari/mobile-safari-5-0.json
+++ b/resources/user-agents/browsers/mobile-safari/mobile-safari-5-0.json
@@ -39,7 +39,7 @@
             "iOS_A_6_1", "iOS_A_6_0",
             "iOS_A_5_1", "iOS_A_5_0",
             "iOS_A_4_3", "iOS_A_4_2", "iOS_A_4_1", "iOS_A_4_0",
-            "iOS_A_3_2", "iOS_A_3_1", "iOS_A_3_0",
+            "iOS_A_3_1", "iOS_A_3_0",
             "iOS_A",
             "iOS_C"
           ]
@@ -54,7 +54,7 @@
             "iOS_C_7_1", "iOS_C_7_0",
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
-            "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
+            "iOS_C_4_3", "iOS_C_4_2",
             "iOS_C_3_2",
             "iOS_C"
           ]
@@ -76,7 +76,7 @@
             "iOS_C_7_1", "iOS_C_7_0",
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
-            "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
+            "iOS_C_4_3", "iOS_C_4_2",
             "iOS_C_3_2",
             "iOS_C"
           ]

--- a/resources/user-agents/browsers/mobile-safari/mobile-safari-5-1.json
+++ b/resources/user-agents/browsers/mobile-safari/mobile-safari-5-1.json
@@ -55,7 +55,7 @@
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
             "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
-            "iOS_C_3_2", "iOS_C_3_1", "iOS_C_3_0",
+            "iOS_C_3_2",
             "iOS_C"
           ]
         },

--- a/resources/user-agents/browsers/mobile-safari/mobile-safari-5-1.json
+++ b/resources/user-agents/browsers/mobile-safari/mobile-safari-5-1.json
@@ -39,7 +39,7 @@
             "iOS_A_6_1", "iOS_A_6_0",
             "iOS_A_5_1", "iOS_A_5_0",
             "iOS_A_4_3", "iOS_A_4_2", "iOS_A_4_1", "iOS_A_4_0",
-            "iOS_A_3_2", "iOS_A_3_1", "iOS_A_3_0",
+            "iOS_A_3_1", "iOS_A_3_0",
             "iOS_A",
             "iOS_C"
           ]
@@ -54,7 +54,7 @@
             "iOS_C_7_1", "iOS_C_7_0",
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
-            "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
+            "iOS_C_4_3", "iOS_C_4_2",
             "iOS_C_3_2",
             "iOS_C"
           ]

--- a/resources/user-agents/browsers/mobile-safari/mobile-safari-6-0.json
+++ b/resources/user-agents/browsers/mobile-safari/mobile-safari-6-0.json
@@ -55,7 +55,7 @@
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
             "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
-            "iOS_C_3_2", "iOS_C_3_1", "iOS_C_3_0",
+            "iOS_C_3_2",
             "iOS_C"
           ]
         },

--- a/resources/user-agents/browsers/mobile-safari/mobile-safari-6-0.json
+++ b/resources/user-agents/browsers/mobile-safari/mobile-safari-6-0.json
@@ -39,7 +39,7 @@
             "iOS_A_6_1", "iOS_A_6_0",
             "iOS_A_5_1", "iOS_A_5_0",
             "iOS_A_4_3", "iOS_A_4_2", "iOS_A_4_1", "iOS_A_4_0",
-            "iOS_A_3_2", "iOS_A_3_1", "iOS_A_3_0",
+            "iOS_A_3_1", "iOS_A_3_0",
             "iOS_A",
             "iOS_C"
           ]
@@ -54,7 +54,7 @@
             "iOS_C_7_1", "iOS_C_7_0",
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
-            "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
+            "iOS_C_4_3", "iOS_C_4_2",
             "iOS_C_3_2",
             "iOS_C"
           ]

--- a/resources/user-agents/browsers/mobile-safari/mobile-safari-6-1.json
+++ b/resources/user-agents/browsers/mobile-safari/mobile-safari-6-1.json
@@ -55,7 +55,7 @@
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
             "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
-            "iOS_C_3_2", "iOS_C_3_1", "iOS_C_3_0",
+            "iOS_C_3_2",
             "iOS_C"
           ]
         },

--- a/resources/user-agents/browsers/mobile-safari/mobile-safari-6-1.json
+++ b/resources/user-agents/browsers/mobile-safari/mobile-safari-6-1.json
@@ -39,7 +39,7 @@
             "iOS_A_6_1", "iOS_A_6_0",
             "iOS_A_5_1", "iOS_A_5_0",
             "iOS_A_4_3", "iOS_A_4_2", "iOS_A_4_1", "iOS_A_4_0",
-            "iOS_A_3_2", "iOS_A_3_1", "iOS_A_3_0",
+            "iOS_A_3_1", "iOS_A_3_0",
             "iOS_A",
             "iOS_C"
           ]
@@ -54,7 +54,7 @@
             "iOS_C_7_1", "iOS_C_7_0",
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
-            "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
+            "iOS_C_4_3", "iOS_C_4_2",
             "iOS_C_3_2",
             "iOS_C"
           ]

--- a/resources/user-agents/browsers/mobile-safari/mobile-safari-7-0.json
+++ b/resources/user-agents/browsers/mobile-safari/mobile-safari-7-0.json
@@ -55,7 +55,7 @@
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
             "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
-            "iOS_C_3_2", "iOS_C_3_1", "iOS_C_3_0",
+            "iOS_C_3_2",
             "iOS_C"
           ]
         },

--- a/resources/user-agents/browsers/mobile-safari/mobile-safari-7-0.json
+++ b/resources/user-agents/browsers/mobile-safari/mobile-safari-7-0.json
@@ -39,7 +39,7 @@
             "iOS_A_6_1", "iOS_A_6_0",
             "iOS_A_5_1", "iOS_A_5_0",
             "iOS_A_4_3", "iOS_A_4_2", "iOS_A_4_1", "iOS_A_4_0",
-            "iOS_A_3_2", "iOS_A_3_1", "iOS_A_3_0",
+            "iOS_A_3_1", "iOS_A_3_0",
             "iOS_A",
             "iOS_C"
           ]
@@ -54,7 +54,7 @@
             "iOS_C_7_1", "iOS_C_7_0",
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
-            "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
+            "iOS_C_4_3", "iOS_C_4_2",
             "iOS_C_3_2",
             "iOS_C"
           ]

--- a/resources/user-agents/browsers/mobile-safari/mobile-safari-7-1.json
+++ b/resources/user-agents/browsers/mobile-safari/mobile-safari-7-1.json
@@ -41,7 +41,7 @@
             "iOS_A_6_1", "iOS_A_6_0",
             "iOS_A_5_1", "iOS_A_5_0",
             "iOS_A_4_3", "iOS_A_4_2", "iOS_A_4_1", "iOS_A_4_0",
-            "iOS_A_3_2", "iOS_A_3_1", "iOS_A_3_0",
+            "iOS_A_3_1", "iOS_A_3_0",
             "iOS_A",
             "iOS_C"
           ]
@@ -58,7 +58,7 @@
             "iOS_C_7_1", "iOS_C_7_0",
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
-            "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
+            "iOS_C_4_3", "iOS_C_4_2",
             "iOS_C_3_2",
             "iOS_C"
           ]

--- a/resources/user-agents/browsers/mobile-safari/mobile-safari-7-1.json
+++ b/resources/user-agents/browsers/mobile-safari/mobile-safari-7-1.json
@@ -59,7 +59,7 @@
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
             "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
-            "iOS_C_3_2", "iOS_C_3_1", "iOS_C_3_0",
+            "iOS_C_3_2",
             "iOS_C"
           ]
         },

--- a/resources/user-agents/browsers/mobile-safari/mobile-safari-generic.json
+++ b/resources/user-agents/browsers/mobile-safari/mobile-safari-generic.json
@@ -37,7 +37,7 @@
             "iOS_A_6_1", "iOS_A_6_0",
             "iOS_A_5_1", "iOS_A_5_0",
             "iOS_A_4_3", "iOS_A_4_1", "iOS_A_4_2", "iOS_A_4_0",
-            "iOS_A_3_2", "iOS_A_3_1", "iOS_A_3_0",
+            "iOS_A_3_1", "iOS_A_3_0",
             "iOS_A_2_0",
             "iOS_A",
             "iOS_C"
@@ -55,7 +55,7 @@
             "iOS_C_7_1", "iOS_C_7_0",
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
-            "iOS_C_4_3", "iOS_C_4_1", "iOS_C_4_2", "iOS_C_4_0",
+            "iOS_C_4_3", "iOS_C_4_2",
             "iOS_C_3_2",
             "iOS_C"
           ]
@@ -81,7 +81,7 @@
             "iOS_A_6_1", "iOS_A_6_0",
             "iOS_A_5_1", "iOS_A_5_0",
             "iOS_A_4_3", "iOS_A_4_1", "iOS_A_4_2", "iOS_A_4_0",
-            "iOS_A_3_2", "iOS_A_3_1", "iOS_A_3_0",
+            "iOS_A_3_1", "iOS_A_3_0",
             "iOS_A_2_0",
             "iOS_A"
           ]
@@ -98,7 +98,7 @@
             "iOS_C_7_1", "iOS_C_7_0",
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
-            "iOS_C_4_3", "iOS_C_4_1", "iOS_C_4_2", "iOS_C_4_0",
+            "iOS_C_4_3", "iOS_C_4_2",
             "iOS_C_3_2",
             "iOS_C"
           ]

--- a/resources/user-agents/browsers/mobile-safari/mobile-safari-generic.json
+++ b/resources/user-agents/browsers/mobile-safari/mobile-safari-generic.json
@@ -56,8 +56,7 @@
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
             "iOS_C_4_3", "iOS_C_4_1", "iOS_C_4_2", "iOS_C_4_0",
-            "iOS_C_3_2", "iOS_C_3_1", "iOS_C_3_0",
-            "iOS_C_2_0",
+            "iOS_C_3_2",
             "iOS_C"
           ]
         },
@@ -100,8 +99,7 @@
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
             "iOS_C_4_3", "iOS_C_4_1", "iOS_C_4_2", "iOS_C_4_0",
-            "iOS_C_3_2", "iOS_C_3_1", "iOS_C_3_0",
-            "iOS_C_2_0",
+            "iOS_C_3_2",
             "iOS_C"
           ]
         },

--- a/resources/user-agents/browsers/sleipnir/sleipnir-generic.json
+++ b/resources/user-agents/browsers/sleipnir/sleipnir-generic.json
@@ -190,7 +190,7 @@
             "iOS_C_7_1", "iOS_C_7_0",
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
-            "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
+            "iOS_C_4_3", "iOS_C_4_2",
             "iOS_C"
           ]
         },

--- a/resources/user-agents/browsers/sleipnir/sleipnir-ios-1-x.json
+++ b/resources/user-agents/browsers/sleipnir/sleipnir-ios-1-x.json
@@ -56,7 +56,7 @@
             "iOS_C_7_1", "iOS_C_7_0",
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
-            "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
+            "iOS_C_4_3", "iOS_C_4_2",
             "iOS_C"
           ]
         },

--- a/resources/user-agents/crawlers/google/adsbot-google-mobile.json
+++ b/resources/user-agents/crawlers/google/adsbot-google-mobile.json
@@ -31,7 +31,7 @@
             "iOS_A_6_1", "iOS_A_6_0",
             "iOS_A_5_1", "iOS_A_5_0",
             "iOS_A_4_3", "iOS_A_4_2", "iOS_A_4_1", "iOS_A_4_0",
-            "iOS_A_3_2", "iOS_A_3_1", "iOS_A_3_0",
+            "iOS_A_3_1", "iOS_A_3_0",
             "iOS_A"
           ]
         },

--- a/resources/user-agents/crawlers/google/google-page-speed.json
+++ b/resources/user-agents/crawlers/google/google-page-speed.json
@@ -30,7 +30,7 @@
             "iOS_A_6_1", "iOS_A_6_0",
             "iOS_A_5_1", "iOS_A_5_0",
             "iOS_A_4_3", "iOS_A_4_2", "iOS_A_4_1", "iOS_A_4_0",
-            "iOS_A_3_2", "iOS_A_3_1", "iOS_A_3_0",
+            "iOS_A_3_1", "iOS_A_3_0",
             "iOS_A"
           ]
         },
@@ -44,7 +44,7 @@
             "iOS_C_7_1", "iOS_C_7_0",
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
-            "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
+            "iOS_C_4_3", "iOS_C_4_2",
             "iOS_C_3_2",
             "iOS_C"
           ]

--- a/resources/user-agents/crawlers/google/google-page-speed.json
+++ b/resources/user-agents/crawlers/google/google-page-speed.json
@@ -45,7 +45,7 @@
             "iOS_C_6_1", "iOS_C_6_0",
             "iOS_C_5_1", "iOS_C_5_0",
             "iOS_C_4_3", "iOS_C_4_2", "iOS_C_4_1", "iOS_C_4_0",
-            "iOS_C_3_2", "iOS_C_3_1", "iOS_C_3_0",
+            "iOS_C_3_2",
             "iOS_C"
           ]
         },

--- a/resources/user-agents/crawlers/yandex/yandex-mobile-bot-generic.json
+++ b/resources/user-agents/crawlers/yandex/yandex-mobile-bot-generic.json
@@ -23,7 +23,7 @@
           "device": "iPhone",
           "engine": "WebKit",
           "platforms": [
-            "iOS_C_4_1", "iOS_C_6_0", "iOS_C_8_1",
+            "iOS_C_8_1", "iOS_C_6_0", "iOS_C_4_1",
             "iOS_C"
           ]
         },
@@ -32,7 +32,7 @@
           "device": "general Mobile Device (Apple)",
           "engine": "WebKit",
           "platforms": [
-            "iOS_C_4_1", "iOS_C_6_0", "iOS_C_8_1",
+            "iOS_C_8_1", "iOS_C_6_0",
             "iOS_C"
           ]
         }


### PR DESCRIPTION
For some reason I was thinking about this today.

The original iPad released with iOS 3.2 (https://en.wikipedia.org/wiki/IPad_(1st_generation)#Software) and now that iphone/ipad are pretty much separated in browscap files, I was curious if there were any instances of iOS < 3.2 + iPad in the patterns.

I found a few, so removed them.

I also removed a few of these iOS_C platforms that aren't used in resource files at all anymore.

No tests covered these removals (they shouldn't, since iPad + iOS < 3.2 shouldn't exist).