### PR TITLE
Removing unused cacheFolder variable and directory

### DIFF
--- a/tests/UserAgentsTest/V4/FullTest.php
+++ b/tests/UserAgentsTest/V4/FullTest.php
@@ -57,14 +57,10 @@ class FullTest extends TestCase
         $buildNumber    = time();
         $resourceFolder = __DIR__ . '/../../../resources/';
         $buildFolder    = __DIR__ . '/../../../build/browscap-ua-test-full4-' . $buildNumber . '/build/';
-        $cacheFolder    = __DIR__ . '/../../../build/browscap-ua-test-full4-' . $buildNumber . '/cache/';
 
         // create folders if it does not exist
         if (!file_exists($buildFolder)) {
             mkdir($buildFolder, 0777, true);
-        }
-        if (!file_exists($cacheFolder)) {
-            mkdir($cacheFolder, 0777, true);
         }
 
         $version = (string) $buildNumber;

--- a/tests/UserAgentsTest/V4/LiteTest.php
+++ b/tests/UserAgentsTest/V4/LiteTest.php
@@ -57,14 +57,10 @@ class LiteTest extends TestCase
         $buildNumber    = time();
         $resourceFolder = __DIR__ . '/../../../resources/';
         $buildFolder    = __DIR__ . '/../../../build/browscap-ua-test-lite4-' . $buildNumber . '/build/';
-        $cacheFolder    = __DIR__ . '/../../../build/browscap-ua-test-lite4-' . $buildNumber . '/cache/';
 
         // create folders if it does not exist
         if (!file_exists($buildFolder)) {
             mkdir($buildFolder, 0777, true);
-        }
-        if (!file_exists($cacheFolder)) {
-            mkdir($cacheFolder, 0777, true);
         }
 
         $version = (string) $buildNumber;

--- a/tests/UserAgentsTest/V4/StandardTest.php
+++ b/tests/UserAgentsTest/V4/StandardTest.php
@@ -57,14 +57,10 @@ class StandardTest extends TestCase
         $buildNumber    = time();
         $resourceFolder = __DIR__ . '/../../../resources/';
         $buildFolder    = __DIR__ . '/../../../build/browscap-ua-test-standard4-' . $buildNumber . '/build/';
-        $cacheFolder    = __DIR__ . '/../../../build/browscap-ua-test-standard4-' . $buildNumber . '/cache/';
 
         // create folders if it does not exist
         if (!file_exists($buildFolder)) {
             mkdir($buildFolder, 0777, true);
-        }
-        if (!file_exists($cacheFolder)) {
-            mkdir($cacheFolder, 0777, true);
         }
 
         $version = (string) $buildNumber;


### PR DESCRIPTION
I noticed that this directory isn't ever written to because the V4 tests use a memory cache.

Removing the variable, and the creation of the directory.