### PR TITLE
Condensing devices for Flipboard App

### DIFF
--- a/resources/user-agents/apps/flipboard-app/flipboard-app-android-2-x.json
+++ b/resources/user-agents/apps/flipboard-app/flipboard-app-android-2-x.json
@@ -31,38 +31,56 @@
       },
       "children": [
         {
-          "match": "Mozilla/5.0 (#PLATFORM#WT19i Build/*)*applewebkit*(*khtml*like*gecko*)*Version/*Safari* Flipboard/#MAJORVER#.#MINORVER#*",
-          "device": "SonyEricsson WT19i",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*)*applewebkit*(*khtml*like*gecko*)*Version/*Safari* Flipboard/#MAJORVER#.#MINORVER#*",
+          "devices": {
+            "SM-T325": "Samsung SM-T325"
+          },
           "platforms": [
-            "Android_2_3"
+            "Android_4_4"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#6036Y Build/*)*applewebkit*(*khtml*like*gecko*)*Version/*Safari* Flipboard/#MAJORVER#.#MINORVER#*",
-          "device": "Alcatel OT-6036Y",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*)*applewebkit*(*khtml*like*gecko*)*Version/*Safari* Flipboard/#MAJORVER#.#MINORVER#*",
+          "devices": {
+            "6036Y": "Alcatel OT-6036Y"
+          },
           "platforms": [
             "Android_4_3"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#SM-T325 Build/*)*applewebkit*(*khtml*like*gecko*)*Version/*Chrome*Safari* Flipboard/#MAJORVER#.#MINORVER#*",
-          "device": "Samsung SM-T325",
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*)*applewebkit*(*khtml*like*gecko*)*Version/*Safari* Flipboard/#MAJORVER#.#MINORVER#*",
+          "devices": {
+            "WT19i": "SonyEricsson WT19i"
+          },
+          "platforms": [
+            "Android_2_3"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM#)*applewebkit*(*khtml*like*gecko*)*Version/*Safari* Flipboard/#MAJORVER#.#MINORVER#*",
+          "platforms": [
+            "Android_4_4", "Android_4_3",
+            "Android_2_3",
+            "Android"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*)*applewebkit*(*khtml*like*gecko*)*Version/*Chrome*Safari* Flipboard/#MAJORVER#.#MINORVER#*",
+          "devices": {
+            "SM-T325": "Samsung SM-T325"
+          },
           "engine": "Blink",
           "platforms": [
             "Android_4_4"
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#SM-T325 Build/*)*applewebkit*(*khtml*like*gecko*)*Version/*Safari* Flipboard/#MAJORVER#.#MINORVER#*",
-          "device": "Samsung SM-T325",
+          "match": "Mozilla/5.0 (#PLATFORM#)*applewebkit*(*khtml*like*gecko*)*Version/*Chrome*Safari* Flipboard/#MAJORVER#.#MINORVER#*",
+          "engine": "Blink",
           "platforms": [
-            "Android_4_4"
-          ]
-        },
-        {
-          "match": "Mozilla/5.0 (#PLATFORM#)*applewebkit*(*khtml*like*gecko*)*Version/*Safari* Flipboard/#MAJORVER#.#MINORVER#*",
-          "platforms": [
-            "Android_2_3", "Android_4_3", "Android"
+            "Android_4_4",
+            "Android"
           ]
         }
       ]

--- a/resources/user-agents/apps/flipboard-app/flipboard-app-android-3-x.json
+++ b/resources/user-agents/apps/flipboard-app/flipboard-app-android-3-x.json
@@ -88,6 +88,15 @@
           ]
         },
         {
+          "match": "Mozilla/5.0 (#PLATFORM#)*applewebkit*(*khtml*like*gecko*)*Version/*Chrome*Safari* Flipboard/#MAJORVER#.#MINORVER#*",
+          "platforms": [
+            "Android_6_0",
+            "Android_5_1", "Android_5_0",
+            "Android_4_4", "Android_4_3", "Android_4_2",
+            "Android"
+          ]
+        },
+        {
           "match": "Mozilla/5.0 (#PLATFORM##DEVICE# Build/*)*applewebkit*(*khtml*like*gecko*)*Version/*Safari* Flipboard/#MAJORVER#.#MINORVER#*",
           "devices": {
             "NokiaX2DS": "Nokia X2DS"
@@ -110,17 +119,11 @@
           ]
         },
         {
-          "match": "Mozilla/5.0 (#PLATFORM#)*applewebkit*(*khtml*like*gecko*)*Version/*Chrome*Safari* Flipboard/#MAJORVER#.#MINORVER#*",
-          "platforms": [
-            "Android_5_1", "Android_5_0", "Android_4_4",
-            "Android"
-          ]
-        },
-        {
           "match": "Mozilla/5.0 (#PLATFORM#)*applewebkit*(*khtml*like*gecko*)*Version/*Safari* Flipboard/#MAJORVER#.#MINORVER#*",
           "engine": "WebKit",
           "platforms": [
-            "Android_5_1", "Android_5_0", "Android_4_4",
+            "Android_5_1", "Android_5_0",
+            "Android_4_4", "Android_4_3", "Android_4_2",
             "Android"
           ]
         }

--- a/resources/user-agents/apps/flipboard-app/flipboard-app-generic.json
+++ b/resources/user-agents/apps/flipboard-app/flipboard-app-generic.json
@@ -1,0 +1,51 @@
+{
+  "division": "Flipboard App Generic",
+  "sortIndex": 941,
+  "lite": false,
+  "standard": true,
+  "userAgents": [
+    {
+      "userAgent": "Flipboard App Generic",
+      "platform": "Android",
+      "engine": "WebKit",
+      "device": "general Mobile Device (Touch)",
+      "properties": {
+        "Parent": "DefaultProperties",
+        "Comment": "Flipboard App Generic",
+        "Browser": "Flipboard App",
+        "Browser_Type": "Application",
+        "Browser_Maker": "Flipboard, Inc.",
+        "Alpha": "false",
+        "Beta": "false",
+        "Frames": "false",
+        "IFrames": "false",
+        "Tables": "false",
+        "Cookies": "false",
+        "JavaScript": "false",
+        "isSyndicationReader": "false",
+        "Crawler": "false"
+      },
+      "children": [
+        {
+          "match": "Mozilla/5.0 (#PLATFORM#)*applewebkit*(*khtml*like*gecko*)*Version/*Chrome*Safari* Flipboard/*",
+          "engine": "Blink",
+          "platforms": [
+            "Android_6_0",
+            "Android_5_1", "Android_5_0",
+            "Android_4_4", "Android_4_3", "Android_4_2",
+            "Android"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM#)*applewebkit*(*khtml*like*gecko*)*Version/*Safari* Flipboard/*",
+          "platforms": [
+            "Android_5_1", "Android_5_0",
+            "Android_4_4", "Android_4_3", "Android_4_2",
+            "Android_2_3",
+            "Android"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Not a lot here (running out of files with a lot of devices :) ).

I did add a generic file to deal with new versions of the flipboard app that may come out so that they won’t be detected as Chrome/Android Webview.

I looked for useragents to add coverage, but the ones I found mapped to `general Mobile Phone` so I didn’t add them as tests (and didn’t want to add the devices).