### PR TITLE
Changing travis to use composer install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ php:
 
 os: linux
 
-env:
-  - COMPOSER_FLAGS=""
-
 cache:
   directories:
     - $HOME/.composer/cache
@@ -37,37 +34,31 @@ jobs:
       php: 7.1
       env:
         - COVERAGE=yes
-        - COMPOSER_FLAGS=""
       script: vendor/bin/phpunit -c phpunit.xml.dist --colors --verbose --coverage-text --coverage-clover=coverage.clover
       after_success:
         - wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover coverage.clover
         - bash <(curl -s https://codecov.io/bash) -f coverage.clover
     - stage: check coding style
       php: 7.1
-      env: COMPOSER_FLAGS=""
       script: php -n -d memory_limit=768M vendor/bin/php-cs-fixer fix --dry-run -vv
     - stage: static code analysis
       php: 7.1
-      env: COMPOSER_FLAGS=""
       script: vendor/bin/phpstan analyse -l 7 -c phpstan.neon --autoload-file=vendor/autoload.php --memory-limit=768M --no-progress src tests/UserAgentsTest tests/BrowscapTest tests/fixtures
     - stage: integration test
       php: 7.1
       env:
         - TEST_SET="full"
-        - COMPOSER_FLAGS=""
       script: php -n vendor/bin/phpunit -c tests/phpunit-integration.xml.dist --no-coverage --colors --verbose tests/UserAgentsTest/FullTest.php
       after_success: bash <(curl -s https://codecov.io/bash) -f coverage-full.json -F full
     - stage: integration test
       php: 7.1
       env:
         - TEST_SET="standard"
-        - COMPOSER_FLAGS=""
       script: php -n vendor/bin/phpunit -c tests/phpunit-integration.xml.dist --no-coverage --colors --verbose tests/UserAgentsTest/StandardTest.php
       after_success: bash <(curl -s https://codecov.io/bash) -f coverage-standard.json -F standard
     - stage: integration test
       php: 7.1
       env:
         - TEST_SET="lite"
-        - COMPOSER_FLAGS=""
       script: php -n vendor/bin/phpunit -c tests/phpunit-integration.xml.dist --no-coverage --colors --verbose tests/UserAgentsTest/LiteTest.php
       after_success: bash <(curl -s https://codecov.io/bash) -f coverage-lite.json -F lite

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ php:
 os: linux
 
 env:
-  - COMPOSER_FLAGS="--prefer-lowest"
   - COMPOSER_FLAGS=""
 
 cache:
@@ -21,7 +20,7 @@ before_install:
   - echo 'opcache.enable_cli=1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - travis_retry composer self-update
 
-install: travis_retry composer install --optimize-autoloader --prefer-dist --prefer-stable --no-progress --no-interaction -vv $COMPOSER_FLAGS
+install: travis_retry composer install --optimize-autoloader --prefer-dist --no-progress --no-interaction -vv $COMPOSER_FLAGS
 
 script:
   - composer validate --strict

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - echo 'opcache.enable_cli=1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - travis_retry composer self-update
 
-install: travis_retry composer update --optimize-autoloader --prefer-dist --prefer-stable --no-progress --no-interaction -vv $COMPOSER_FLAGS
+install: travis_retry composer install --optimize-autoloader --prefer-dist --prefer-stable --no-progress --no-interaction -vv $COMPOSER_FLAGS
 
 script:
   - composer validate --strict

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
     "issues": "https://github.com/browscap/browscap/issues",
     "source": "https://github.com/browscap/browscap"
   },
+  "prefer-stable": true,
   "require": {
     "php": "^7.1",
     "symfony/console": "^3.3",
@@ -40,7 +41,7 @@
     "phpunit/phpunit": "^6.3",
     "browscap/browscap-php": "^3.1.0",
     "mikey179/vfsStream": "^1.6",
-    "friendsofphp/php-cs-fixer": "^2.7",
+    "friendsofphp/php-cs-fixer": "2.7.1",
     "seld/jsonlint": "^1.5",
     "phpstan/phpstan": "^0.8.4"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "809d4bbf9a5dfa6dc26c88ce2c9145d3",
+    "content-hash": "f7b0c98f2f58fc88a9e5eb8ce0b4a5f3",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -3819,7 +3819,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],
-    "prefer-stable": false,
+    "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^7.1"


### PR DESCRIPTION
Fixes #1661

Since this project has the composer.lock file in the repo travis should obey it.

Changing travis to use `composer install` instead of `composer update`. This required removing a couple of composer flags, but when `install` is used, these flags don’t have an effect (which is probably why they’re not available).

I also had to lock php-cs-fixer to 2.7.1 as part of this, as I needed to do a `composer update` to make the lock file match the json file (with the new `prefer-stable` option added), otherwise it would have pulled down 2.7.2 which errors out.