### PR TITLE
[Code] Allow setting an output divison & section type on `CustomFilter` and `CustomWriterFactory`

### DIFF
--- a/src/Browscap/Filter/CustomFilter.php
+++ b/src/Browscap/Filter/CustomFilter.php
@@ -17,6 +17,11 @@ class CustomFilter implements FilterInterface
     private $fields = [];
 
     /**
+     * @var string
+     */
+    private $outputType = FilterInterface::TYPE_FULL;
+
+    /**
      * @var \Browscap\Data\PropertyHolder
      */
     private $propertyHolder;
@@ -24,10 +29,12 @@ class CustomFilter implements FilterInterface
     /**
      * @param PropertyHolder $propertyHolder
      * @param array          $fields
+     * @param string         $outputType
      */
-    public function __construct(PropertyHolder $propertyHolder, array $fields)
+    public function __construct(PropertyHolder $propertyHolder, array $fields, $outputType = FilterInterface::TYPE_FULL)
     {
         $this->fields         = $fields;
+        $this->outputType     = $outputType;
         $this->propertyHolder = $propertyHolder;
     }
 
@@ -50,7 +57,17 @@ class CustomFilter implements FilterInterface
      */
     public function isOutput(Division $division) : bool
     {
-        return true;
+        switch ($this->outputType) {
+            case FilterInterface::TYPE_STANDARD:
+                return $division->isStandard();
+
+            case FilterInterface::TYPE_LITE:
+                return $division->isLite();
+
+            case FilterInterface::TYPE_FULL:
+            default:
+                return true;
+        }
     }
 
     /**
@@ -62,7 +79,17 @@ class CustomFilter implements FilterInterface
      */
     public function isOutputSection(array $section) : bool
     {
-        return true;
+        switch ($this->outputType) {
+            case FilterInterface::TYPE_STANDARD:
+                return !isset($section['standard']) || $section['standard'];
+
+            case FilterInterface::TYPE_LITE:
+                return isset($section['lite']) && $section['lite'];
+
+            case FilterInterface::TYPE_FULL:
+            default:
+                return true;
+        }
     }
 
     /**

--- a/src/Browscap/Writer/Factory/CustomWriterFactory.php
+++ b/src/Browscap/Writer/Factory/CustomWriterFactory.php
@@ -4,6 +4,7 @@ namespace Browscap\Writer\Factory;
 
 use Browscap\Data\PropertyHolder;
 use Browscap\Filter\CustomFilter;
+use Browscap\Filter\FilterInterface;
 use Browscap\Formatter;
 use Browscap\Formatter\FormatterInterface;
 use Browscap\Writer;
@@ -21,6 +22,7 @@ class CustomWriterFactory
      * @param string|null     $file
      * @param array           $fields
      * @param string          $format
+     * @param string          $outputType
      *
      * @return WriterCollection
      */
@@ -29,7 +31,8 @@ class CustomWriterFactory
         string $buildFolder,
         ?string $file = null,
         array $fields = [],
-        string $format = FormatterInterface::TYPE_PHP
+        string $format = FormatterInterface::TYPE_PHP,
+        string $outputType = FilterInterface::TYPE_FULL
     ) : WriterCollection {
         $writerCollection = new WriterCollection();
         $propertyHolder   = new PropertyHolder();
@@ -60,7 +63,7 @@ class CustomWriterFactory
             }
         }
 
-        $filter = new CustomFilter($propertyHolder, $fields);
+        $filter = new CustomFilter($propertyHolder, $fields, $outputType);
 
         switch ($format) {
             case FormatterInterface::TYPE_ASP:


### PR DESCRIPTION
I use this to do custom builds of BrowsCap JSON cache data that are shipped as part of a browser extension developed by me (size matters in this). If wanted I can also add another patch that implements the other filters as special configurations of the custom filter (reducing code concept duplication).

There is also another patch waiting to be made for allowing setting custom cache item prefix length, but this is the more important one.