### PR TITLE
Adding Opera 47

### DIFF
--- a/resources/user-agents/browsers/opera/opera-42-on.json
+++ b/resources/user-agents/browsers/opera/opera-42-on.json
@@ -1,6 +1,6 @@
 {
   "division": "Opera #MAJORVER#.#MINORVER#",
-  "versions": [46, 45, 44, 43, 42],
+  "versions": [47, 46, 45, 44, 43, 42],
   "sortIndex": 1045,
   "lite": true,
   "standard": true,


### PR DESCRIPTION
Fixes #1554.

Adding opera version 47 to desktop file.  Opera Mobile and Opera Mini aren’t at this version yet.