### PR TITLE
add integration tests for native get_browser function and browscap-php v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ jobs:
           key: composer-v1-{{ checksum "composer.json" }}
           paths:
             - vendor
+      - run: stty cols 130
       - run: vendor/bin/phpunit -c phpunit.xml.dist --no-coverage --colors --columns 117 --verbose
   php-cs-fixer:
     docker:
@@ -64,6 +65,7 @@ jobs:
           key: composer-v1-{{ checksum "composer.json" }}
           paths:
             - vendor
+      - run: stty cols 130
       - run: php -n vendor/bin/phpunit -c tests/phpunit-integration.xml.dist --no-coverage --colors --columns 121 --verbose tests/UserAgentsTest/V3/
 
   integration-tests-v4:
@@ -80,8 +82,67 @@ jobs:
           key: composer-v1-{{ checksum "composer.json" }}
           paths:
             - vendor
+      - run: stty cols 130
       - run: composer require --update-with-dependencies --prefer-dist --no-suggest browscap/browscap-php:dev-master
       - run: php -n vendor/bin/phpunit -c tests/phpunit-integration.xml.dist --no-coverage --colors --columns 121 --verbose tests/UserAgentsTest/V4/
+
+  integration-tests-v2:
+    docker:
+      - image: circleci/php:7.1
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - composer-v1-{{ checksum "composer.json" }}
+            - composer-v1-
+      - run: composer update --optimize-autoloader --prefer-dist --prefer-stable --no-progress --no-interaction --no-suggest -vv
+      - save_cache:
+          key: composer-v1-{{ checksum "composer.json" }}
+          paths:
+            - vendor
+      - run: stty cols 130
+      - run: composer require --update-with-dependencies --prefer-dist --no-suggest browscap/browscap-php:^2.1
+      - run: php -n vendor/bin/phpunit -c tests/phpunit-integration.xml.dist --no-coverage --colors --columns 121 --verbose tests/UserAgentsTest/V2/FullTest.php
+
+  integration-tests-v2-unsorted:
+    docker:
+      - image: circleci/php:7.1
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - composer-v1-{{ checksum "composer.json" }}
+            - composer-v1-
+      - run: composer update --optimize-autoloader --prefer-dist --prefer-stable --no-progress --no-interaction --no-suggest -vv
+      - save_cache:
+          key: composer-v1-{{ checksum "composer.json" }}
+          paths:
+            - vendor
+      - run: stty cols 130
+      - run: composer remove --dev browscap/browscap-php
+      - run: composer require --update-with-dependencies --prefer-dist --no-suggest mimmi20/browscap-php-unsorted:dev-master
+      - run: php -n vendor/bin/phpunit -c tests/phpunit-integration.xml.dist --no-coverage --colors --columns 121 --verbose tests/UserAgentsTest/V2/FullUnsortedTest.php
+
+  integration-tests-native:
+    docker:
+      - image: circleci/php:7.1
+    working_directory: /home/circleci/project
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - composer-v1-{{ checksum "composer.json" }}
+            - composer-v1-
+      - run: composer update --optimize-autoloader --prefer-dist --prefer-stable --no-progress --no-interaction --no-suggest -vv
+      - save_cache:
+          key: composer-v1-{{ checksum "composer.json" }}
+          paths:
+            - vendor
+      - run: stty cols 130
+      - run: php -n bin/browscap build --no-zip --coverage test
+      - run: php -n -d browscap=$CIRCLE_WORKING_DIRECTORY/build/full_php_browscap.ini vendor/bin/phpunit -c tests/phpunit-integration.xml.dist --no-coverage --colors --columns 121 --verbose tests/UserAgentsTest/Native/FullTest.php
+      - run: php -n -d browscap=$CIRCLE_WORKING_DIRECTORY/build/php_browscap.ini vendor/bin/phpunit -c tests/phpunit-integration.xml.dist --no-coverage --colors --columns 121 --verbose tests/UserAgentsTest/Native/StandardTest.php
+      - run: php -n -d browscap=$CIRCLE_WORKING_DIRECTORY/build/lite_php_browscap.ini vendor/bin/phpunit -c tests/phpunit-integration.xml.dist --no-coverage --colors --columns 121 --verbose tests/UserAgentsTest/Native/LiteTest.php
 
   validate:
     docker:
@@ -106,24 +167,54 @@ workflows:
       - validate:
           filters:
             branches:
-              only: issue-1433-5
-      - phpunit::
+              only:
+                - issue-1433-5
+                - detection-mismatches
+      - phpunit:
           filters:
             branches:
-              only: issue-1433-5
+              only:
+                - issue-1433-5
+                - detection-mismatches
       - php-cs-fixer:
           filters:
             branches:
-              only: issue-1433-5
+              only:
+                - issue-1433-5
+                - detection-mismatches
       - phpstan:
           filters:
             branches:
-              only: issue-1433-5
+              only:
+                - issue-1433-5
+                - detection-mismatches
       - integration-tests-v3:
           filters:
             branches:
-              only: issue-1433-5
+              only:
+                - issue-1433-5
+                - detection-mismatches
       - integration-tests-v4:
           filters:
             branches:
-              only: issue-1433-5
+              only:
+                - issue-1433-5
+                - detection-mismatches
+      - integration-tests-v2:
+          filters:
+            branches:
+              only:
+                - issue-1433-5
+                - detection-mismatches
+      - integration-tests-native:
+          filters:
+            branches:
+              only:
+                - issue-1433-5
+                - detection-mismatches
+      - integration-tests-v2-unsorted:
+          filters:
+            branches:
+              only:
+                - issue-1433-5
+                - detection-mismatches

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,21 @@ jobs:
   fast_finish: true
   allow_failures:
     - php: nightly
+    - env:
+        - parser="native"
+        - TEST_SET="full"
+    - env:
+        - parser="native"
+        - TEST_SET="standard"
+    - env:
+        - parser="native"
+        - TEST_SET="lite"
+    - env:
+        - parser="browscap-php 2.x"
+        - TEST_SET="full"
+    - env:
+        - parser="browscap-php 2.x (unsorted)"
+        - TEST_SET="full"
   include:
     - php: nightly
       env: COMPOSER_FLAGS="--ignore-platform-reqs"
@@ -76,6 +91,7 @@ jobs:
         - travis_retry composer update --optimize-autoloader --prefer-dist --prefer-stable --no-progress --no-interaction -vv $COMPOSER_FLAGS
         - travis_retry composer require --update-with-dependencies --prefer-dist --no-suggest browscap/browscap-php:dev-master
       script: php -n vendor/bin/phpunit -c tests/phpunit-integration.xml.dist --no-coverage --colors --columns 121 --verbose tests/UserAgentsTest/V4/FullTest.php
+      after_success: bash <(curl -s https://codecov.io/bash) -f coverage-full4.json -F full,v4
 
     - stage: integration tests
       php: 7.1
@@ -86,6 +102,7 @@ jobs:
         - travis_retry composer update --optimize-autoloader --prefer-dist --prefer-stable --no-progress --no-interaction -vv $COMPOSER_FLAGS
         - travis_retry composer require --update-with-dependencies --prefer-dist --no-suggest browscap/browscap-php:dev-master
       script: php -n vendor/bin/phpunit -c tests/phpunit-integration.xml.dist --no-coverage --colors --columns 121 --verbose tests/UserAgentsTest/V4/StandardTest.php
+      after_success: bash <(curl -s https://codecov.io/bash) -f coverage-standard4.json -F standard,v4
 
     - stage: integration tests
       php: 7.1
@@ -96,6 +113,7 @@ jobs:
         - travis_retry composer update --optimize-autoloader --prefer-dist --prefer-stable --no-progress --no-interaction -vv $COMPOSER_FLAGS
         - travis_retry composer require --update-with-dependencies --prefer-dist --no-suggest browscap/browscap-php:dev-master
       script: php -n vendor/bin/phpunit -c tests/phpunit-integration.xml.dist --no-coverage --colors --columns 119 --verbose tests/UserAgentsTest/V4/LiteTest.php
+      after_success: bash <(curl -s https://codecov.io/bash) -f coverage-lite4.json -F lite,v4
 
     - stage: integration tests
       php: 7.1
@@ -103,7 +121,7 @@ jobs:
         - parser="browscap-php 3.1"
         - TEST_SET="full"
       script: php -n vendor/bin/phpunit -c tests/phpunit-integration.xml.dist --no-coverage --colors --columns 121 --verbose tests/UserAgentsTest/V3/FullTest.php
-      after_success: bash <(curl -s https://codecov.io/bash) -f coverage-full3.json -F full
+      after_success: bash <(curl -s https://codecov.io/bash) -f coverage-full3.json -F full,v3
 
     - stage: integration tests
       php: 7.1
@@ -111,7 +129,7 @@ jobs:
         - parser="browscap-php 3.1"
         - TEST_SET="standard"
       script: php -n vendor/bin/phpunit -c tests/phpunit-integration.xml.dist --no-coverage --colors --columns 121 --verbose tests/UserAgentsTest/V3/StandardTest.php
-      after_success: bash <(curl -s https://codecov.io/bash) -f coverage-standard3.json -F standard
+      after_success: bash <(curl -s https://codecov.io/bash) -f coverage-standard3.json -F standard,v3
 
     - stage: integration tests
       php: 7.1
@@ -119,4 +137,59 @@ jobs:
         - parser="browscap-php 3.1"
         - TEST_SET="lite"
       script: php -n vendor/bin/phpunit -c tests/phpunit-integration.xml.dist --no-coverage --colors --columns 119 --verbose tests/UserAgentsTest/V3/LiteTest.php
-      after_success: bash <(curl -s https://codecov.io/bash) -f coverage-lite3.json -F lite
+      after_success: bash <(curl -s https://codecov.io/bash) -f coverage-lite3.json -F lite,v3
+
+    - stage: integration tests
+      php: 7.1
+      env:
+        - parser="native"
+        - TEST_SET="full"
+      before_script: php -n bin/browscap build --no-zip --coverage test
+      script: php -n -d browscap=$TRAVIS_BUILD_DIR/build/full_php_browscap.ini vendor/bin/phpunit -c tests/phpunit-integration.xml.dist --no-coverage --colors --columns 121 --verbose tests/UserAgentsTest/Native/FullTest.php
+      after_success:
+        - bash <(curl -s https://codecov.io/bash) -f coverage-full-native.json -F full,native
+
+    - stage: integration tests
+      php: 7.1
+      env:
+        - parser="native"
+        - TEST_SET="standard"
+      before_script: php -n bin/browscap build --no-zip --coverage test
+      script: php -n -d browscap=$TRAVIS_BUILD_DIR/build/php_browscap.ini vendor/bin/phpunit -c tests/phpunit-integration.xml.dist --no-coverage --colors --columns 121 --verbose tests/UserAgentsTest/Native/StandardTest.php
+      after_success:
+        - bash <(curl -s https://codecov.io/bash) -f coverage-standard-native.json -F standard,native
+
+    - stage: integration tests
+      php: 7.1
+      env:
+        - parser="native"
+        - TEST_SET="lite"
+      before_script: php -n bin/browscap build --no-zip --coverage test
+      script: php -n -d browscap=$TRAVIS_BUILD_DIR/build/lite_php_browscap.ini vendor/bin/phpunit -c tests/phpunit-integration.xml.dist --no-coverage --colors --columns 121 --verbose tests/UserAgentsTest/Native/LiteTest.php
+      after_success:
+        - bash <(curl -s https://codecov.io/bash) -f coverage-lite-native.json -F lite,native
+
+    - stage: integration tests
+      php: 7.1
+      env:
+        - parser="browscap-php 2.x"
+        - TEST_SET="full"
+      install:
+        - travis_retry composer update --optimize-autoloader --prefer-dist --prefer-stable --no-progress --no-interaction -vv $COMPOSER_FLAGS
+        - travis_retry composer require --update-with-dependencies --prefer-dist --no-suggest browscap/browscap-php:^2.1
+      script: php -n vendor/bin/phpunit -c tests/phpunit-integration.xml.dist --no-coverage --colors --columns 121 --verbose tests/UserAgentsTest/V2/FullTest.php
+      after_success:
+        - bash <(curl -s https://codecov.io/bash) -f coverage-full2.json -F full,v2
+
+    - stage: integration tests
+      php: 7.1
+      env:
+        - parser="browscap-php 2.x (unsorted)"
+        - TEST_SET="full"
+      install:
+        - travis_retry composer remove --dev browscap/browscap-php
+        - travis_retry composer update --optimize-autoloader --prefer-dist --prefer-stable --no-progress --no-interaction -vv $COMPOSER_FLAGS
+        - travis_retry composer require --update-with-dependencies --prefer-dist --no-suggest mimmi20/browscap-php-unsorted:dev-master
+      script: php -n vendor/bin/phpunit -c tests/phpunit-integration.xml.dist --no-coverage --colors --columns 121 --verbose tests/UserAgentsTest/V2/FullUnsortedTest.php
+#      after_success:
+#        - bash <(curl -s https://codecov.io/bash) -f coverage-full2.json -F full,v2

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,7 @@
 parameters:
   excludes_analyse:
     - */tests/*/data/*
+    - */V2/*Test.php
     - */V4/*Test.php
   ignoreErrors:
     - '~Parameter #2 \$sort_order of function array_multisort is passed by reference, so it expects variables only.~'

--- a/tests/UserAgentsTest/Native/FullTest.php
+++ b/tests/UserAgentsTest/Native/FullTest.php
@@ -1,0 +1,195 @@
+<?php
+declare(strict_types = 1);
+namespace UserAgentsTest\Native;
+
+use Browscap\Coverage\Processor;
+use Browscap\Data\PropertyHolder;
+use Browscap\Filter\FullFilter;
+use Browscap\Formatter\PhpFormatter;
+use Browscap\Helper\IteratorHelper;
+use Browscap\Writer\IniWriter;
+use BrowscapPHP\Browscap;
+use BrowscapPHP\BrowscapUpdater;
+use BrowscapPHP\Formatter\LegacyFormatter;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use WurflCache\Adapter\File;
+
+class FullTest extends TestCase
+{
+    /**
+     * @var \BrowscapPHP\Browscap
+     */
+    private static $browscap;
+
+    /**
+     * @var \BrowscapPHP\BrowscapUpdater
+     */
+    private static $browscapUpdater;
+
+    /**
+     * @var \Browscap\Data\PropertyHolder
+     */
+    private static $propertyHolder;
+
+    /**
+     * @var string[]
+     */
+    private static $coveredPatterns = [];
+
+    /**
+     * @var \Browscap\Filter\FilterInterface
+     */
+    private static $filter;
+
+    /**
+     * @var \Browscap\Writer\WriterInterface
+     */
+    private static $writer;
+
+    /**
+     * @throws \BrowscapPHP\Exception
+     */
+    public static function setUpBeforeClass() : void
+    {
+        $objectIniPath = ini_get('browscap');
+
+        echo 'using browscap.ini file: ', $objectIniPath, PHP_EOL;
+
+        if (!is_file($objectIniPath)) {
+            self::markTestSkipped('browscap not defined in php.ini');
+        }
+
+        $buildFolder = __DIR__ . '/../../../build/build/';
+        $cacheFolder = __DIR__ . '/../../../build/cache/';
+
+        // create build folder if it does not exist
+        if (!file_exists($buildFolder)) {
+            mkdir($buildFolder, 0777, true);
+        }
+        if (!file_exists($cacheFolder)) {
+            mkdir($cacheFolder, 0777, true);
+        }
+
+        $logger = new NullLogger();
+
+        self::$propertyHolder = new PropertyHolder();
+        self::$filter         = new FullFilter(self::$propertyHolder);
+        self::$writer         = new IniWriter($buildFolder . '/full_php_browscap.ini', $logger);
+        $formatter            = new PhpFormatter(self::$propertyHolder);
+        self::$writer->setFormatter($formatter);
+        self::$writer->setFilter(self::$filter);
+
+        $cache = new File([File::DIR => $cacheFolder]);
+        $cache->flush();
+
+        $resultFormatter = new LegacyFormatter(['lowercase' => true]);
+
+        self::$browscap = new Browscap();
+        self::$browscap
+            ->setCache($cache)
+            ->setLogger($logger)
+            ->setFormatter($resultFormatter);
+
+        self::$browscapUpdater = new BrowscapUpdater();
+        self::$browscapUpdater
+            ->setCache($cache)
+            ->setLogger($logger)
+            ->convertFile($objectIniPath);
+    }
+
+    /**
+     * Runs after the entire test suite is run.  Generates a coverage report for JSON resource files if
+     * the $coveredPatterns array isn't empty
+     */
+    public static function tearDownAfterClass() : void
+    {
+        if (!empty(self::$coveredPatterns)) {
+            $coverageProcessor = new Processor(__DIR__ . '/../../../resources/user-agents/');
+            $coverageProcessor->process(self::$coveredPatterns);
+            $coverageProcessor->write(__DIR__ . '/../../../coverage-full-native.json');
+        }
+    }
+
+    /**
+     * @return array[]
+     */
+    public function userAgentDataProvider() : array
+    {
+        [$data, $errors] = (new IteratorHelper())->getTestFiles(new NullLogger(), 'full');
+
+        if (!empty($errors)) {
+            throw new \RuntimeException(
+                'Errors occured while collecting test files' . PHP_EOL . implode(PHP_EOL, $errors)
+            );
+        }
+
+        return $data;
+    }
+
+    /**
+     * @dataProvider userAgentDataProvider
+     * @coversNothing
+     *
+     * @param string $userAgent
+     * @param array  $expectedProperties
+     *
+     * @throws \Exception
+     * @throws \BrowscapPHP\Exception
+     */
+    public function testUserAgents(string $userAgent, array $expectedProperties) : void
+    {
+        if (!count($expectedProperties)) {
+            self::markTestSkipped('Could not run test - no properties were defined to test');
+        }
+
+        $bcResult  = self::$browscap->getBrowser($userAgent);
+        $libResult = (object) get_browser($userAgent, false);
+
+        if (isset($libResult->{'PatternId'})) {
+            self::$coveredPatterns[] = $libResult->{'PatternId'};
+        }
+
+        foreach (array_keys($expectedProperties) as $propName) {
+            if (!self::$filter->isOutputProperty($propName, self::$writer)) {
+                continue;
+            }
+
+            self::assertFalse(
+                self::$propertyHolder->isDeprecatedProperty($propName),
+                'Actual result expects to test for deprecated property "' . $propName . '"'
+            );
+
+            $expectedValue = (string) $expectedProperties[$propName];
+            $propName      = mb_strtolower($propName);
+
+            self::assertObjectHasAttribute(
+                $propName,
+                $libResult,
+                'Actual native result does not have "' . $propName . '" property'
+            );
+
+            self::assertObjectHasAttribute(
+                $propName,
+                $bcResult,
+                'Actual browscap result does not have "' . $propName . '" property'
+            );
+
+            $libValue = (string) $libResult->{$propName};
+            $message  = 'Expected actual "' . $propName . '" to be "' . $expectedValue . '" '
+                . '(was "' . $libValue . '") [native]' . PHP_EOL
+                . '(Full Result: "' . var_export($libResult, true) . '")' . PHP_EOL;
+
+            if (null !== $bcResult->browser_name_pattern && null !== $libResult->browser_name_pattern) {
+                $message .= 'expected pattern [\BrowscapPHP\Browscap::getBrowser()]:' . mb_strtolower($bcResult->browser_name_pattern) . PHP_EOL
+                    . 'used pattern [get_browser]:                            ' . mb_strtolower($libResult->browser_name_pattern) . PHP_EOL;
+            }
+
+            self::assertSame(
+                $expectedValue,
+                $libValue,
+                $message
+            );
+        }
+    }
+}

--- a/tests/UserAgentsTest/Native/LiteTest.php
+++ b/tests/UserAgentsTest/Native/LiteTest.php
@@ -1,0 +1,211 @@
+<?php
+declare(strict_types = 1);
+namespace UserAgentsTest\Native;
+
+use Browscap\Coverage\Processor;
+use Browscap\Data\PropertyHolder;
+use Browscap\Filter\LiteFilter;
+use Browscap\Formatter\PhpFormatter;
+use Browscap\Helper\IteratorHelper;
+use Browscap\Writer\IniWriter;
+use BrowscapPHP\Browscap;
+use BrowscapPHP\BrowscapUpdater;
+use BrowscapPHP\Formatter\LegacyFormatter;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use WurflCache\Adapter\File;
+
+class LiteTest extends TestCase
+{
+    /**
+     * @var \BrowscapPHP\Browscap
+     */
+    private static $browscap;
+
+    /**
+     * @var \BrowscapPHP\BrowscapUpdater
+     */
+    private static $browscapUpdater;
+
+    /**
+     * @var \Browscap\Data\PropertyHolder
+     */
+    private static $propertyHolder;
+
+    /**
+     * @var string[]
+     */
+    private static $coveredPatterns = [];
+
+    /**
+     * @var \Browscap\Filter\FilterInterface
+     */
+    private static $filter;
+
+    /**
+     * @var \Browscap\Writer\WriterInterface
+     */
+    private static $writer;
+
+    /**
+     * @throws \BrowscapPHP\Exception
+     */
+    public static function setUpBeforeClass() : void
+    {
+        $objectIniPath = ini_get('browscap');
+
+        echo 'using browscap.ini file: ', $objectIniPath, PHP_EOL;
+
+        if (!is_file($objectIniPath)) {
+            self::markTestSkipped('browscap not defined in php.ini');
+        }
+
+        $buildFolder = __DIR__ . '/../../../build/build/';
+        $cacheFolder = __DIR__ . '/../../../build/cache/';
+
+        // create build folder if it does not exist
+        if (!file_exists($buildFolder)) {
+            mkdir($buildFolder, 0777, true);
+        }
+        if (!file_exists($cacheFolder)) {
+            mkdir($cacheFolder, 0777, true);
+        }
+
+        $logger = new NullLogger();
+
+        self::$propertyHolder = new PropertyHolder();
+        self::$filter         = new LiteFilter(self::$propertyHolder);
+        self::$writer         = new IniWriter($buildFolder . '/lite_php_browscap.ini', $logger);
+        $formatter            = new PhpFormatter(self::$propertyHolder);
+        self::$writer->setFormatter($formatter);
+        self::$writer->setFilter(self::$filter);
+
+        $cache = new File([File::DIR => $cacheFolder]);
+        $cache->flush();
+
+        $resultFormatter = new LegacyFormatter(['lowercase' => true]);
+
+        self::$browscap = new Browscap();
+        self::$browscap
+            ->setCache($cache)
+            ->setLogger($logger)
+            ->setFormatter($resultFormatter);
+
+        self::$browscapUpdater = new BrowscapUpdater();
+        self::$browscapUpdater
+            ->setCache($cache)
+            ->setLogger($logger)
+            ->convertFile($objectIniPath);
+    }
+
+    /**
+     * Runs after the entire test suite is run.  Generates a coverage report for JSON resource files if
+     * the $coveredPatterns array isn't empty
+     */
+    public static function tearDownAfterClass() : void
+    {
+        if (!empty(self::$coveredPatterns)) {
+            $coverageProcessor = new Processor(__DIR__ . '/../../../resources/user-agents/');
+            $coverageProcessor->process(self::$coveredPatterns);
+            $coverageProcessor->write(__DIR__ . '/../../../coverage-lite-native.json');
+        }
+    }
+
+    /**
+     * @return array[]
+     */
+    public function userAgentDataProvider() : array
+    {
+        [$data, $errors] = (new IteratorHelper())->getTestFiles(new NullLogger(), 'lite');
+
+        if (!empty($errors)) {
+            throw new \RuntimeException(
+                'Errors occured while collecting test files' . PHP_EOL . implode(PHP_EOL, $errors)
+            );
+        }
+
+        return $data;
+    }
+
+    /**
+     * @dataProvider userAgentDataProvider
+     * @coversNothing
+     *
+     * @param string $userAgent
+     * @param array  $expectedProperties
+     *
+     * @throws \Exception
+     * @throws \BrowscapPHP\Exception
+     */
+    public function testUserAgents(string $userAgent, array $expectedProperties) : void
+    {
+        if (!count($expectedProperties)) {
+            self::markTestSkipped('Could not run test - no properties were defined to test');
+        }
+
+        $bcResult  = self::$browscap->getBrowser($userAgent);
+        $libResult = (object) get_browser($userAgent, false);
+
+        if (isset($libResult->{'PatternId'})) {
+            self::$coveredPatterns[] = $libResult->{'PatternId'};
+        }
+
+        foreach (array_keys($expectedProperties) as $propName) {
+            if (!self::$filter->isOutputProperty($propName, self::$writer)) {
+                continue;
+            }
+
+            self::assertFalse(
+                self::$propertyHolder->isDeprecatedProperty($propName),
+                'Actual result expects to test for deprecated property "' . $propName . '"'
+            );
+
+            $expectedValue = (string) $expectedProperties[$propName];
+            $propName      = mb_strtolower($propName);
+
+            self::assertObjectHasAttribute(
+                $propName,
+                $libResult,
+                'Actual library result does not have "' . $propName . '" property'
+            );
+
+            self::assertObjectHasAttribute(
+                $propName,
+                $bcResult,
+                'Actual browscap result does not have "' . $propName . '" property'
+            );
+
+            $libValue = (string) $libResult->{$propName};
+            $message  = 'Expected actual "' . $propName . '" to be "' . $expectedValue . '" '
+                . '(was "' . $libValue . '")' . PHP_EOL
+                . '(Full Result: "' . var_export($libResult, true) . '")' . PHP_EOL;
+
+            if (null !== $bcResult->browser_name_pattern && null !== $libResult->browser_name_pattern) {
+                $message .= 'expected pattern [\BrowscapPHP\Browscap::getBrowser()]:' . mb_strtolower($bcResult->browser_name_pattern) . PHP_EOL
+                    . 'used pattern [get_browser]:                            ' . mb_strtolower($libResult->browser_name_pattern) . PHP_EOL;
+            }
+
+            self::assertSame(
+                $expectedValue,
+                $libValue,
+                $message
+            );
+
+            $bcValue = (string) $bcResult->{$propName};
+            $message = 'Expected actual "' . $propName . '" to be "' . $bcValue . '" '
+                . '(was "' . $libValue . '")' . PHP_EOL
+                . '(Full Result: "' . var_export($libResult, true) . '")' . PHP_EOL;
+
+            if (null !== $bcResult->browser_name_pattern && null !== $libResult->browser_name_pattern) {
+                $message .= 'expected pattern [\BrowscapPHP\Browscap::getBrowser()]:' . mb_strtolower($bcResult->browser_name_pattern) . PHP_EOL
+                    . 'used pattern [get_browser]:                            ' . mb_strtolower($libResult->browser_name_pattern) . PHP_EOL;
+            }
+
+            self::assertSame(
+                $bcValue,
+                $libValue,
+                $message
+            );
+        }
+    }
+}

--- a/tests/UserAgentsTest/Native/StandardTest.php
+++ b/tests/UserAgentsTest/Native/StandardTest.php
@@ -1,0 +1,211 @@
+<?php
+declare(strict_types = 1);
+namespace UserAgentsTest\Native;
+
+use Browscap\Coverage\Processor;
+use Browscap\Data\PropertyHolder;
+use Browscap\Filter\StandardFilter;
+use Browscap\Formatter\PhpFormatter;
+use Browscap\Helper\IteratorHelper;
+use Browscap\Writer\IniWriter;
+use BrowscapPHP\Browscap;
+use BrowscapPHP\BrowscapUpdater;
+use BrowscapPHP\Formatter\LegacyFormatter;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use WurflCache\Adapter\File;
+
+class StandardTest extends TestCase
+{
+    /**
+     * @var \BrowscapPHP\Browscap
+     */
+    private static $browscap;
+
+    /**
+     * @var \BrowscapPHP\BrowscapUpdater
+     */
+    private static $browscapUpdater;
+
+    /**
+     * @var \Browscap\Data\PropertyHolder
+     */
+    private static $propertyHolder;
+
+    /**
+     * @var string[]
+     */
+    private static $coveredPatterns = [];
+
+    /**
+     * @var \Browscap\Filter\FilterInterface
+     */
+    private static $filter;
+
+    /**
+     * @var \Browscap\Writer\WriterInterface
+     */
+    private static $writer;
+
+    /**
+     * @throws \BrowscapPHP\Exception
+     */
+    public static function setUpBeforeClass() : void
+    {
+        $objectIniPath = ini_get('browscap');
+
+        echo 'using browscap.ini file: ', $objectIniPath, PHP_EOL;
+
+        if (!is_file($objectIniPath)) {
+            self::markTestSkipped('browscap not defined in php.ini');
+        }
+
+        $buildFolder = __DIR__ . '/../../../build/build/';
+        $cacheFolder = __DIR__ . '/../../../build/cache/';
+
+        // create build folder if it does not exist
+        if (!file_exists($buildFolder)) {
+            mkdir($buildFolder, 0777, true);
+        }
+        if (!file_exists($cacheFolder)) {
+            mkdir($cacheFolder, 0777, true);
+        }
+
+        $logger = new NullLogger();
+
+        self::$propertyHolder = new PropertyHolder();
+        self::$filter         = new StandardFilter(self::$propertyHolder);
+        self::$writer         = new IniWriter($buildFolder . '/php_browscap.ini', $logger);
+        $formatter            = new PhpFormatter(self::$propertyHolder);
+        self::$writer->setFormatter($formatter);
+        self::$writer->setFilter(self::$filter);
+
+        $cache = new File([File::DIR => $cacheFolder]);
+        $cache->flush();
+
+        $resultFormatter = new LegacyFormatter(['lowercase' => true]);
+
+        self::$browscap = new Browscap();
+        self::$browscap
+            ->setCache($cache)
+            ->setLogger($logger)
+            ->setFormatter($resultFormatter);
+
+        self::$browscapUpdater = new BrowscapUpdater();
+        self::$browscapUpdater
+            ->setCache($cache)
+            ->setLogger($logger)
+            ->convertFile($objectIniPath);
+    }
+
+    /**
+     * Runs after the entire test suite is run.  Generates a coverage report for JSON resource files if
+     * the $coveredPatterns array isn't empty
+     */
+    public static function tearDownAfterClass() : void
+    {
+        if (!empty(self::$coveredPatterns)) {
+            $coverageProcessor = new Processor(__DIR__ . '/../../../resources/user-agents/');
+            $coverageProcessor->process(self::$coveredPatterns);
+            $coverageProcessor->write(__DIR__ . '/../../../coverage-standard-native.json');
+        }
+    }
+
+    /**
+     * @return array[]
+     */
+    public function userAgentDataProvider() : array
+    {
+        [$data, $errors] = (new IteratorHelper())->getTestFiles(new NullLogger(), 'standard');
+
+        if (!empty($errors)) {
+            throw new \RuntimeException(
+                'Errors occured while collecting test files' . PHP_EOL . implode(PHP_EOL, $errors)
+            );
+        }
+
+        return $data;
+    }
+
+    /**
+     * @dataProvider userAgentDataProvider
+     * @coversNothing
+     *
+     * @param string $userAgent
+     * @param array  $expectedProperties
+     *
+     * @throws \Exception
+     * @throws \BrowscapPHP\Exception
+     */
+    public function testUserAgents(string $userAgent, array $expectedProperties) : void
+    {
+        if (!count($expectedProperties)) {
+            self::markTestSkipped('Could not run test - no properties were defined to test');
+        }
+
+        $bcResult  = self::$browscap->getBrowser($userAgent);
+        $libResult = (object) get_browser($userAgent, false);
+
+        if (isset($libResult->{'PatternId'})) {
+            self::$coveredPatterns[] = $libResult->{'PatternId'};
+        }
+
+        foreach (array_keys($expectedProperties) as $propName) {
+            if (!self::$filter->isOutputProperty($propName, self::$writer)) {
+                continue;
+            }
+
+            self::assertFalse(
+                self::$propertyHolder->isDeprecatedProperty($propName),
+                'Actual result expects to test for deprecated property "' . $propName . '"'
+            );
+
+            $expectedValue = (string) $expectedProperties[$propName];
+            $propName      = mb_strtolower($propName);
+
+            self::assertObjectHasAttribute(
+                $propName,
+                $libResult,
+                'Actual library result does not have "' . $propName . '" property'
+            );
+
+            self::assertObjectHasAttribute(
+                $propName,
+                $bcResult,
+                'Actual browscap result does not have "' . $propName . '" property'
+            );
+
+            $libValue = (string) $libResult->{$propName};
+            $message  = 'Expected actual "' . $propName . '" to be "' . $expectedValue . '" '
+                . '(was "' . $libValue . '")' . PHP_EOL
+                . '(Full Result: "' . var_export($libResult, true) . '")' . PHP_EOL;
+
+            if (null !== $bcResult->browser_name_pattern && null !== $libResult->browser_name_pattern) {
+                $message .= 'expected pattern [\BrowscapPHP\Browscap::getBrowser()]:' . mb_strtolower($bcResult->browser_name_pattern) . PHP_EOL
+                    . 'used pattern [get_browser]:                            ' . mb_strtolower($libResult->browser_name_pattern) . PHP_EOL;
+            }
+
+            self::assertSame(
+                $expectedValue,
+                $libValue,
+                $message
+            );
+
+            $bcValue = (string) $bcResult->{$propName};
+            $message = 'Expected actual "' . $propName . '" to be "' . $bcValue . '" '
+                . '(was "' . $libValue . '")' . PHP_EOL
+                . '(Full Result: "' . var_export($libResult, true) . '")' . PHP_EOL;
+
+            if (null !== $bcResult->browser_name_pattern && null !== $libResult->browser_name_pattern) {
+                $message .= 'expected pattern [\BrowscapPHP\Browscap::getBrowser()]:' . mb_strtolower($bcResult->browser_name_pattern) . PHP_EOL
+                    . 'used pattern [get_browser]:                            ' . mb_strtolower($libResult->browser_name_pattern) . PHP_EOL;
+            }
+
+            self::assertSame(
+                $bcValue,
+                $libValue,
+                $message
+            );
+        }
+    }
+}

--- a/tests/UserAgentsTest/V2/FullTest.php
+++ b/tests/UserAgentsTest/V2/FullTest.php
@@ -1,0 +1,181 @@
+<?php
+declare(strict_types = 1);
+namespace UserAgentsTest\V2;
+
+use Browscap\Coverage\Processor;
+use Browscap\Data\Factory\DataCollectionFactory;
+use Browscap\Data\PropertyHolder;
+use Browscap\Filter\FullFilter;
+use Browscap\Formatter\PhpFormatter;
+use Browscap\Generator\BuildGenerator;
+use Browscap\Helper\IteratorHelper;
+use Browscap\Writer\IniWriter;
+use Browscap\Writer\WriterCollection;
+use phpbrowscap\Browscap;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class FullTest extends TestCase
+{
+    /**
+     * @var \phpbrowscap\Browscap
+     */
+    private static $browscap = null;
+
+    /**
+     * @var string
+     */
+    private static $buildFolder = null;
+
+    /**
+     * @var \Browscap\Data\PropertyHolder
+     */
+    private static $propertyHolder;
+
+    /**
+     * @var string[]
+     */
+    private static $coveredPatterns = [];
+
+    /**
+     * @var \Browscap\Filter\FilterInterface
+     */
+    private static $filter;
+
+    /**
+     * @var \Browscap\Writer\WriterInterface
+     */
+    private static $writer;
+
+    public static function setUpBeforeClass() : void
+    {
+        // First, generate the INI files
+        $buildNumber    = time();
+        $resourceFolder = __DIR__ . '/../../../resources/';
+        $buildFolder    = __DIR__ . '/../../../build/browscap-ua-test-full2-';
+        $cacheFolder    = __DIR__ . '/../../../build/browscap-ua-test-full2-' . $buildNumber . '/cache/';
+
+        // create build folder if it does not exist
+        if (!file_exists($buildFolder)) {
+            mkdir($buildFolder, 0777, true);
+        }
+        if (!file_exists($cacheFolder)) {
+            mkdir($cacheFolder, 0777, true);
+        }
+
+        $version = (string) $buildNumber;
+
+        $logger               = new NullLogger();
+        $writerCollection     = new WriterCollection();
+        self::$propertyHolder = new PropertyHolder();
+        self::$filter         = new FullFilter(self::$propertyHolder);
+        self::$writer         = new IniWriter($buildFolder . '/full_php_browscap.ini', $logger);
+        $formatter            = new PhpFormatter(self::$propertyHolder);
+        self::$writer->setFormatter($formatter);
+        self::$writer->setFilter(self::$filter);
+        $writerCollection->addWriter(self::$writer);
+
+        $dataCollectionFactory = new DataCollectionFactory($logger);
+
+        $buildGenerator = new BuildGenerator(
+            $resourceFolder,
+            $buildFolder,
+            $logger,
+            $writerCollection,
+            $dataCollectionFactory
+        );
+
+        $buildGenerator->setCollectPatternIds(true);
+        $buildGenerator->run($version, false);
+
+        // Now, load an INI file into phpbrowscap\Browscap for testing the UAs
+        self::$browscap            = new Browscap($cacheFolder);
+        self::$browscap->lowercase = true;
+        self::$browscap->localFile = $buildFolder . '/full_php_browscap.ini';
+        self::$browscap->updateCache();
+
+        self::$propertyHolder = new PropertyHolder();
+    }
+
+    /**
+     * Runs after the entire test suite is run.  Generates a coverage report for JSON resource files if
+     * the $coveredPatterns array isn't empty
+     */
+    public static function tearDownAfterClass() : void
+    {
+        if (!empty(self::$coveredPatterns)) {
+            $coverageProcessor = new Processor(__DIR__ . '/../../../resources/user-agents/');
+            $coverageProcessor->process(self::$coveredPatterns);
+            $coverageProcessor->write(__DIR__ . '/../../../coverage-full2.json');
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function userAgentDataProvider() : array
+    {
+        [$data, $errors] = (new IteratorHelper())->getTestFiles(new NullLogger(), 'full');
+
+        if (!empty($errors)) {
+            throw new \RuntimeException(
+                'Errors occured while collecting test files' . PHP_EOL . implode(PHP_EOL, $errors)
+            );
+        }
+
+        return $data;
+    }
+
+    /**
+     * @dataProvider userAgentDataProvider
+     * @coversNothing
+     *
+     * @param string $userAgent
+     * @param array  $expectedProperties
+     *
+     * @throws \Exception
+     */
+    public function testUserAgents(string $userAgent, array $expectedProperties) : void
+    {
+        if (!count($expectedProperties)) {
+            self::markTestSkipped('Could not run test - no properties were defined to test');
+        }
+
+        $actualProps = self::$browscap->getBrowser($userAgent, true);
+
+        if (isset($actualProps['PatternId'])) {
+            self::$coveredPatterns[] = $actualProps['PatternId'];
+        }
+
+        foreach (array_keys($expectedProperties) as $propName) {
+            if (!self::$filter->isOutputProperty($propName, self::$writer)) {
+                continue;
+            }
+
+            self::assertFalse(
+                self::$propertyHolder->isDeprecatedProperty($propName),
+                'Actual result expects to test for deprecated property "' . $propName . '"'
+            );
+
+            $expectedValue = $expectedProperties[$propName];
+            $propName      = mb_strtolower($propName);
+
+            self::assertArrayHasKey(
+                $propName,
+                $actualProps,
+                'Actual result does not have "' . $propName . '" property'
+            );
+
+            $libValue = $actualProps[$propName];
+            $message  = 'Expected actual "' . $propName . '" to be "' . $expectedValue . '" '
+                . '(was "' . $libValue . '")' . PHP_EOL
+                . '(Full Result: "' . var_export($actualProps, true) . '")' . PHP_EOL;
+
+            self::assertSame(
+                $expectedValue,
+                $libValue,
+                $message
+            );
+        }
+    }
+}

--- a/tests/UserAgentsTest/V2/FullUnsortedTest.php
+++ b/tests/UserAgentsTest/V2/FullUnsortedTest.php
@@ -1,0 +1,176 @@
+<?php
+declare(strict_types = 1);
+namespace UserAgentsTest\V2;
+
+use Browscap\Coverage\Processor;
+use Browscap\Data\Factory\DataCollectionFactory;
+use Browscap\Data\PropertyHolder;
+use Browscap\Filter\FullFilter;
+use Browscap\Formatter\PhpFormatter;
+use Browscap\Generator\BuildGenerator;
+use Browscap\Helper\IteratorHelper;
+use Browscap\Writer\IniWriter;
+use Browscap\Writer\WriterCollection;
+use phpbrowscap\Browscap;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class FullUnsortedTest extends TestCase
+{
+    /**
+     * @var \phpbrowscap\Browscap
+     */
+    private static $browscap = null;
+
+    /**
+     * @var \Browscap\Data\PropertyHolder
+     */
+    private static $propertyHolder;
+
+    /**
+     * @var string[]
+     */
+    private static $coveredPatterns = [];
+
+    /**
+     * @var \Browscap\Filter\FilterInterface
+     */
+    private static $filter;
+
+    /**
+     * @var \Browscap\Writer\WriterInterface
+     */
+    private static $writer;
+
+    public static function setUpBeforeClass() : void
+    {
+        // First, generate the INI files
+        $buildNumber    = time();
+        $resourceFolder = __DIR__ . '/../../../resources/';
+        $buildFolder    = __DIR__ . '/../../../build/browscap-ua-test-full2-';
+        $cacheFolder    = __DIR__ . '/../../../build/browscap-ua-test-full2-' . $buildNumber . '/cache/';
+
+        // create build folder if it does not exist
+        if (!file_exists($buildFolder)) {
+            mkdir($buildFolder, 0777, true);
+        }
+        if (!file_exists($cacheFolder)) {
+            mkdir($cacheFolder, 0777, true);
+        }
+
+        $version = (string) $buildNumber;
+
+        $logger               = new NullLogger();
+        $writerCollection     = new WriterCollection();
+        self::$propertyHolder = new PropertyHolder();
+        self::$filter         = new FullFilter(self::$propertyHolder);
+        self::$writer         = new IniWriter($buildFolder . '/full_php_browscap.ini', $logger);
+        $formatter            = new PhpFormatter(self::$propertyHolder);
+        self::$writer->setFormatter($formatter);
+        self::$writer->setFilter(self::$filter);
+        $writerCollection->addWriter(self::$writer);
+
+        $dataCollectionFactory = new DataCollectionFactory($logger);
+
+        $buildGenerator = new BuildGenerator(
+            $resourceFolder,
+            $buildFolder,
+            $logger,
+            $writerCollection,
+            $dataCollectionFactory
+        );
+
+        $buildGenerator->setCollectPatternIds(true);
+        $buildGenerator->run($version, false);
+
+        // Now, load an INI file into phpbrowscap\Browscap for testing the UAs
+        self::$browscap            = new Browscap($cacheFolder);
+        self::$browscap->lowercase = true;
+        self::$browscap->localFile = $buildFolder . '/full_php_browscap.ini';
+        self::$browscap->updateCache();
+
+        self::$propertyHolder = new PropertyHolder();
+    }
+
+    /**
+     * Runs after the entire test suite is run.  Generates a coverage report for JSON resource files if
+     * the $coveredPatterns array isn't empty
+     */
+    public static function tearDownAfterClass() : void
+    {
+        if (!empty(self::$coveredPatterns)) {
+            $coverageProcessor = new Processor(__DIR__ . '/../../../resources/user-agents/');
+            $coverageProcessor->process(self::$coveredPatterns);
+            $coverageProcessor->write(__DIR__ . '/../../../coverage-full2.json');
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function userAgentDataProvider() : array
+    {
+        [$data, $errors] = (new IteratorHelper())->getTestFiles(new NullLogger(), 'full');
+
+        if (!empty($errors)) {
+            throw new \RuntimeException(
+                'Errors occured while collecting test files' . PHP_EOL . implode(PHP_EOL, $errors)
+            );
+        }
+
+        return $data;
+    }
+
+    /**
+     * @dataProvider userAgentDataProvider
+     * @coversNothing
+     *
+     * @param string $userAgent
+     * @param array  $expectedProperties
+     *
+     * @throws \Exception
+     */
+    public function testUserAgents(string $userAgent, array $expectedProperties) : void
+    {
+        if (!count($expectedProperties)) {
+            self::markTestSkipped('Could not run test - no properties were defined to test');
+        }
+
+        $actualProps = self::$browscap->getBrowser($userAgent, true);
+
+        if (isset($actualProps['PatternId'])) {
+            self::$coveredPatterns[] = $actualProps['PatternId'];
+        }
+
+        foreach (array_keys($expectedProperties) as $propName) {
+            if (!self::$filter->isOutputProperty($propName, self::$writer)) {
+                continue;
+            }
+
+            self::assertFalse(
+                self::$propertyHolder->isDeprecatedProperty($propName),
+                'Actual result expects to test for deprecated property "' . $propName . '"'
+            );
+
+            $expectedValue = $expectedProperties[$propName];
+            $propName      = mb_strtolower($propName);
+
+            self::assertArrayHasKey(
+                $propName,
+                $actualProps,
+                'Actual result does not have "' . $propName . '" property'
+            );
+
+            $libValue = $actualProps[$propName];
+            $message  = 'Expected actual "' . $propName . '" to be "' . $expectedValue . '" '
+                . '(was "' . $libValue . '")' . PHP_EOL
+                . '(Full Result: "' . var_export($actualProps, true) . '")' . PHP_EOL;
+
+            self::assertSame(
+                $expectedValue,
+                $libValue,
+                $message
+            );
+        }
+    }
+}


### PR DESCRIPTION
There are a lot of people who are using tthe browscap files with the native get_browser function or with browscap-php v2 (or other projects which are using the same logic).

This PR adds integration tests for using the native get_browser function and browscap-php v2.
This PR shall not be merged actually, but shall help to identify issues in our rules.

This PR is related to browscap/browscap-php#179.
This PR is related to PR #1746.