### PR TITLE
Removing Android 6.1

### DIFF
--- a/resources/platforms.json
+++ b/resources/platforms.json
@@ -3211,15 +3211,6 @@
         "Platform_Version": "6.0"
       }
     },
-    "Android_6_1": {
-      "match": "*Linux*Android?6.1*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "6.1"
-      }
-    },
     "Android_7_0": {
       "match": "*Linux*Android?7.0*",
       "lite": false,
@@ -3649,15 +3640,6 @@
         "Platform_Version": "6.0"
       }
     },
-    "Android_E_6_1": {
-      "match": "*; U; Adr 6.1*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "6.1"
-      }
-    },
     "Android_E_7_0": {
       "match": "*; U; Adr 7.0*",
       "lite": false,
@@ -3826,15 +3808,6 @@
         "Platform_Version": "6.0"
       }
     },
-    "Android_F_6_1": {
-      "match": "*Android?6.1*Linux*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "6.1"
-      }
-    },
     "Android_F_7_0": {
       "match": "*Android?7.0*Linux*",
       "lite": false,
@@ -3989,15 +3962,6 @@
       "inherits": "Android",
       "properties": {
         "Platform_Version": "6.0"
-      }
-    },
-    "Android_H_6_1": {
-      "match": "*Android?6.1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "6.1"
       }
     },
     "Android_H_7_0": {

--- a/resources/user-agents/apps/alibaba/ali-app.json
+++ b/resources/user-agents/apps/alibaba/ali-app.json
@@ -40,7 +40,7 @@
           "match": "Mozilla/5.0 (#PLATFORM# Build/*) applewebkit* (*khtml*like*gecko*) Version/* Chrome/* Safari/* AliApp*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android"

--- a/resources/user-agents/apps/baidu/baidu-box-app-generic.json
+++ b/resources/user-agents/apps/baidu/baidu-box-app-generic.json
@@ -56,7 +56,7 @@
           "engine": "T7",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_4_4", "Android_4_3", "Android_4_2",
             "Android"
           ]

--- a/resources/user-agents/apps/baidu/baidu-box-app-t7.json
+++ b/resources/user-agents/apps/baidu/baidu-box-app-t7.json
@@ -58,7 +58,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) Version/* Chrome/* Safari/* T7/* baiduboxapp/#MAJORVER#.#MINORVER#*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2"
           ]

--- a/resources/user-agents/apps/crosswalk/crosswalk-generic.json
+++ b/resources/user-agents/apps/crosswalk/crosswalk-generic.json
@@ -26,7 +26,11 @@
         {
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) Chrome/* Crosswalk/* Safari/*",
           "platforms": [
-            "Android_4_4", "Android_5_0", "Android_5_1", "Android_6_0", "Android_6_1", "Android_7_0", "Android_7_1", "Android"
+            "Android_7_1", "Android_7_0",
+            "Android_6_0",
+            "Android_5_1", "Android_5_0",
+            "Android_4_4",
+            "Android"
           ]
         }
       ]

--- a/resources/user-agents/apps/crosswalk/crosswalk.json
+++ b/resources/user-agents/apps/crosswalk/crosswalk.json
@@ -37,7 +37,11 @@
         {
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) Chrome/* Crosswalk/#MAJORVER#.* Safari/*",
           "platforms": [
-            "Android_4_4", "Android_5_0", "Android_5_1", "Android_6_0", "Android_6_1", "Android_7_0", "Android_7_1", "Android"
+            "Android_7_1", "Android_7_0",
+            "Android_6_0",
+            "Android_5_1", "Android_5_0",
+            "Android_4_4",
+            "Android"
           ]
         }
       ]

--- a/resources/user-agents/apps/dalvik/dalvik-2-1.json
+++ b/resources/user-agents/apps/dalvik/dalvik-2-1.json
@@ -36,7 +36,11 @@
         {
           "match": "Dalvik/#MAJORVER#.#MINORVER#* (#PLATFORM#",
           "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3", "Android_4_4", "Android_5_0", "Android_5_1", "Android_6_0", "Android_6_1", "Android_7_0", "Android_7_1", "Android"
+            "Android_7_1", "Android_7_0",
+            "Android_6_0",
+            "Android_5_1", "Android_5_0",
+            "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
+            "Android"
           ]
         }
       ]

--- a/resources/user-agents/apps/facebook/facebook-app.json
+++ b/resources/user-agents/apps/facebook/facebook-app.json
@@ -144,7 +144,7 @@
           },
           "platforms": [
             "Android_7_0",
-            "Android_6_1", "Android_6_0"
+            "Android_6_0"
           ]
         },
         {
@@ -556,7 +556,7 @@
           "match": "Mozilla/5.0 (#PLATFORM# Build/*) applewebkit* (*khtml*like*gecko*) Version/* Chrome/* Safari/*?FB*/*;FBAV/*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4",
             "Android"

--- a/resources/user-agents/apps/facebook/facebook-messenger-app.json
+++ b/resources/user-agents/apps/facebook/facebook-messenger-app.json
@@ -108,7 +108,7 @@
           },
           "platforms": [
             "Android_7_0",
-            "Android_6_1", "Android_6_0"
+            "Android_6_0"
           ]
         },
         {
@@ -418,7 +418,7 @@
           "match": "Mozilla/5.0 (#PLATFORM# Build/*) applewebkit* (*khtml*like*gecko*) Version/* Chrome/* Safari/* ?FB_IAB/MESSENGER;FBAV/*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4",
             "Android"

--- a/resources/user-agents/apps/google/google-app.json
+++ b/resources/user-agents/apps/google/google-app.json
@@ -119,7 +119,7 @@
           "engine": "Blink",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4",
             "Android"
@@ -195,7 +195,7 @@
           "device": "general Tablet",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4",
             "Android"

--- a/resources/user-agents/apps/instagram-app/instagram-app-7-0-on.json
+++ b/resources/user-agents/apps/instagram-app/instagram-app-7-0-on.json
@@ -171,7 +171,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) version* chrome* safari* Instagram #MAJORVER#.* Android*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android"

--- a/resources/user-agents/apps/instagram-app/instagram-app-generic.json
+++ b/resources/user-agents/apps/instagram-app/instagram-app-generic.json
@@ -70,7 +70,7 @@
           "device": "general Mobile Device (Touch)",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4",
             "Android"

--- a/resources/user-agents/apps/line-app/line-app-generic.json
+++ b/resources/user-agents/apps/line-app/line-app-generic.json
@@ -83,7 +83,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) Version/* Chrome/* Safari/* Line/*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4",
             "Android"

--- a/resources/user-agents/apps/naver/naver-7-on.json
+++ b/resources/user-agents/apps/naver/naver-7-on.json
@@ -85,7 +85,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) Version/* Chrome/* Safari/* NAVER(* #MAJORVER#.#MINORVER#.*)",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4",
             "Android"

--- a/resources/user-agents/apps/naver/naver-generic.json
+++ b/resources/user-agents/apps/naver/naver-generic.json
@@ -84,7 +84,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) Version/* Chrome/* Safari/* NAVER*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4",
             "Android"

--- a/resources/user-agents/apps/password-managers/callpod-keeper.json
+++ b/resources/user-agents/apps/password-managers/callpod-keeper.json
@@ -68,7 +68,10 @@
         {
           "match": "Callpod Keeper for Android #MAJORVER#.#MINORVER#* Dalvik/* (#PLATFORM#*",
           "platforms": [
-            "Android_5_0", "Android_5_1", "Android_6_0", "Android_6_1", "Android_7_0", "Android_7_1", "Android"
+            "Android_7_1", "Android_7_0",
+            "Android_6_0",
+            "Android_5_1", "Android_5_0",
+            "Android"
           ]
         }
       ]

--- a/resources/user-agents/apps/twitter-app.json
+++ b/resources/user-agents/apps/twitter-app.json
@@ -83,7 +83,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) Version/* Chrome/* Mobile Safari/* TwitterAndroid*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4",
             "Android"
@@ -94,7 +94,7 @@
           "device": "general Tablet",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4",
             "Android"

--- a/resources/user-agents/browsers/android-webview/android-webview-4-0.json
+++ b/resources/user-agents/browsers/android-webview/android-webview-4-0.json
@@ -777,7 +777,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#)*applewebkit*(*khtml*like*gecko*)*Version/#MAJORVER#.#MINORVER#*Chrome*Safari*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android"
@@ -998,7 +998,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#)*applewebkit*(*khtml*like*gecko*)*Version/#MAJORVER#.#MINORVER#*Safari*Chrome*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android"

--- a/resources/user-agents/browsers/android-webview/android-webview-4-1-on.json
+++ b/resources/user-agents/browsers/android-webview/android-webview-4-1-on.json
@@ -59,7 +59,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#)*applewebkit*(*khtml*like*gecko*)*Version/#MAJORVER#.#MINORVER#*Chrome*Safari*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android"
@@ -69,7 +69,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#)*applewebkit*(*khtml*like*gecko*)*Version/#MAJORVER#.#MINORVER#*Safari*Chrome*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android"

--- a/resources/user-agents/browsers/android-webview/android-webview-generic.json
+++ b/resources/user-agents/browsers/android-webview/android-webview-generic.json
@@ -34,7 +34,7 @@
           "match": "*Mozilla/5.0 (#PLATFORM#) applewebkit*khtml*like*gecko*) Version/*Chrome*Safari*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android"
@@ -44,7 +44,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#)*applewebkit*(*khtml*like*gecko*)*Version/*Chrome*Safari*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android"
@@ -54,7 +54,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#)*applewebkit*(*khtml*like*gecko*)*Version/*Safari*Chrome*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android"

--- a/resources/user-agents/browsers/chrome/chrome-30-34.json
+++ b/resources/user-agents/browsers/chrome/chrome-30-34.json
@@ -904,7 +904,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) Chrome/#MAJORVER#.*Safari/*",
           "platforms": [
             "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2",
             "Android"

--- a/resources/user-agents/browsers/chrome/chrome-50-54.json
+++ b/resources/user-agents/browsers/chrome/chrome-50-54.json
@@ -784,7 +784,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) Chrome/#MAJORVER#.*Safari/*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1",
             "Android"

--- a/resources/user-agents/browsers/chrome/chrome-55-on.json
+++ b/resources/user-agents/browsers/chrome/chrome-55-on.json
@@ -849,7 +849,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#)*applewebkit* (*khtml*like*gecko*) Chrome/#MAJORVER#.*Safari/*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4",
             "Android"
@@ -859,7 +859,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) Chrome/#MAJORVER#.*Safari/*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1",
             "Android"

--- a/resources/user-agents/browsers/chrome/chrome-generic.json
+++ b/resources/user-agents/browsers/chrome/chrome-generic.json
@@ -28,7 +28,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit*(*khtml*like*gecko*) Chrome/*Safari/*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android"

--- a/resources/user-agents/browsers/cm-browser/cm-browser.json
+++ b/resources/user-agents/browsers/cm-browser/cm-browser.json
@@ -130,9 +130,10 @@
         {
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) Version/*Chrome/*Safari/* ACHEETAHI/*",
           "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3",
-            "Android_4_4", "Android_5_0", "Android_5_1", "Android_6_0",
-            "Android_6_1", "Android_7_0", "Android_7_1",
+            "Android_7_1", "Android_7_0",
+            "Android_6_0",
+            "Android_5_1", "Android_5_0",
+            "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android"
           ]
         },
@@ -253,9 +254,10 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) Version/*Safari/* ACHEETAHI/*",
           "engine": "WebKit",
           "platforms": [
-            "Android_4_0", "Android_4_1", "Android_4_2", "Android_4_3",
-            "Android_4_4", "Android_5_0", "Android_5_1", "Android_6_0",
-            "Android_6_1", "Android_7_0", "Android_7_1",
+            "Android_7_1", "Android_7_0",
+            "Android_6_0",
+            "Android_5_1", "Android_5_0",
+            "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android"
           ]
         }

--- a/resources/user-agents/browsers/maxthon/maxthon-4-1-4-3.json
+++ b/resources/user-agents/browsers/maxthon/maxthon-4-1-4-3.json
@@ -245,7 +245,7 @@
           "engine": "Blink",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4",
             "Android"

--- a/resources/user-agents/browsers/maxthon/maxthon-4-4-on.json
+++ b/resources/user-agents/browsers/maxthon/maxthon-4-4-on.json
@@ -153,7 +153,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) Version/*Chrome/*Safari/* Maxthon/#MAJORVER#.#MINORVER#*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android"
@@ -172,7 +172,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) Version/*Chrome/*Safari/* MxBrowser/#MAJORVER#.#MINORVER#*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android"

--- a/resources/user-agents/browsers/maxthon/maxthon-generic.json
+++ b/resources/user-agents/browsers/maxthon/maxthon-generic.json
@@ -50,7 +50,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) Version/*Chrome/*Safari/* Maxthon/*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android"
@@ -60,7 +60,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) Version/*Chrome/*Safari/* MxBrowser/*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android"

--- a/resources/user-agents/browsers/misc/blue-browser.json
+++ b/resources/user-agents/browsers/misc/blue-browser.json
@@ -34,7 +34,7 @@
           },
           "platforms": [
             "Android_H_7_1", "Android_H_7_0",
-            "Android_H_6_1", "Android_H_6_0"
+            "Android_H_6_0"
           ]
         },
         {
@@ -44,7 +44,7 @@
           },
           "platforms": [
             "Android_H_7_0",
-            "Android_H_6_1", "Android_H_6_0",
+            "Android_H_6_0",
             "Android_H_5_1", "Android_H_5_0"
           ]
         },
@@ -71,7 +71,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) Version/* Chrome/* Safari/* BlueBrowser/*",
           "platforms": [
             "Android_H_7_1", "Android_H_7_0",
-            "Android_H_6_1", "Android_H_6_0",
+            "Android_H_6_0",
             "Android_H_5_1", "Android_H_5_0",
             "Android_H_4_4", "Android_H_4_3", "Android_H_4_2",
             "Android"
@@ -94,7 +94,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) Version/* Chrome/* Safari/* SurfBrowser/*",
           "platforms": [
             "Android_H_7_1", "Android_H_7_0",
-            "Android_H_6_1", "Android_H_6_0",
+            "Android_H_6_0",
             "Android_H_5_1", "Android_H_5_0",
             "Android_H_4_4", "Android_H_4_3", "Android_H_4_2",
             "Android"

--- a/resources/user-agents/browsers/mobileiron/mobileiron.json
+++ b/resources/user-agents/browsers/mobileiron/mobileiron.json
@@ -40,7 +40,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) Chrome/* MobileIron/#MAJORVER#.#MINORVER#* Safari/*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4",
             "Android"

--- a/resources/user-agents/browsers/mqq-browser/mqq-browser-2-7-on.json
+++ b/resources/user-agents/browsers/mqq-browser/mqq-browser-2-7-on.json
@@ -128,7 +128,7 @@
           "engine": "Blink",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android"
           ]
@@ -146,7 +146,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*)*Version/4.0 MQQBrowser/#MAJORVER#.#MINORVER#*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android"
           ]
@@ -165,7 +165,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*)*Chrome/* MQQBrowser/#MAJORVER#.#MINORVER#*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1",
             "Android"
           ]

--- a/resources/user-agents/browsers/ntent/ntent-generic.json
+++ b/resources/user-agents/browsers/ntent/ntent-generic.json
@@ -27,7 +27,7 @@
           "engine": "Blink",
           "platforms": [
             "Android_H_7_1", "Android_H_7_0",
-            "Android_H_6_1", "Android_H_6_0",
+            "Android_H_6_0",
             "Android_H_5_1", "Android_H_5_0",
             "Android_H_4_4", "Android_H_4_3", "Android_H_4_2", "Android_H_4_1", "Android_H_4_0",
             "Android_H"
@@ -37,7 +37,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) NTENTBrowser/* Safari/*",
           "platforms": [
             "Android_H_7_1", "Android_H_7_0",
-            "Android_H_6_1", "Android_H_6_0",
+            "Android_H_6_0",
             "Android_H_5_1", "Android_H_5_0",
             "Android_H_4_4", "Android_H_4_3", "Android_H_4_2", "Android_H_4_1", "Android_H_4_0",
             "Android_H"

--- a/resources/user-agents/browsers/ntent/ntent.json
+++ b/resources/user-agents/browsers/ntent/ntent.json
@@ -74,7 +74,7 @@
           "engine": "Blink",
           "platforms": [
             "Android_H_7_1", "Android_H_7_0",
-            "Android_H_6_1", "Android_H_6_0",
+            "Android_H_6_0",
             "Android_H_5_1", "Android_H_5_0",
             "Android_H_4_4", "Android_H_4_3", "Android_H_4_2", "Android_H_4_1", "Android_H_4_0",
             "Android_H"
@@ -84,7 +84,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) NTENTBrowser/#MAJORVER#.#MINORVER#* Safari/*",
           "platforms": [
             "Android_H_7_1", "Android_H_7_0",
-            "Android_H_6_1", "Android_H_6_0",
+            "Android_H_6_0",
             "Android_H_5_1", "Android_H_5_0",
             "Android_H_4_4", "Android_H_4_3", "Android_H_4_2", "Android_H_4_1", "Android_H_4_0",
             "Android_H"

--- a/resources/user-agents/browsers/opera-mobile/opera-mobile-11-60-to-12-13.json
+++ b/resources/user-agents/browsers/opera-mobile/opera-mobile-11-60-to-12-13.json
@@ -37,7 +37,7 @@
           "platforms": [
             "AndroidLinux",
             "Android_F_7_1", "Android_F_7_0",
-            "Android_F_6_1", "Android_F_6_0",
+            "Android_F_6_0",
             "Android_F_5_1", "Android_F_5_0",
             "Android_F_4_4", "Android_F_4_3", "Android_F_4_2", "Android_F_4_1", "Android_F_4_0",
             "Android_F_2_3", "Android_F_2_2", "Android_F_2_1", "Android_F_2_0",
@@ -54,7 +54,7 @@
           "platforms": [
             "AndroidLinux",
             "Android_F_7_1", "Android_F_7_0",
-            "Android_F_6_1", "Android_F_6_0",
+            "Android_F_6_0",
             "Android_F_5_1", "Android_F_5_0",
             "Android_F_4_4", "Android_F_4_3", "Android_F_4_2", "Android_F_4_1", "Android_F_4_0",
             "Android_F_3_2", "Android_F_3_1", "Android_F_3_0",

--- a/resources/user-agents/browsers/opera-mobile/opera-mobile-14-on.json
+++ b/resources/user-agents/browsers/opera-mobile/opera-mobile-14-on.json
@@ -45,7 +45,7 @@
           },
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0"
+            "Android_6_0"
           ]
         },
         {
@@ -55,7 +55,7 @@
           },
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0"
           ]
         },
@@ -78,7 +78,7 @@
           },
           "platforms": [
             "Android_7_0",
-            "Android_6_1", "Android_6_0"
+            "Android_6_0"
           ]
         },
         {
@@ -88,7 +88,7 @@
           },
           "platforms": [
             "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0"
           ]
         },
@@ -465,7 +465,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) Chrome/*Safari/* OPR/#MAJORVER#.*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_0", "Android_6_1",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android_2_3",
@@ -483,7 +483,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) Version/* Chrome/* Safari/* OPR/#MAJORVER#.*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_0", "Android_6_1",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android"

--- a/resources/user-agents/browsers/opera-mobile/opera-mobile-generic.json
+++ b/resources/user-agents/browsers/opera-mobile/opera-mobile-generic.json
@@ -138,7 +138,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*)*Chrome/*Safari/* OPR/*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android_2_3",
@@ -217,7 +217,7 @@
           "engine": "Presto",
           "platforms": [
             "Android_F_7_1", "Android_F_7_0",
-            "Android_F_6_1", "Android_F_6_0",
+            "Android_F_6_0",
             "Android_F_5_1", "Android_F_5_0",
             "Android_F_4_4", "Android_F_4_3", "Android_F_4_2", "Android_F_4_1", "Android_F_4_0",
             "Android_F_2_3", "Android_F_2_2", "Android_F_2_1",
@@ -232,7 +232,7 @@
           "device": "general Tablet",
           "platforms": [
             "Android_F_7_1", "Android_F_7_0",
-            "Android_F_6_1", "Android_F_6_0",
+            "Android_F_6_0",
             "Android_F_5_1", "Android_F_5_0",
             "Android_F_4_4", "Android_F_4_3", "Android_F_4_2", "Android_F_4_1", "Android_F_4_0",
             "Android_F_3_2", "Android_F_3_1", "Android_F_3_0",

--- a/resources/user-agents/browsers/puffin/puffin-4-1-4-8.json
+++ b/resources/user-agents/browsers/puffin/puffin-4-1-4-8.json
@@ -81,7 +81,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) *Chrome/* Safari/* Puffin/#MAJORVER#.#MINORVER#.*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android_2_3",
@@ -93,7 +93,7 @@
           "device": "general Tablet",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android"
@@ -102,7 +102,7 @@
         {
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) *Safari/* Puffin/#MAJORVER#.#MINORVER#.* Chrome/*",
           "platforms": [
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android"
@@ -112,7 +112,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) *Safari/* Puffin/#MAJORVER#.#MINORVER#.*AT Chrome/*",
           "device": "general Tablet",
           "platforms": [
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android"

--- a/resources/user-agents/browsers/puffin/puffin-5-0-on.json
+++ b/resources/user-agents/browsers/puffin/puffin-5-0-on.json
@@ -164,7 +164,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) *Chrome/* Safari/* Puffin/#MAJORVER#.#MINORVER#.*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android"
@@ -175,7 +175,7 @@
           "device": "general Tablet",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android"
@@ -185,7 +185,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) *Safari/* Puffin/#MAJORVER#.#MINORVER#.* Chrome/*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android"

--- a/resources/user-agents/browsers/puffin/puffin-generic.json
+++ b/resources/user-agents/browsers/puffin/puffin-generic.json
@@ -27,7 +27,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) *Chrome/* Safari/* Puffin/*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android_2_3", "Android_2_2",
@@ -46,7 +46,7 @@
           "device": "general Tablet",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android"
@@ -56,7 +56,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) *Safari/* Puffin/* Chrome/*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android"

--- a/resources/user-agents/browsers/samsung/samsung-android-browser-generic.json
+++ b/resources/user-agents/browsers/samsung/samsung-android-browser-generic.json
@@ -27,7 +27,7 @@
           "match": "Mozilla/5.0 (#PLATFORM# Build/*) applewebkit* (*khtml*like*gecko*) SamsungBrowser/*Chrome*Safari*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4",
             "Android"

--- a/resources/user-agents/browsers/samsung/samsung-android-browser.json
+++ b/resources/user-agents/browsers/samsung/samsung-android-browser.json
@@ -175,7 +175,7 @@
           "match": "Mozilla/5.0 (#PLATFORM# Build/*) applewebkit* (*khtml*like*gecko*) SamsungBrowser/#MAJORVER#.#MINORVER#*Chrome*Safari*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4",
             "Android"

--- a/resources/user-agents/browsers/samsung/samsung-android-crossapp.json
+++ b/resources/user-agents/browsers/samsung/samsung-android-crossapp.json
@@ -77,7 +77,7 @@
           "match": "Mozilla/5.0 (#PLATFORM# Build/*) applewebkit* (*khtml*like*gecko*) Version*Chrome*Safari* SamsungBrowser/CrossApp/*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android"
           ]
         }

--- a/resources/user-agents/browsers/start-browser/start-browser-generic.json
+++ b/resources/user-agents/browsers/start-browser/start-browser-generic.json
@@ -40,7 +40,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) Start/* Chrome/* Safari/*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_1",
             "Android"

--- a/resources/user-agents/browsers/uc-browser/uc-web-10.json
+++ b/resources/user-agents/browsers/uc-browser/uc-web-10.json
@@ -237,7 +237,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android_2_3", "Android_2_2",
@@ -256,7 +256,7 @@
           "engine": "Blink",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4",
             "Android"
@@ -302,7 +302,7 @@
           "engine": "WebKit",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android_2_3",
@@ -401,7 +401,7 @@
           "device": "general Mobile Phone (Touch)",
           "platforms": [
             "Android_E_7_1", "Android_E_7_0",
-            "Android_E_6_1", "Android_E_6_0",
+            "Android_E_6_0",
             "Android_E_5_1", "Android_E_5_0",
             "Android_E_4_4", "Android_E_4_3", "Android_E_4_2", "Android_E_4_1", "Android_E_4_0",
             "Android_E_2_3", "Android_E_2_2", "Android_E_2_1", "Android_E_2_0",

--- a/resources/user-agents/browsers/uc-browser/uc-web-11.json
+++ b/resources/user-agents/browsers/uc-browser/uc-web-11.json
@@ -193,7 +193,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) Version/* UCBrowser/#MAJORVER#.#MINORVER#* U3/* Safari/*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android_2_3",
@@ -208,7 +208,7 @@
           },
           "platforms": [
             "Android_7_0",
-            "Android_6_1", "Android_6_0"
+            "Android_6_0"
           ]
         },
         {
@@ -227,7 +227,7 @@
           "engine": "Blink",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android"

--- a/resources/user-agents/browsers/uc-browser/uc-web-9.json
+++ b/resources/user-agents/browsers/uc-browser/uc-web-9.json
@@ -552,7 +552,7 @@
           "engine": "U2",
           "platforms": [
             "Android_E_7_0",
-            "Android_E_6_1", "Android_E_6_0",
+            "Android_E_6_0",
             "Android_E_5_1", "Android_E_5_0",
             "Android_E_4_4", "Android_E_4_3", "Android_E_4_2", "Android_E_4_1", "Android_E_4_0",
             "Android_E_2_3", "Android_E_2_2", "Android_E_2_1",

--- a/resources/user-agents/browsers/uc-browser/uc-web-generic.json
+++ b/resources/user-agents/browsers/uc-browser/uc-web-generic.json
@@ -57,7 +57,7 @@
           "engine": "U2",
           "platforms": [
             "Android_E_7_1", "Android_E_7_0",
-            "Android_E_6_1", "Android_E_6_0",
+            "Android_E_6_0",
             "Android_E_5_1", "Android_E_5_0",
             "Android_E_4_4", "Android_E_4_3", "Android_E_4_2", "Android_E_4_1", "Android_E_4_0",
             "Android_E_2_3", "Android_E_2_2", "Android_E_2_1",
@@ -135,7 +135,7 @@
           "engine": "Blink",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1",
             "Android"
@@ -146,7 +146,7 @@
           "engine": "Blink",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4",
             "Android"
@@ -157,7 +157,7 @@
           "engine": "U3",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android_2_3", "Android_2_2", "Android_2_1", "Android_2_0",

--- a/resources/user-agents/browsers/yabrowser/yabrowser-15-on.json
+++ b/resources/user-agents/browsers/yabrowser/yabrowser-15-on.json
@@ -343,7 +343,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) Chrome/* YaBrowser/#MAJORVER#.#MINORVER#* Safari/*",
           "platforms": [
             "Android_7_1", "Android_7_0",
-            "Android_6_1", "Android_6_0",
+            "Android_6_0",
             "Android_5_1", "Android_5_0",
             "Android_4_4", "Android_4_3", "Android_4_2", "Android_4_1", "Android_4_0",
             "Android"


### PR DESCRIPTION
As mentioned in #1454 there is no Android 6.1.

https://en.wikipedia.org/wiki/Android_version_history

Removing all versions of it from the resource files.

No tests covered this platform.