### PR TITLE
Aligning Brave platforms to what they support

### DIFF
--- a/resources/user-agents/browsers/brave/brave-browser-generic.json
+++ b/resources/user-agents/browsers/brave/brave-browser-generic.json
@@ -26,18 +26,18 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) brave/* Chrome/* Brave/* Safari/*",
           "device": "Windows Desktop",
           "platforms": [
-            "WinXPa_64", "WinXPa_32", "WinXPb_64", "WinXPb_32",
-            "Vista_64", "Vista_32", "Win7_x64", "Win7_64", "Win7_32",
-            "Win8_x64", "Win8_64", "Win8_32",
+            "Win10_x64", "Win10_64", "Win10_32", "Win10_x64_B", "Win10_64_B", "Win10_32_B",
             "Win8_1_x64", "Win8_1_64", "Win8_1_32",
-            "Win10_x64", "Win10_64", "Win10_32", "Win10_x64_B", "Win10_64_B", "Win10_32_B", "Windows"
+            "Win8_x64", "Win8_64", "Win8_32",
+            "Win7_x64", "Win7_64", "Win7_32",
+            "Windows"
           ]
         },
         {
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) brave/* Chrome/* Brave/* Safari/*",
           "device": "Macintosh",
           "platforms": [
-            "OSX_10_9", "OSX_10_10", "OSX_10_11",
+            "OSX_10_12", "OSX_10_11", "OSX_10_10", "OSX_10_9",
             "OSX"
           ]
         }

--- a/resources/user-agents/browsers/brave/brave-browser.json
+++ b/resources/user-agents/browsers/brave/brave-browser.json
@@ -1,6 +1,6 @@
 {
   "division": "Brave #MAJORVER#.#MINORVER#",
-  "versions": ["0.7"],
+  "versions": ["0.8", "0.7"],
   "sortIndex": 883,
   "lite": false,
   "standard": true,
@@ -30,18 +30,18 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) brave/#MAJORVER#.#MINORVER#* Chrome/* Brave/* Safari/*",
           "device": "Windows Desktop",
           "platforms": [
-            "WinXPa_64", "WinXPa_32", "WinXPb_64", "WinXPb_32",
-            "Vista_64", "Vista_32", "Win7_x64", "Win7_64", "Win7_32",
-            "Win8_x64", "Win8_64", "Win8_32",
+            "Win10_x64", "Win10_64", "Win10_32", "Win10_x64_B", "Win10_64_B", "Win10_32_B",
             "Win8_1_x64", "Win8_1_64", "Win8_1_32",
-            "Win10_x64", "Win10_64", "Win10_32", "Win10_x64_B", "Win10_64_B", "Win10_32_B", "Windows"
+            "Win8_x64", "Win8_64", "Win8_32",
+            "Win7_x64", "Win7_64", "Win7_32",
+            "Windows"
           ]
         },
         {
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) brave/#MAJORVER#.#MINORVER#* Chrome/* Brave/* Safari/*",
           "device": "Macintosh",
           "platforms": [
-            "OSX_10_9", "OSX_10_10", "OSX_10_11",
+            "OSX_10_12", "OSX_10_11", "OSX_10_10", "OSX_10_9",
             "OSX"
           ]
         }


### PR DESCRIPTION
I noticed a couple of Brave identifiers being detected as Chrome.

They were missing the first 'brave/' so I think they're just spoofed, but while I was looking at that, I noticed that there were some windows platforms here that brave doesn't support (Win7+):

https://brave.com/downloads.html

I also added `OSX_10_12` and added version `0.8`.  Apparently Brave removed their identifiers from the UA as of version `0.9`, so no need to add any newer versions to these files (https://github.com/brave/browser-laptop/blob/master/CHANGELOG.md#090).  I did download the most recent version and tested it, confirmed that there are no "Brave" identifiers in the UA.

I didn't have any tests to add for this.