### PR TITLE
Grouping some Opera Mobile patterns

### DIFF
--- a/resources/user-agents/browsers/maxthon/maxthon-nitro-1-0-on.json
+++ b/resources/user-agents/browsers/maxthon/maxthon-nitro-1-0-on.json
@@ -9,7 +9,7 @@
       "userAgent": "Maxthon Nitro #MAJORVER#.#MINORVER#",
       "platform": "Windows",
       "engine": "Blink",
-      "device": "general Desktop",
+      "device": "Windows Desktop",
       "properties": {
         "Parent": "DefaultProperties",
         "Comment": "Maxthon Nitro #MAJORVER#.#MINORVER#",
@@ -25,7 +25,6 @@
       "children": [
         {
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) MxNitro/#MAJORVER#.#MINORVER#* Chrome/*Safari/*",
-          "device": "Windows Desktop",
           "platforms": [
             "WinXPa_64", "WinXPa_32", "WinXPb_64", "WinXPb_32", "Vista_64", "Vista_32",
             "Win10_x64_B", "Win10_64_B", "Win10_32_B",

--- a/resources/user-agents/browsers/opera-mobile/opera-mobile-10-00-to-10-70.json
+++ b/resources/user-agents/browsers/opera-mobile/opera-mobile-10-00-to-10-70.json
@@ -6,7 +6,7 @@
   "standard": true,
   "userAgents": [
     {
-      "userAgent": "Opera Mobile #MAJORVER#.#MINORVER# Android",
+      "userAgent": "Opera Mobile #MAJORVER#.#MINORVER# for Android",
       "engine": "Presto_2_2",
       "device": "general Mobile Phone (Touch)",
       "platform": "Android",

--- a/resources/user-agents/browsers/opera-mobile/opera-mobile-10-00-to-10-70.json
+++ b/resources/user-agents/browsers/opera-mobile/opera-mobile-10-00-to-10-70.json
@@ -6,9 +6,10 @@
   "standard": true,
   "userAgents": [
     {
-      "userAgent": "Opera Mobile #MAJORVER#.#MINORVER#",
+      "userAgent": "Opera Mobile #MAJORVER#.#MINORVER# Android",
       "engine": "Presto_2_2",
       "device": "general Mobile Phone (Touch)",
+      "platform": "Android",
       "properties": {
         "Parent": "DefaultProperties",
         "Comment": "Opera Mobile #MAJORVER#.#MINORVER#",
@@ -25,11 +26,7 @@
             "Android_F_2_3", "Android_F_2_2", "Android_F_2_1",
             "Android_F",
             "Android_H_2_2",
-            "Android_H",
-            "SymbianOS_C",
-            "WinMobile",
-            "Maemo_ARM",
-            "Linux"
+            "Android_H"
           ]
         },
         {
@@ -37,33 +34,13 @@
           "device": "general Tablet",
           "platforms": [
             "AndroidLinux",
-            "Android_F",
-            "SymbianOS_C",
-            "WinMobile"
+            "Android_F"
           ]
         },
         {
           "match": "Mozilla/5.0 (#PLATFORM# Opera Mobi/*) Gecko/* Firefox/* Opera #MAJORVER#.#MINORVER#*",
           "platforms": [
-            "Maemo_ARM", "AndroidLinux", "SymbianOS_C"
-          ]
-        },
-        {
-          "match": "Mozilla/4.0 (#PLATFORM#Opera Mobi*)*Version/#MAJORVER#.#MINORVER#*",
-          "platforms": [
-            "WinMobile"
-          ]
-        },
-        {
-          "match": "Mozilla/4.0 (compatible; MSIE ?*.?*; #PLATFORM#) Opera?#MAJORVER#.#MINORVER#*",
-          "platforms": [
-            "WinMobile"
-          ]
-        },
-        {
-          "match": "Mozilla/4.0 (compatible; MSIE#PLATFORM# Opera Mobi*) Opera?#MAJORVER#.#MINORVER#*",
-          "platforms": [
-            "Maemo_ARM"
+            "AndroidLinux"
           ]
         },
         {
@@ -71,15 +48,6 @@
           "device": "general Mobile Phone (Touch)",
           "platforms": [
             "Android"
-          ]
-        },
-        {
-          "match": "#DEVICE# ASTRO36_TD/* MAUI/* Release/* Browser/Opera */MIDP* Opera/9.80 (*) Presto/* Version/#MAJORVER#.#MINORVER#*",
-          "devices": {
-            "MicromaxX650": "Micromax X650"
-          },
-          "platforms": [
-            "JAVA"
           ]
         },
         {
@@ -95,13 +63,6 @@
           "platforms": [
             "Android"
           ]
-        },
-        {
-          "match": "#DEVICE# Opera/#MAJORVER#.#MINORVER#*",
-          "devices": {
-            "HTC_Touch_HD_T8282": "HTC T8282",
-            "HTC_Touch_HD2_T8585": "HTC T8585"
-          }
         },
         {
           "match": "Huawei/*/#DEVICE# Browser/Opera *Profile/MIDP* Opera/*(MTK*)*Version/#MAJORVER#.#MINORVER#*",
@@ -124,6 +85,78 @@
           "platforms": [
             "Android"
           ]
+        }
+      ]
+    },
+    {
+      "userAgent": "Opera Mobile #MAJORVER#.#MINORVER#",
+      "engine": "Presto_2_2",
+      "device": "general Mobile Phone (Touch)",
+      "properties": {
+        "Parent": "DefaultProperties",
+        "Comment": "Opera Mobile #MAJORVER#.#MINORVER#",
+        "Browser": "Opera Mobile",
+        "Browser_Maker": "Opera Software ASA",
+        "Browser_Type": "Browser",
+        "Version": "#MAJORVER#.#MINORVER#"
+      },
+      "children": [
+        {
+          "match": "Opera/9.80*(#PLATFORM#Opera Mobi*)*Version/#MAJORVER#.#MINORVER#*",
+          "platforms": [
+            "SymbianOS_C",
+            "WinMobile",
+            "Maemo_ARM",
+            "Linux"
+          ]
+        },
+        {
+          "match": "Opera/9.80*(#PLATFORM#Opera Tablet*)*Version/#MAJORVER#.#MINORVER#*",
+          "device": "general Tablet",
+          "platforms": [
+            "SymbianOS_C",
+            "WinMobile"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM# Opera Mobi/*) Gecko/* Firefox/* Opera #MAJORVER#.#MINORVER#*",
+          "platforms": [
+            "Maemo_ARM", "SymbianOS_C"
+          ]
+        },
+        {
+          "match": "Mozilla/4.0 (#PLATFORM#Opera Mobi*)*Version/#MAJORVER#.#MINORVER#*",
+          "platforms": [
+            "WinMobile"
+          ]
+        },
+        {
+          "match": "Mozilla/4.0 (compatible; MSIE ?*.?*; #PLATFORM#) Opera?#MAJORVER#.#MINORVER#*",
+          "platforms": [
+            "WinMobile"
+          ]
+        },
+        {
+          "match": "Mozilla/4.0 (compatible; MSIE#PLATFORM# Opera Mobi*) Opera?#MAJORVER#.#MINORVER#*",
+          "platforms": [
+            "Maemo_ARM"
+          ]
+        },
+        {
+          "match": "#DEVICE# ASTRO36_TD/* MAUI/* Release/* Browser/Opera */MIDP* Opera/9.80 (*) Presto/* Version/#MAJORVER#.#MINORVER#*",
+          "devices": {
+            "MicromaxX650": "Micromax X650"
+          },
+          "platforms": [
+            "JAVA"
+          ]
+        },
+        {
+          "match": "#DEVICE# Opera/#MAJORVER#.#MINORVER#*",
+          "devices": {
+            "HTC_Touch_HD_T8282": "HTC T8282",
+            "HTC_Touch_HD2_T8585": "HTC T8585"
+          }
         }
       ]
     }

--- a/resources/user-agents/browsers/opera-mobile/opera-mobile-11-00.json
+++ b/resources/user-agents/browsers/opera-mobile/opera-mobile-11-00.json
@@ -6,6 +6,64 @@
   "standard": true,
   "userAgents": [
     {
+      "userAgent": "Opera Mobile #MAJORVER#.#MINORVER# for Android",
+      "engine": "Presto_2_7",
+      "device": "general Mobile Phone (Touch)",
+      "platform": "Android",
+      "properties": {
+        "Parent": "DefaultProperties",
+        "Comment": "Opera Mobile #MAJORVER#.#MINORVER#",
+        "Browser": "Opera Mobile",
+        "Browser_Maker": "Opera Software ASA",
+        "Browser_Type": "Browser",
+        "Version": "#MAJORVER#.#MINORVER#"
+      },
+      "children": [
+        {
+          "match": "Mozilla/4.0 (compatible; MSIE#PLATFORM# Opera Mobi*) Opera?#MAJORVER#.#MINORVER#*",
+          "platforms": [
+            "Android_F_2_2",
+            "Android_F"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM# Opera Mobi/*) Gecko/* Firefox/* Opera #MAJORVER#.#MINORVER#*",
+          "platforms": [
+            "Android_F_2_3", "Android_F_2_2",
+            "Android_F"
+          ]
+        },
+        {
+          "match": "Mozilla/5.0 (#PLATFORM# Opera Tablet/*) Gecko/* Firefox/* Opera #MAJORVER#.#MINORVER#*",
+          "device": "general Tablet",
+          "platforms": [
+            "Android_F_2_3", "Android_F_2_2",
+            "Android_F"
+          ]
+        },
+        {
+          "match": "Opera/9.80*(#PLATFORM#Opera Mobi*)*Version/#MAJORVER#.#MINORVER#*",
+          "platforms": [
+            "AndroidLinux",
+            "Android_F_5_0",
+            "Android_F_4_4", "Android_F_4_3", "Android_F_4_2", "Android_F_4_1", "Android_F_4_0",
+            "Android_F_2_3", "Android_F_2_2", "Android_F_2_1",
+            "Android_F"
+          ]
+        },
+        {
+          "match": "Opera/9.80*(#PLATFORM#Opera Tablet*)*Version/#MAJORVER#.#MINORVER#*",
+          "device": "general Tablet",
+          "platforms": [
+            "Android_F_4_4", "Android_F_4_3", "Android_F_4_2", "Android_F_4_1", "Android_F_4_0",
+            "Android_F_3_2",
+            "Android_F_2_3", "Android_F_2_2", "Android_F_2_1",
+            "Android_F"
+          ]
+        }
+      ]
+    },
+    {
       "userAgent": "Opera Mobile #MAJORVER#.#MINORVER#",
       "engine": "Presto_2_7",
       "device": "general Mobile Phone (Touch)",
@@ -21,16 +79,12 @@
         {
           "match": "Mozilla/4.0 (compatible; MSIE#PLATFORM# Opera Mobi*) Opera?#MAJORVER#.#MINORVER#*",
           "platforms": [
-            "Maemo_ARM",
-            "Android_F_2_2",
-            "Android_F"
+            "Maemo_ARM"
           ]
         },
         {
           "match": "Mozilla/5.0 (#PLATFORM# Opera Mobi/*) Gecko/* Firefox/* Opera #MAJORVER#.#MINORVER#*",
           "platforms": [
-            "Android_F_2_3", "Android_F_2_2",
-            "Android_F",
             "Maemo_ARM",
             "SymbianOS_C"
           ]
@@ -39,32 +93,15 @@
           "match": "Mozilla/5.0 (#PLATFORM# Opera Tablet/*) Gecko/* Firefox/* Opera #MAJORVER#.#MINORVER#*",
           "device": "general Tablet",
           "platforms": [
-            "Android_F_2_3", "Android_F_2_2",
-            "Android_F",
             "Maemo_ARM"
           ]
         },
         {
           "match": "Opera/9.80*(#PLATFORM#Opera Mobi*)*Version/#MAJORVER#.#MINORVER#*",
           "platforms": [
-            "AndroidLinux",
-            "Android_F_5_0",
-            "Android_F_4_4", "Android_F_4_3", "Android_F_4_2", "Android_F_4_1", "Android_F_4_0",
-            "Android_F_2_3", "Android_F_2_2", "Android_F_2_1",
-            "Android_F",
             "SymbianOS_C",
             "WinMobile",
             "Maemo_ARM"
-          ]
-        },
-        {
-          "match": "Opera/9.80*(#PLATFORM#Opera Tablet*)*Version/#MAJORVER#.#MINORVER#*",
-          "device": "general Tablet",
-          "platforms": [
-            "Android_F_4_4", "Android_F_4_3", "Android_F_4_2", "Android_F_4_1", "Android_F_4_0",
-            "Android_F_3_2",
-            "Android_F_2_3", "Android_F_2_2", "Android_F_2_1",
-            "Android_F"
           ]
         }
       ]

--- a/resources/user-agents/browsers/opera-mobile/opera-mobile-11-10.json
+++ b/resources/user-agents/browsers/opera-mobile/opera-mobile-11-10.json
@@ -6,9 +6,10 @@
   "standard": true,
   "userAgents": [
     {
-      "userAgent": "Opera Mobile #MAJORVER#.#MINORVER#",
+      "userAgent": "Opera Mobile #MAJORVER#.#MINORVER# for Android",
       "engine": "Presto_2_8",
       "device": "general Mobile Phone (Touch)",
+      "platform": "Android",
       "properties": {
         "Parent": "DefaultProperties",
         "Comment": "Opera Mobile #MAJORVER#.#MINORVER#",
@@ -19,21 +20,13 @@
       },
       "children": [
         {
-          "match": "Mozilla/4.0 (compatible; MSIE ?*.?*; #PLATFORM#)*Opera?#MAJORVER#.#MINORVER#*",
-          "platforms": [
-            "SymbianOS_C"
-          ]
-        },
-        {
           "match": "Opera/9.80*(#PLATFORM#Opera Mobi*)*Version/#MAJORVER#.#MINORVER#*",
           "platforms": [
             "AndroidLinux",
             "Android_F_5_0",
             "Android_F_4_4", "Android_F_4_3", "Android_F_4_2", "Android_F_4_1", "Android_F_4_0",
             "Android_F_2_3", "Android_F_2_2", "Android_F_2_1",
-            "Android_F",
-            "SymbianOS_C",
-            "WinMobile"
+            "Android_F"
           ]
         },
         {
@@ -65,6 +58,34 @@
           "match": "* Browser/Opera *Profile/MIDP* Opera/9.80 (MTK*) Presto/* Version/#MAJORVER#.#MINORVER#*",
           "platforms": [
             "Android"
+          ]
+        }
+      ]
+    },
+    {
+      "userAgent": "Opera Mobile #MAJORVER#.#MINORVER#",
+      "engine": "Presto_2_8",
+      "device": "general Mobile Phone (Touch)",
+      "properties": {
+        "Parent": "DefaultProperties",
+        "Comment": "Opera Mobile #MAJORVER#.#MINORVER#",
+        "Browser": "Opera Mobile",
+        "Browser_Maker": "Opera Software ASA",
+        "Browser_Type": "Browser",
+        "Version": "#MAJORVER#.#MINORVER#"
+      },
+      "children": [
+        {
+          "match": "Mozilla/4.0 (compatible; MSIE ?*.?*; #PLATFORM#)*Opera?#MAJORVER#.#MINORVER#*",
+          "platforms": [
+            "SymbianOS_C"
+          ]
+        },
+        {
+          "match": "Opera/9.80*(#PLATFORM#Opera Mobi*)*Version/#MAJORVER#.#MINORVER#*",
+          "platforms": [
+            "SymbianOS_C",
+            "WinMobile"
           ]
         }
       ]

--- a/resources/user-agents/browsers/opera-mobile/opera-mobile-11-50.json
+++ b/resources/user-agents/browsers/opera-mobile/opera-mobile-11-50.json
@@ -6,9 +6,10 @@
   "standard": true,
   "userAgents": [
     {
-      "userAgent": "Opera Mobile #MAJORVER#.#MINORVER#",
+      "userAgent": "Opera Mobile #MAJORVER#.#MINORVER# for Android",
       "engine": "Presto_2_9",
       "device": "general Mobile Phone (Touch)",
+      "platform": "Android",
       "properties": {
         "Parent": "DefaultProperties",
         "Comment": "Opera Mobile #MAJORVER#.#MINORVER#",
@@ -25,10 +26,7 @@
             "Android_F_5_0",
             "Android_F_4_4", "Android_F_4_3", "Android_F_4_2", "Android_F_4_1", "Android_F_4_0",
             "Android_F_2_3", "Android_F_2_2", "Android_F_2_1",
-            "Android_F",
-            "SymbianOS_C",
-            "WinMobile",
-            "Maemo_ARM"
+            "Android_F"
           ]
         },
         {
@@ -40,6 +38,29 @@
             "Android_F_3_2", "Android_F_3_1", "Android_F_3_0",
             "Android_F_2_3", "Android_F_2_2", "Android_F_2_1",
             "Android_F"
+          ]
+        }
+      ]
+    },
+    {
+      "userAgent": "Opera Mobile #MAJORVER#.#MINORVER#",
+      "engine": "Presto_2_9",
+      "device": "general Mobile Phone (Touch)",
+      "properties": {
+        "Parent": "DefaultProperties",
+        "Comment": "Opera Mobile #MAJORVER#.#MINORVER#",
+        "Browser": "Opera Mobile",
+        "Browser_Maker": "Opera Software ASA",
+        "Browser_Type": "Browser",
+        "Version": "#MAJORVER#.#MINORVER#"
+      },
+      "children": [
+        {
+          "match": "Opera/9.80*(#PLATFORM#Opera Mobi*)*Version/#MAJORVER#.#MINORVER#*",
+          "platforms": [
+            "SymbianOS_C",
+            "WinMobile",
+            "Maemo_ARM"
           ]
         }
       ]

--- a/resources/user-agents/browsers/opera-mobile/opera-mobile-11-60-to-12-13.json
+++ b/resources/user-agents/browsers/opera-mobile/opera-mobile-11-60-to-12-13.json
@@ -6,6 +6,50 @@
   "standard": true,
   "userAgents": [
     {
+      "userAgent": "Opera Mobile #MAJORVER#.#MINORVER# for Android",
+      "engine": "Presto_2_10",
+      "device": "general Mobile Phone (Touch)",
+      "platform": "Android",
+      "properties": {
+        "Parent": "DefaultProperties",
+        "Comment": "Opera Mobile #MAJORVER#.#MINORVER#",
+        "Browser": "Opera Mobile",
+        "Browser_Maker": "Opera Software ASA",
+        "Browser_Type": "Browser",
+        "Version": "#MAJORVER#.#MINORVER#"
+      },
+      "children": [
+        {
+          "match": "Opera/9.80*(#PLATFORM#Opera Mobi*)*Version/#MAJORVER#.#MINORVER#*",
+          "platforms": [
+            "AndroidLinux",
+            "Android_F_7_1", "Android_F_7_0",
+            "Android_F_6_0",
+            "Android_F_5_1", "Android_F_5_0",
+            "Android_F_4_4", "Android_F_4_3", "Android_F_4_2", "Android_F_4_1", "Android_F_4_0",
+            "Android_F_2_3", "Android_F_2_2", "Android_F_2_1", "Android_F_2_0",
+            "Android_F_1_6",
+            "Android_F"
+          ]
+        },
+        {
+          "match": "Opera/9.80*(#PLATFORM#Opera Tablet*)*Version/#MAJORVER#.#MINORVER#*",
+          "device": "general Tablet",
+          "platforms": [
+            "AndroidLinux",
+            "Android_F_7_1", "Android_F_7_0",
+            "Android_F_6_0",
+            "Android_F_5_1", "Android_F_5_0",
+            "Android_F_4_4", "Android_F_4_3", "Android_F_4_2", "Android_F_4_1", "Android_F_4_0",
+            "Android_F_3_2", "Android_F_3_1", "Android_F_3_0",
+            "Android_F_2_3", "Android_F_2_2", "Android_F_2_1", "Android_F_2_0",
+            "Android_F_1_6",
+            "Android_F"
+          ]
+        }
+      ]
+    },
+    {
       "userAgent": "Opera Mobile #MAJORVER#.#MINORVER#",
       "engine": "Presto_2_10",
       "device": "general Mobile Phone (Touch)",
@@ -27,14 +71,6 @@
         {
           "match": "Opera/9.80*(#PLATFORM#Opera Mobi*)*Version/#MAJORVER#.#MINORVER#*",
           "platforms": [
-            "AndroidLinux",
-            "Android_F_7_1", "Android_F_7_0",
-            "Android_F_6_0",
-            "Android_F_5_1", "Android_F_5_0",
-            "Android_F_4_4", "Android_F_4_3", "Android_F_4_2", "Android_F_4_1", "Android_F_4_0",
-            "Android_F_2_3", "Android_F_2_2", "Android_F_2_1", "Android_F_2_0",
-            "Android_F_1_6",
-            "Android_F",
             "SymbianOS_C",
             "WinMobile",
             "Maemo_ARM"
@@ -44,15 +80,6 @@
           "match": "Opera/9.80*(#PLATFORM#Opera Tablet*)*Version/#MAJORVER#.#MINORVER#*",
           "device": "general Tablet",
           "platforms": [
-            "AndroidLinux",
-            "Android_F_7_1", "Android_F_7_0",
-            "Android_F_6_0",
-            "Android_F_5_1", "Android_F_5_0",
-            "Android_F_4_4", "Android_F_4_3", "Android_F_4_2", "Android_F_4_1", "Android_F_4_0",
-            "Android_F_3_2", "Android_F_3_1", "Android_F_3_0",
-            "Android_F_2_3", "Android_F_2_2", "Android_F_2_1", "Android_F_2_0",
-            "Android_F_1_6",
-            "Android_F",
             "SymbianOS_C",
             "WinMobile"
           ]


### PR DESCRIPTION
Another browser that seemed like it could benefit from grouping the Android patterns separately from the other ones.

No surprises here though, reduced lines in `full_php_browscap.ini` by 1,709.