### PR TITLE
remove duplicate version

### DIFF
--- a/resources/user-agents/browsers/safari/safari-9-1.json
+++ b/resources/user-agents/browsers/safari/safari-9-1.json
@@ -1,6 +1,6 @@
 {
   "division": "Safari #MAJORVER#.#MINORVER#",
-  "versions": ["9.1", 9],
+  "versions": ["9.1"],
   "sortIndex": 1970,
   "lite": true,
   "standard": true,


### PR DESCRIPTION
The version 9 for Safari is defined twice, in the files for the versions 9 and 9.1. Because of this the build of the `strong typing` branch fails. 

The reason is that the `CFNetwork` versions of the useragents do not have a normal version number and do not have a version placeholder in the files. A version placeholder is required if more than one version is defined in a source file to avoid duplicate ua definitions in the output files.