### PR TITLE
Aborting useragent test suites when INI file building throws an exception

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ cache:
 stages:
   - composer validate
   - validate sources and tests
+  - style check
   - static code analysis
   - test
   - test with coverage
@@ -54,7 +55,7 @@ jobs:
       install: skip
       script: composer validate --strict
 
-    - stage: static code analysis
+    - stage: style check
       php: 7.1
       script: php -n -d memory_limit=768M vendor/bin/php-cs-fixer fix --dry-run -vv
 

--- a/tests/UserAgentsTest/V3/FullTest.php
+++ b/tests/UserAgentsTest/V3/FullTest.php
@@ -73,45 +73,54 @@ class FullTest extends TestCase
 
         $version = (string) $buildNumber;
 
-        $logger               = new NullLogger();
-        $writerCollection     = new WriterCollection();
-        self::$propertyHolder = new PropertyHolder();
-        self::$filter         = new FullFilter(self::$propertyHolder);
-        self::$writer         = new IniWriter($buildFolder . '/full_php_browscap.ini', $logger);
-        $formatter            = new PhpFormatter(self::$propertyHolder);
-        self::$writer->setFormatter($formatter);
-        self::$writer->setFilter(self::$filter);
-        $writerCollection->addWriter(self::$writer);
+        try {
+            $logger               = new NullLogger();
+            $writerCollection     = new WriterCollection();
+            self::$propertyHolder = new PropertyHolder();
+            self::$filter         = new FullFilter(self::$propertyHolder);
+            self::$writer         = new IniWriter($buildFolder . '/full_php_browscap.ini', $logger);
+            $formatter            = new PhpFormatter(self::$propertyHolder);
+            self::$writer->setFormatter($formatter);
+            self::$writer->setFilter(self::$filter);
+            $writerCollection->addWriter(self::$writer);
 
-        $dataCollectionFactory = new DataCollectionFactory($logger);
+            $dataCollectionFactory = new DataCollectionFactory($logger);
 
-        $buildGenerator = new BuildGenerator(
-            $resourceFolder,
-            $buildFolder,
-            $logger,
-            $writerCollection,
-            $dataCollectionFactory
-        );
+            $buildGenerator = new BuildGenerator(
+                $resourceFolder,
+                $buildFolder,
+                $logger,
+                $writerCollection,
+                $dataCollectionFactory
+            );
 
-        $buildGenerator->setCollectPatternIds(true);
-        $buildGenerator->run($version, false);
+            $buildGenerator->setCollectPatternIds(true);
+            $buildGenerator->run($version, false);
 
-        $cache = new File([File::DIR => $cacheFolder]);
-        $cache->flush();
+            $cache = new File([File::DIR => $cacheFolder]);
+            $cache->flush();
 
-        $resultFormatter = new LegacyFormatter();
+            $resultFormatter = new LegacyFormatter();
 
-        self::$browscap = new Browscap();
-        self::$browscap
-            ->setCache($cache)
-            ->setLogger($logger)
-            ->setFormatter($resultFormatter);
+            self::$browscap = new Browscap();
+            self::$browscap
+                ->setCache($cache)
+                ->setLogger($logger)
+                ->setFormatter($resultFormatter);
 
-        self::$browscapUpdater = new BrowscapUpdater();
-        self::$browscapUpdater
-            ->setCache($cache)
-            ->setLogger($logger)
-            ->convertFile($buildFolder . '/full_php_browscap.ini');
+            self::$browscapUpdater = new BrowscapUpdater();
+            self::$browscapUpdater
+                ->setCache($cache)
+                ->setLogger($logger)
+                ->convertFile($buildFolder . '/full_php_browscap.ini');
+        } catch (\Exception $e) {
+            die(sprintf(
+                'Browscap ini file could not be built in %s test class, there was an uncaught exception: %s (%s)' . PHP_EOL,
+                __CLASS__,
+                get_class($e),
+                $e->getMessage()
+            ));
+        }
     }
 
     /**

--- a/tests/UserAgentsTest/V3/LiteTest.php
+++ b/tests/UserAgentsTest/V3/LiteTest.php
@@ -73,45 +73,54 @@ class LiteTest extends TestCase
 
         $version = (string) $buildNumber;
 
-        $logger               = new NullLogger();
-        $writerCollection     = new WriterCollection();
-        self::$propertyHolder = new PropertyHolder();
-        self::$filter         = new LiteFilter(self::$propertyHolder);
-        self::$writer         = new IniWriter($buildFolder . '/lite_php_browscap.ini', $logger);
-        $formatter            = new PhpFormatter(self::$propertyHolder);
-        self::$writer->setFormatter($formatter);
-        self::$writer->setFilter(self::$filter);
-        $writerCollection->addWriter(self::$writer);
+        try {
+            $logger               = new NullLogger();
+            $writerCollection     = new WriterCollection();
+            self::$propertyHolder = new PropertyHolder();
+            self::$filter         = new LiteFilter(self::$propertyHolder);
+            self::$writer         = new IniWriter($buildFolder . '/lite_php_browscap.ini', $logger);
+            $formatter            = new PhpFormatter(self::$propertyHolder);
+            self::$writer->setFormatter($formatter);
+            self::$writer->setFilter(self::$filter);
+            $writerCollection->addWriter(self::$writer);
 
-        $dataCollectionFactory = new DataCollectionFactory($logger);
+            $dataCollectionFactory = new DataCollectionFactory($logger);
 
-        $buildGenerator = new BuildGenerator(
-            $resourceFolder,
-            $buildFolder,
-            $logger,
-            $writerCollection,
-            $dataCollectionFactory
-        );
+            $buildGenerator = new BuildGenerator(
+                $resourceFolder,
+                $buildFolder,
+                $logger,
+                $writerCollection,
+                $dataCollectionFactory
+            );
 
-        $buildGenerator->setCollectPatternIds(true);
-        $buildGenerator->run($version, false);
+            $buildGenerator->setCollectPatternIds(true);
+            $buildGenerator->run($version, false);
 
-        $cache = new File([File::DIR => $cacheFolder]);
-        $cache->flush();
+            $cache = new File([File::DIR => $cacheFolder]);
+            $cache->flush();
 
-        $resultFormatter = new LegacyFormatter();
+            $resultFormatter = new LegacyFormatter();
 
-        self::$browscap = new Browscap();
-        self::$browscap
-            ->setCache($cache)
-            ->setLogger($logger)
-            ->setFormatter($resultFormatter);
+            self::$browscap = new Browscap();
+            self::$browscap
+                ->setCache($cache)
+                ->setLogger($logger)
+                ->setFormatter($resultFormatter);
 
-        self::$browscapUpdater = new BrowscapUpdater();
-        self::$browscapUpdater
-            ->setCache($cache)
-            ->setLogger($logger)
-            ->convertFile($buildFolder . '/lite_php_browscap.ini');
+            self::$browscapUpdater = new BrowscapUpdater();
+            self::$browscapUpdater
+                ->setCache($cache)
+                ->setLogger($logger)
+                ->convertFile($buildFolder . '/lite_php_browscap.ini');
+        } catch (\Exception $e) {
+            die(sprintf(
+                'Browscap ini file could not be built in %s test class, there was an uncaught exception: %s (%s)' . PHP_EOL,
+                __CLASS__,
+                get_class($e),
+                $e->getMessage()
+            ));
+        }
     }
 
     /**

--- a/tests/UserAgentsTest/V3/StandardTest.php
+++ b/tests/UserAgentsTest/V3/StandardTest.php
@@ -73,45 +73,54 @@ class StandardTest extends TestCase
 
         $version = (string) $buildNumber;
 
-        $logger               = new NullLogger();
-        $writerCollection     = new WriterCollection();
-        self::$propertyHolder = new PropertyHolder();
-        self::$filter         = new StandardFilter(self::$propertyHolder);
-        self::$writer         = new IniWriter($buildFolder . '/php_browscap.ini', $logger);
-        $formatter            = new PhpFormatter(self::$propertyHolder);
-        self::$writer->setFormatter($formatter);
-        self::$writer->setFilter(self::$filter);
-        $writerCollection->addWriter(self::$writer);
+        try {
+            $logger               = new NullLogger();
+            $writerCollection     = new WriterCollection();
+            self::$propertyHolder = new PropertyHolder();
+            self::$filter         = new StandardFilter(self::$propertyHolder);
+            self::$writer         = new IniWriter($buildFolder . '/php_browscap.ini', $logger);
+            $formatter            = new PhpFormatter(self::$propertyHolder);
+            self::$writer->setFormatter($formatter);
+            self::$writer->setFilter(self::$filter);
+            $writerCollection->addWriter(self::$writer);
 
-        $dataCollectionFactory = new DataCollectionFactory($logger);
+            $dataCollectionFactory = new DataCollectionFactory($logger);
 
-        $buildGenerator = new BuildGenerator(
-            $resourceFolder,
-            $buildFolder,
-            $logger,
-            $writerCollection,
-            $dataCollectionFactory
-        );
+            $buildGenerator = new BuildGenerator(
+                $resourceFolder,
+                $buildFolder,
+                $logger,
+                $writerCollection,
+                $dataCollectionFactory
+            );
 
-        $buildGenerator->setCollectPatternIds(true);
-        $buildGenerator->run($version, false);
+            $buildGenerator->setCollectPatternIds(true);
+            $buildGenerator->run($version, false);
 
-        $cache = new File([File::DIR => $cacheFolder]);
-        $cache->flush();
+            $cache = new File([File::DIR => $cacheFolder]);
+            $cache->flush();
 
-        $resultFormatter = new LegacyFormatter();
+            $resultFormatter = new LegacyFormatter();
 
-        self::$browscap = new Browscap();
-        self::$browscap
-            ->setCache($cache)
-            ->setLogger($logger)
-            ->setFormatter($resultFormatter);
+            self::$browscap = new Browscap();
+            self::$browscap
+                ->setCache($cache)
+                ->setLogger($logger)
+                ->setFormatter($resultFormatter);
 
-        self::$browscapUpdater = new BrowscapUpdater();
-        self::$browscapUpdater
-            ->setCache($cache)
-            ->setLogger($logger)
-            ->convertFile($buildFolder . '/php_browscap.ini');
+            self::$browscapUpdater = new BrowscapUpdater();
+            self::$browscapUpdater
+                ->setCache($cache)
+                ->setLogger($logger)
+                ->convertFile($buildFolder . '/php_browscap.ini');
+        } catch (\Exception $e) {
+            die(sprintf(
+                'Browscap ini file could not be built in %s test class, there was an uncaught exception: %s (%s)' . PHP_EOL,
+                __CLASS__,
+                get_class($e),
+                $e->getMessage()
+            ));
+        }
     }
 
     /**

--- a/tests/UserAgentsTest/V4/FullTest.php
+++ b/tests/UserAgentsTest/V4/FullTest.php
@@ -69,40 +69,49 @@ class FullTest extends TestCase
 
         $version = (string) $buildNumber;
 
-        $logger               = new NullLogger();
-        $writerCollection     = new WriterCollection();
-        self::$propertyHolder = new PropertyHolder();
-        self::$filter         = new FullFilter(self::$propertyHolder);
-        self::$writer         = new IniWriter($buildFolder . '/full_php_browscap.ini', $logger);
-        $formatter            = new PhpFormatter(self::$propertyHolder);
-        self::$writer->setFormatter($formatter);
-        self::$writer->setFilter(self::$filter);
-        $writerCollection->addWriter(self::$writer);
+        try {
+            $logger               = new NullLogger();
+            $writerCollection     = new WriterCollection();
+            self::$propertyHolder = new PropertyHolder();
+            self::$filter         = new FullFilter(self::$propertyHolder);
+            self::$writer         = new IniWriter($buildFolder . '/full_php_browscap.ini', $logger);
+            $formatter            = new PhpFormatter(self::$propertyHolder);
+            self::$writer->setFormatter($formatter);
+            self::$writer->setFilter(self::$filter);
+            $writerCollection->addWriter(self::$writer);
 
-        $dataCollectionFactory = new DataCollectionFactory($logger);
+            $dataCollectionFactory = new DataCollectionFactory($logger);
 
-        $buildGenerator = new BuildGenerator(
-            $resourceFolder,
-            $buildFolder,
-            $logger,
-            $writerCollection,
-            $dataCollectionFactory
-        );
+            $buildGenerator = new BuildGenerator(
+                $resourceFolder,
+                $buildFolder,
+                $logger,
+                $writerCollection,
+                $dataCollectionFactory
+            );
 
-        $buildGenerator->setCollectPatternIds(true);
-        $buildGenerator->run($version, false);
+            $buildGenerator->setCollectPatternIds(true);
+            $buildGenerator->run($version, false);
 
-        $memoryCache = new ArrayCache();
-        $cache       = new SimpleCacheAdapter($memoryCache);
-        $cache->clear();
+            $memoryCache = new ArrayCache();
+            $cache       = new SimpleCacheAdapter($memoryCache);
+            $cache->clear();
 
-        $resultFormatter = new LegacyFormatter();
+            $resultFormatter = new LegacyFormatter();
 
-        self::$browscap = new Browscap($cache, $logger);
-        self::$browscap->setFormatter($resultFormatter);
+            self::$browscap = new Browscap($cache, $logger);
+            self::$browscap->setFormatter($resultFormatter);
 
-        $updater = new BrowscapUpdater($cache, $logger);
-        $updater->convertFile($buildFolder . '/full_php_browscap.ini');
+            $updater = new BrowscapUpdater($cache, $logger);
+            $updater->convertFile($buildFolder . '/full_php_browscap.ini');
+        } catch (\Exception $e) {
+            die(sprintf(
+                'Browscap ini file could not be built in %s test class, there was an uncaught exception: %s (%s)' . PHP_EOL,
+                __CLASS__,
+                get_class($e),
+                $e->getMessage()
+            ));
+        }
     }
 
     /**

--- a/tests/UserAgentsTest/V4/LiteTest.php
+++ b/tests/UserAgentsTest/V4/LiteTest.php
@@ -69,40 +69,49 @@ class LiteTest extends TestCase
 
         $version = (string) $buildNumber;
 
-        $logger               = new NullLogger();
-        $writerCollection     = new WriterCollection();
-        self::$propertyHolder = new PropertyHolder();
-        self::$filter         = new LiteFilter(self::$propertyHolder);
-        self::$writer         = new IniWriter($buildFolder . '/lite_php_browscap.ini', $logger);
-        $formatter            = new PhpFormatter(self::$propertyHolder);
-        self::$writer->setFormatter($formatter);
-        self::$writer->setFilter(self::$filter);
-        $writerCollection->addWriter(self::$writer);
+        try {
+            $logger               = new NullLogger();
+            $writerCollection     = new WriterCollection();
+            self::$propertyHolder = new PropertyHolder();
+            self::$filter         = new LiteFilter(self::$propertyHolder);
+            self::$writer         = new IniWriter($buildFolder . '/lite_php_browscap.ini', $logger);
+            $formatter            = new PhpFormatter(self::$propertyHolder);
+            self::$writer->setFormatter($formatter);
+            self::$writer->setFilter(self::$filter);
+            $writerCollection->addWriter(self::$writer);
 
-        $dataCollectionFactory = new DataCollectionFactory($logger);
+            $dataCollectionFactory = new DataCollectionFactory($logger);
 
-        $buildGenerator = new BuildGenerator(
-            $resourceFolder,
-            $buildFolder,
-            $logger,
-            $writerCollection,
-            $dataCollectionFactory
-        );
+            $buildGenerator = new BuildGenerator(
+                $resourceFolder,
+                $buildFolder,
+                $logger,
+                $writerCollection,
+                $dataCollectionFactory
+            );
 
-        $buildGenerator->setCollectPatternIds(true);
-        $buildGenerator->run($version, false);
+            $buildGenerator->setCollectPatternIds(true);
+            $buildGenerator->run($version, false);
 
-        $memoryCache = new ArrayCache();
-        $cache       = new SimpleCacheAdapter($memoryCache);
-        $cache->clear();
+            $memoryCache = new ArrayCache();
+            $cache       = new SimpleCacheAdapter($memoryCache);
+            $cache->clear();
 
-        $resultFormatter = new LegacyFormatter();
+            $resultFormatter = new LegacyFormatter();
 
-        self::$browscap = new Browscap($cache, $logger);
-        self::$browscap->setFormatter($resultFormatter);
+            self::$browscap = new Browscap($cache, $logger);
+            self::$browscap->setFormatter($resultFormatter);
 
-        $updater = new BrowscapUpdater($cache, $logger);
-        $updater->convertFile($buildFolder . '/lite_php_browscap.ini');
+            $updater = new BrowscapUpdater($cache, $logger);
+            $updater->convertFile($buildFolder . '/lite_php_browscap.ini');
+        } catch (\Exception $e) {
+            die(sprintf(
+                'Browscap ini file could not be built in %s test class, there was an uncaught exception: %s (%s)' . PHP_EOL,
+                __CLASS__,
+                get_class($e),
+                $e->getMessage()
+            ));
+        }
     }
 
     /**

--- a/tests/UserAgentsTest/V4/StandardTest.php
+++ b/tests/UserAgentsTest/V4/StandardTest.php
@@ -69,40 +69,49 @@ class StandardTest extends TestCase
 
         $version = (string) $buildNumber;
 
-        $logger               = new NullLogger();
-        $writerCollection     = new WriterCollection();
-        self::$propertyHolder = new PropertyHolder();
-        self::$filter         = new StandardFilter(self::$propertyHolder);
-        self::$writer         = new IniWriter($buildFolder . '/php_browscap.ini', $logger);
-        $formatter            = new PhpFormatter(self::$propertyHolder);
-        self::$writer->setFormatter($formatter);
-        self::$writer->setFilter(self::$filter);
-        $writerCollection->addWriter(self::$writer);
+        try {
+            $logger               = new NullLogger();
+            $writerCollection     = new WriterCollection();
+            self::$propertyHolder = new PropertyHolder();
+            self::$filter         = new StandardFilter(self::$propertyHolder);
+            self::$writer         = new IniWriter($buildFolder . '/php_browscap.ini', $logger);
+            $formatter            = new PhpFormatter(self::$propertyHolder);
+            self::$writer->setFormatter($formatter);
+            self::$writer->setFilter(self::$filter);
+            $writerCollection->addWriter(self::$writer);
 
-        $dataCollectionFactory = new DataCollectionFactory($logger);
+            $dataCollectionFactory = new DataCollectionFactory($logger);
 
-        $buildGenerator = new BuildGenerator(
-            $resourceFolder,
-            $buildFolder,
-            $logger,
-            $writerCollection,
-            $dataCollectionFactory
-        );
+            $buildGenerator = new BuildGenerator(
+                $resourceFolder,
+                $buildFolder,
+                $logger,
+                $writerCollection,
+                $dataCollectionFactory
+            );
 
-        $buildGenerator->setCollectPatternIds(true);
-        $buildGenerator->run($version, false);
+            $buildGenerator->setCollectPatternIds(true);
+            $buildGenerator->run($version, false);
 
-        $memoryCache = new ArrayCache();
-        $cache       = new SimpleCacheAdapter($memoryCache);
-        $cache->clear();
+            $memoryCache = new ArrayCache();
+            $cache       = new SimpleCacheAdapter($memoryCache);
+            $cache->clear();
 
-        $resultFormatter = new LegacyFormatter();
+            $resultFormatter = new LegacyFormatter();
 
-        self::$browscap = new Browscap($cache, $logger);
-        self::$browscap->setFormatter($resultFormatter);
+            self::$browscap = new Browscap($cache, $logger);
+            self::$browscap->setFormatter($resultFormatter);
 
-        $updater = new BrowscapUpdater($cache, $logger);
-        $updater->convertFile($buildFolder . '/php_browscap.ini');
+            $updater = new BrowscapUpdater($cache, $logger);
+            $updater->convertFile($buildFolder . '/php_browscap.ini');
+        } catch (\Exception $e) {
+            die(sprintf(
+                'Browscap ini file could not be built in %s test class, there was an uncaught exception: %s (%s)' . PHP_EOL,
+                __CLASS__,
+                get_class($e),
+                $e->getMessage()
+            ));
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #1333.

I ran into this again today, so figured I'd try to put together a solution for it.

I referenced an undefined platform in an update I'm doing, and this was the output when I ran the tests:

```
PHPUnit 7.2.4 by Sebastian Bergmann and contributors.

EEEEEEEEEEEEEEEEEEEEEEEEEEEEEE
(truncated)
```

Sometimes I kick off the tests and then come back to see how they did (I was watching them in this case), which is annoying when it's just a screen full of `E`s.  It's also not possible to know why the tests are failing here without letting the suite finish (which actually takes longer than a successful run), or aborting the suite and either running the build manually, or using the `--stop-on-failure` flag to phpunit.

With these changes, this error will get caught during the INI building process and then output will look something like this:

```
PHPUnit 7.2.4 by Sebastian Bergmann and contributors.

Browscap ini file could not be built in UserAgentsTest\V3\FullTest test class, there was an uncaught exception: OutOfBoundsException (Platform "iOS_I_11_3" does not exist in data)
```

IMO, this is more helpful, because the tests will abort immediately and will output a helpful error message so I can correct the issue and re-run the suite.

I don't know of a "clean" way to abort phpunit execution during the `setUpBeforeClass`, so used `die` here.