### PR TITLE
Restore IniParser implementation which was removed in 72914e0f

### DIFF
--- a/src/Browscap/Parser/IniParser.php
+++ b/src/Browscap/Parser/IniParser.php
@@ -1,6 +1,14 @@
 <?php
-declare(strict_types=1);
+/**
+ * This file is part of the browscap package.
+ *
+ * Copyright (c) 1998-2017, Browser Capabilities Project
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
+declare(strict_types = 1);
 namespace Browscap\Parser;
 
 final class IniParser implements ParserInterface
@@ -30,12 +38,12 @@ final class IniParser implements ParserInterface
         $this->filename = $filename;
     }
 
-    public function setShouldSort(bool $shouldSort): void
+    public function setShouldSort(bool $shouldSort) : void
     {
         $this->shouldSort = $shouldSort;
     }
 
-    public function shouldSort(): bool
+    public function shouldSort() : bool
     {
         return $this->shouldSort;
     }
@@ -43,7 +51,7 @@ final class IniParser implements ParserInterface
     /**
      * @return array
      */
-    public function getParsed(): array
+    public function getParsed() : array
     {
         return $this->data;
     }
@@ -51,16 +59,17 @@ final class IniParser implements ParserInterface
     /**
      * @return string
      */
-    public function getFilename(): string
+    public function getFilename() : string
     {
         return $this->filename;
     }
 
     /**
      * @throws \InvalidArgumentException
+     *
      * @return array
      */
-    public function getLinesFromFile(): array
+    public function getLinesFromFile() : array
     {
         $filename = $this->filename;
 
@@ -74,7 +83,7 @@ final class IniParser implements ParserInterface
     /**
      * @param string[] $fileLines
      */
-    public function setFileLines(array $fileLines)
+    public function setFileLines(array $fileLines) : void
     {
         $this->fileLines = $fileLines;
     }
@@ -82,7 +91,7 @@ final class IniParser implements ParserInterface
     /**
      * @return array
      */
-    public function getFileLines(): array
+    public function getFileLines() : array
     {
         if (!$this->fileLines) {
             $fileLines = $this->getLinesFromFile();
@@ -95,9 +104,10 @@ final class IniParser implements ParserInterface
 
     /**
      * @throws \RuntimeException
+     *
      * @return array
      */
-    public function parse(): array
+    public function parse() : array
     {
         $fileLines = $this->getFileLines();
 
@@ -108,34 +118,36 @@ final class IniParser implements ParserInterface
 
         for ($line = 0, $count = count($fileLines); $line < $count; ++$line) {
             $currentLine       = ($fileLines[$line]);
-            $currentLineLength = strlen($currentLine);
+            $currentLineLength = mb_strlen($currentLine);
 
-            if ($currentLineLength === 0) {
+            if (0 === $currentLineLength) {
                 continue;
             }
 
-            if (substr($currentLine, 0, 40) === ';;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;') {
-                $currentDivision = trim(substr($currentLine, 41));
+            if (';;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;' === mb_substr($currentLine, 0, 40)) {
+                $currentDivision = trim(mb_substr($currentLine, 41));
+
                 continue;
             }
 
             // We only skip comments that *start* with semicolon
-            if ($currentLine[0] === ';') {
+            if (';' === $currentLine[0]) {
                 continue;
             }
 
-            if ($currentLine[0] === '[') {
-                $currentSection = substr($currentLine, 1, ($currentLineLength - 2));
+            if ('[' === $currentLine[0]) {
+                $currentSection = mb_substr($currentLine, 1, ($currentLineLength - 2));
+
                 continue;
             }
 
             $bits = explode('=', $currentLine);
 
-            if (count($bits) > 2) {
+            if (2 < count($bits)) {
                 throw new \RuntimeException("Too many equals in line: {$currentLine}, in Division: {$currentDivision}");
             }
 
-            if (count($bits) < 2) {
+            if (2 > count($bits)) {
                 $bits[1] = '';
             }
 
@@ -157,7 +169,7 @@ final class IniParser implements ParserInterface
      *
      * @return array
      */
-    private function sortArrayAndChildArrays(array $array): array
+    private function sortArrayAndChildArrays(array $array) : array
     {
         ksort($array);
 

--- a/src/Browscap/Parser/IniParser.php
+++ b/src/Browscap/Parser/IniParser.php
@@ -1,0 +1,174 @@
+<?php
+declare(strict_types=1);
+
+namespace Browscap\Parser;
+
+final class IniParser implements ParserInterface
+{
+    /**
+     * @var string
+     */
+    private $filename;
+
+    /**
+     * @var bool
+     */
+    private $shouldSort = false;
+
+    /**
+     * @var array
+     */
+    private $data;
+
+    /**
+     * @var array
+     */
+    private $fileLines;
+
+    public function __construct(string $filename)
+    {
+        $this->filename = $filename;
+    }
+
+    public function setShouldSort(bool $shouldSort): void
+    {
+        $this->shouldSort = $shouldSort;
+    }
+
+    public function shouldSort(): bool
+    {
+        return $this->shouldSort;
+    }
+
+    /**
+     * @return array
+     */
+    public function getParsed(): array
+    {
+        return $this->data;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFilename(): string
+    {
+        return $this->filename;
+    }
+
+    /**
+     * @throws \InvalidArgumentException
+     * @return array
+     */
+    public function getLinesFromFile(): array
+    {
+        $filename = $this->filename;
+
+        if (!file_exists($filename)) {
+            throw new \InvalidArgumentException("File not found: {$filename}");
+        }
+
+        return file($filename, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+    }
+
+    /**
+     * @param string[] $fileLines
+     */
+    public function setFileLines(array $fileLines)
+    {
+        $this->fileLines = $fileLines;
+    }
+
+    /**
+     * @return array
+     */
+    public function getFileLines(): array
+    {
+        if (!$this->fileLines) {
+            $fileLines = $this->getLinesFromFile();
+        } else {
+            $fileLines = $this->fileLines;
+        }
+
+        return $fileLines;
+    }
+
+    /**
+     * @throws \RuntimeException
+     * @return array
+     */
+    public function parse(): array
+    {
+        $fileLines = $this->getFileLines();
+
+        $data = [];
+
+        $currentSection  = '';
+        $currentDivision = '';
+
+        for ($line = 0, $count = count($fileLines); $line < $count; ++$line) {
+            $currentLine       = ($fileLines[$line]);
+            $currentLineLength = strlen($currentLine);
+
+            if ($currentLineLength === 0) {
+                continue;
+            }
+
+            if (substr($currentLine, 0, 40) === ';;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;') {
+                $currentDivision = trim(substr($currentLine, 41));
+                continue;
+            }
+
+            // We only skip comments that *start* with semicolon
+            if ($currentLine[0] === ';') {
+                continue;
+            }
+
+            if ($currentLine[0] === '[') {
+                $currentSection = substr($currentLine, 1, ($currentLineLength - 2));
+                continue;
+            }
+
+            $bits = explode('=', $currentLine);
+
+            if (count($bits) > 2) {
+                throw new \RuntimeException("Too many equals in line: {$currentLine}, in Division: {$currentDivision}");
+            }
+
+            if (count($bits) < 2) {
+                $bits[1] = '';
+            }
+
+            $data[$currentSection][$bits[0]]   = $bits[1];
+            $data[$currentSection]['Division'] = $currentDivision;
+        }
+
+        if ($this->shouldSort()) {
+            $data = $this->sortArrayAndChildArrays($data);
+        }
+
+        $this->data = $data;
+
+        return $data;
+    }
+
+    /**
+     * @param array $array
+     *
+     * @return array
+     */
+    private function sortArrayAndChildArrays(array $array): array
+    {
+        ksort($array);
+
+        foreach (array_keys($array) as $key) {
+            if (!is_array($array[$key]) || empty($array[$key])) {
+                continue;
+            }
+
+            $array[$key] = $this->sortArrayAndChildArrays($array[$key]);
+        }
+
+        return $array;
+    }
+}

--- a/src/Browscap/Parser/ParserInterface.php
+++ b/src/Browscap/Parser/ParserInterface.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace Browscap\Parser;
+
+interface ParserInterface
+{
+    /**
+     * @return array
+     */
+    public function parse(): array;
+
+    /**
+     * @return array
+     */
+    public function getParsed(): array;
+
+    /**
+     * @return string
+     */
+    public function getFilename(): string;
+}

--- a/src/Browscap/Parser/ParserInterface.php
+++ b/src/Browscap/Parser/ParserInterface.php
@@ -1,6 +1,14 @@
 <?php
-declare(strict_types=1);
+/**
+ * This file is part of the browscap package.
+ *
+ * Copyright (c) 1998-2017, Browser Capabilities Project
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
+declare(strict_types = 1);
 namespace Browscap\Parser;
 
 interface ParserInterface
@@ -8,15 +16,15 @@ interface ParserInterface
     /**
      * @return array
      */
-    public function parse(): array;
+    public function parse() : array;
 
     /**
      * @return array
      */
-    public function getParsed(): array;
+    public function getParsed() : array;
 
     /**
      * @return string
      */
-    public function getFilename(): string;
+    public function getFilename() : string;
 }

--- a/tests/BrowscapTest/Parser/IniParserTest.php
+++ b/tests/BrowscapTest/Parser/IniParserTest.php
@@ -1,0 +1,315 @@
+<?php
+declare(strict_types=1);
+
+namespace BrowscapTest\Parser;
+
+use Browscap\Parser\IniParser;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Browscap\Parser\IniParser
+ */
+final class IniParserTest extends TestCase
+{
+    /**
+     * tests creating the parser class
+     *
+     * @group parser
+     * @group sourcetest
+     */
+    public function testConstructorSetsFilename(): void
+    {
+        $parser = new IniParser('foobar');
+        self::assertSame('foobar', $parser->getFilename());
+    }
+
+    /**
+     * tests setting the should sort flag
+     *
+     * @group parser
+     * @group sourcetest
+     */
+    public function testSetShouldSort(): void
+    {
+        $parser = new IniParser('');
+
+        // Test the default value
+        self::assertAttributeEquals(false, 'shouldSort', $parser);
+
+        // Test setting it to true
+        $parser->setShouldSort(true);
+        self::assertAttributeEquals(true, 'shouldSort', $parser);
+
+        // Test setting it back to false
+        $parser->setShouldSort(false);
+        self::assertAttributeEquals(false, 'shouldSort', $parser);
+    }
+
+    /**
+     * tests setting and getting the should sort flag
+     *
+     * @group parser
+     * @group sourcetest
+     */
+    public function testShouldSort(): void
+    {
+        $parser = new IniParser('');
+
+        self::assertFalse($parser->shouldSort());
+
+        $parser->setShouldSort(true);
+        self::assertTrue($parser->shouldSort());
+
+        $parser->setShouldSort(false);
+        self::assertFalse($parser->shouldSort());
+    }
+
+    /**
+     * tests setting and getting a logger
+     */
+    public function sortArrayDataProvider(): array
+    {
+        return [
+            'flatArray' => [
+                ['d' => 'lemon', 'a' => 'orange', 'b' => 'banana', 'c' => 'apple'],
+                ['a' => 'orange', 'b' => 'banana', 'c' => 'apple', 'd' => 'lemon'],
+            ],
+            'twoDimensionalArray' => [
+                ['z' => 'zzz', 'x' => ['b' => 'bbb', 'a' => 'aaa', 'c' => 'ccc'], 'y' => ['k' => 'kkk', 'j' => 'jjj', 'i' => 'iii']],
+                ['x' => ['a' => 'aaa', 'b' => 'bbb', 'c' => 'ccc'], 'y' => ['i' => 'iii', 'j' => 'jjj', 'k' => 'kkk'], 'z' => 'zzz'],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider sortArrayDataProvider
+     *
+     * @group parser
+     * @group sourcetest
+     * @param string[] $unsorted
+     * @param string[] $sorted
+     */
+    public function testSortArrayAndChildArrays(array $unsorted, array $sorted): void
+    {
+        $parser = new IniParser('');
+
+        $sortMethod = new \ReflectionMethod('\Browscap\Parser\IniParser', 'sortArrayAndChildArrays');
+        $sortMethod->setAccessible(true);
+        self::assertSame($sorted, $sortMethod->invokeArgs($parser, [$unsorted]));
+    }
+
+    /**
+     * tests getting lines from a file
+     *
+     * @group parser
+     * @group sourcetest
+     */
+    public function testGetLinesFromFileReturnsArrayWithLines(): void
+    {
+        $tmpfile = tempnam(sys_get_temp_dir(), 'browscaptest');
+
+        $in = <<<HERE
+; comment
+
+[test]
+test=test
+HERE;
+
+        file_put_contents($tmpfile, $in);
+
+        $parser = new IniParser($tmpfile);
+
+        $out = $parser->getLinesFromFile();
+
+        unlink($tmpfile);
+
+        $expected = [
+            '; comment',
+            '[test]',
+            'test=test',
+        ];
+
+        self::assertSame($expected, $out);
+    }
+
+    /**
+     * tests throwing an exception if the input file does not exist
+     *
+     * @group parser
+     * @group sourcetest
+     */
+    public function testGetLinesFromFileThrowsExceptionIfFileDoesNotExist(): void
+    {
+        $file   = '/hopefully/this/file/does/not/exist';
+        $parser = new IniParser($file);
+
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('File not found: ' . $file);
+
+        $parser->getLinesFromFile();
+    }
+
+    /**
+     * tests getting lines from a file
+     *
+     * @group parser
+     * @group sourcetest
+     */
+    public function testGetFileLinesReturnsLinesFromFile(): void
+    {
+        $tmpfile = tempnam(sys_get_temp_dir(), 'browscaptest');
+
+        $in = <<<HERE
+; comment
+
+[test]
+test=test
+HERE;
+
+        file_put_contents($tmpfile, $in);
+
+        $parser = new IniParser($tmpfile);
+
+        $out = $parser->getFileLines();
+
+        unlink($tmpfile);
+
+        $expected = [
+            '; comment',
+            '[test]',
+            'test=test',
+        ];
+
+        self::assertSame($expected, $out);
+    }
+
+    /**
+     * tests setting and getting lines of a file
+     *
+     * @group parser
+     * @group sourcetest
+     */
+    public function testGetFileLinesReturnsLinesFromPreviouslySetLines(): void
+    {
+        $lines = ['first', 'second', 'third'];
+
+        $parser = new IniParser('');
+        $parser->setFileLines($lines);
+
+        self::assertSame($lines, $parser->getFileLines());
+    }
+
+    /**
+     * tests parsing sections without sorting
+     *
+     * @group parser
+     * @group sourcetest
+     */
+    public function testParseWithoutSorting(): void
+    {
+        $lines = [
+            '',
+            ';;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; division1',
+            '',
+            '; this line is a comment',
+            '[section1]',
+            'property11=value11',
+            'property12=value12',
+            '',
+            '; this line is a comment',
+            '[section2]',
+            'property21=value21',
+            'property22=value22',
+            '',
+            ';;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; division2',
+            '',
+            '; this line is a comment',
+            '[section3]',
+            'property31=value31',
+            'property32=value32',
+            'property33',
+        ];
+
+        $parser = new IniParser('');
+        $parser->setFileLines($lines);
+        $parser->setShouldSort(true);
+
+        $expected = [
+            'section1' => ['property11' => 'value11', 'property12' => 'value12', 'Division' => 'division1'],
+            'section2' => ['property21' => 'value21', 'property22' => 'value22', 'Division' => 'division1'],
+            'section3' => ['property31' => 'value31', 'property32' => 'value32', 'property33' => '', 'Division' => 'division2'],
+        ];
+
+        $data = $parser->parse();
+
+        self::assertSame($data, $parser->getParsed());
+
+        self::assertEquals($expected, $data);
+    }
+
+    /**
+     * tests parsing sections with sorting
+     *
+     * @group parser
+     * @group sourcetest
+     */
+    public function testParseWithSorting(): void
+    {
+        $lines = [
+            '',
+            ';;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; division1',
+            '',
+            '; this line is a comment',
+            '[section1]',
+            'property11=value11',
+            'property12=value12',
+            '',
+            '; this line is a comment',
+            '[section2]',
+            'property21=value21',
+            'property22=value22',
+            '',
+            ';;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; division2',
+            '',
+            '; this line is a comment',
+            '[section3]',
+            'property31=value31',
+            'property32=value32',
+        ];
+
+        $parser = new IniParser('');
+        $parser->setFileLines($lines);
+        $parser->setShouldSort(true);
+
+        $expected = [
+            'section1' => ['Division' => 'division1', 'property11' => 'value11', 'property12' => 'value12'],
+            'section2' => ['Division' => 'division1', 'property21' => 'value21', 'property22' => 'value22'],
+            'section3' => ['Division' => 'division2', 'property31' => 'value31', 'property32' => 'value32'],
+        ];
+
+        $data = $parser->parse();
+
+        self::assertSame($expected, $data);
+    }
+
+    /**
+     * tests throwing an exception if more than one eual sign is present in a line
+     *
+     * @group parser
+     * @group sourcetest
+     *
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Too many equals in line: double=equals=here
+     */
+    public function testParseThrowsExceptionWhenInvalidFormatting(): void
+    {
+        $lines = [
+            'double=equals=here',
+        ];
+
+        $parser = new IniParser('');
+        $parser->setFileLines($lines);
+
+        $parser->parse();
+    }
+}

--- a/tests/BrowscapTest/Parser/IniParserTest.php
+++ b/tests/BrowscapTest/Parser/IniParserTest.php
@@ -1,6 +1,14 @@
 <?php
-declare(strict_types=1);
+/**
+ * This file is part of the browscap package.
+ *
+ * Copyright (c) 1998-2017, Browser Capabilities Project
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
+declare(strict_types = 1);
 namespace BrowscapTest\Parser;
 
 use Browscap\Parser\IniParser;
@@ -17,7 +25,7 @@ final class IniParserTest extends TestCase
      * @group parser
      * @group sourcetest
      */
-    public function testConstructorSetsFilename(): void
+    public function testConstructorSetsFilename() : void
     {
         $parser = new IniParser('foobar');
         self::assertSame('foobar', $parser->getFilename());
@@ -29,7 +37,7 @@ final class IniParserTest extends TestCase
      * @group parser
      * @group sourcetest
      */
-    public function testSetShouldSort(): void
+    public function testSetShouldSort() : void
     {
         $parser = new IniParser('');
 
@@ -51,7 +59,7 @@ final class IniParserTest extends TestCase
      * @group parser
      * @group sourcetest
      */
-    public function testShouldSort(): void
+    public function testShouldSort() : void
     {
         $parser = new IniParser('');
 
@@ -67,7 +75,7 @@ final class IniParserTest extends TestCase
     /**
      * tests setting and getting a logger
      */
-    public function sortArrayDataProvider(): array
+    public function sortArrayDataProvider() : array
     {
         return [
             'flatArray' => [
@@ -86,10 +94,11 @@ final class IniParserTest extends TestCase
      *
      * @group parser
      * @group sourcetest
+     *
      * @param string[] $unsorted
      * @param string[] $sorted
      */
-    public function testSortArrayAndChildArrays(array $unsorted, array $sorted): void
+    public function testSortArrayAndChildArrays(array $unsorted, array $sorted) : void
     {
         $parser = new IniParser('');
 
@@ -104,11 +113,11 @@ final class IniParserTest extends TestCase
      * @group parser
      * @group sourcetest
      */
-    public function testGetLinesFromFileReturnsArrayWithLines(): void
+    public function testGetLinesFromFileReturnsArrayWithLines() : void
     {
         $tmpfile = tempnam(sys_get_temp_dir(), 'browscaptest');
 
-        $in = <<<HERE
+        $in = <<<'HERE'
 ; comment
 
 [test]
@@ -138,7 +147,7 @@ HERE;
      * @group parser
      * @group sourcetest
      */
-    public function testGetLinesFromFileThrowsExceptionIfFileDoesNotExist(): void
+    public function testGetLinesFromFileThrowsExceptionIfFileDoesNotExist() : void
     {
         $file   = '/hopefully/this/file/does/not/exist';
         $parser = new IniParser($file);
@@ -155,11 +164,11 @@ HERE;
      * @group parser
      * @group sourcetest
      */
-    public function testGetFileLinesReturnsLinesFromFile(): void
+    public function testGetFileLinesReturnsLinesFromFile() : void
     {
         $tmpfile = tempnam(sys_get_temp_dir(), 'browscaptest');
 
-        $in = <<<HERE
+        $in = <<<'HERE'
 ; comment
 
 [test]
@@ -189,7 +198,7 @@ HERE;
      * @group parser
      * @group sourcetest
      */
-    public function testGetFileLinesReturnsLinesFromPreviouslySetLines(): void
+    public function testGetFileLinesReturnsLinesFromPreviouslySetLines() : void
     {
         $lines = ['first', 'second', 'third'];
 
@@ -205,7 +214,7 @@ HERE;
      * @group parser
      * @group sourcetest
      */
-    public function testParseWithoutSorting(): void
+    public function testParseWithoutSorting() : void
     {
         $lines = [
             '',
@@ -253,7 +262,7 @@ HERE;
      * @group parser
      * @group sourcetest
      */
-    public function testParseWithSorting(): void
+    public function testParseWithSorting() : void
     {
         $lines = [
             '',
@@ -297,11 +306,8 @@ HERE;
      *
      * @group parser
      * @group sourcetest
-     *
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Too many equals in line: double=equals=here
      */
-    public function testParseThrowsExceptionWhenInvalidFormatting(): void
+    public function testParseThrowsExceptionWhenInvalidFormatting() : void
     {
         $lines = [
             'double=equals=here',
@@ -310,6 +316,8 @@ HERE;
         $parser = new IniParser('');
         $parser->setFileLines($lines);
 
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Too many equals in line: double=equals=here');
         $parser->parse();
     }
 }


### PR DESCRIPTION
`IniParser` got removed in #1583 thinking it wasn't used; however, it's used by the website; so we need to leave it here until it can get ported over (as it probably belongs there anyway).

Without the `IniParser`, I can't release the version (so 6025 is a "dead" version; assuming this works, we'll go straight to 6026)