### PR TITLE
Adding safari 11 for mac

### DIFF
--- a/resources/user-agents/browsers/safari/safari-10-0-on.json
+++ b/resources/user-agents/browsers/safari/safari-10-0-on.json
@@ -1,6 +1,6 @@
 {
   "division": "Safari #MAJORVER#.#MINORVER#",
-  "versions": ["10.2", "10.1", 10],
+  "versions": [11, "10.2", "10.1", 10],
   "sortIndex": 1969,
   "lite": true,
   "standard": true,


### PR DESCRIPTION
I grabbed some UAs from our logs, but they already have coverage.

I confirmed they all parsed as Safari 11 though.

Fixes #1594.