### PR TITLE
remove extra namespace, rewrite resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ vendor/
 .settings
 .project
 .php_cs.cache
+.phpunit.result.cache
 composer.phar
 test*.txt
 /coverage

--- a/composer.lock
+++ b/composer.lock
@@ -332,16 +332,16 @@
         },
         {
             "name": "mimmi20/ua-device-type",
-            "version": "6.0.0",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mimmi20/ua-device-type.git",
-                "reference": "c978e7e3bb169a3cbd635c7f70e59150f0c60f82"
+                "reference": "b36f9cb0dbe263b6fd9014c8340985ddb400738c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mimmi20/ua-device-type/zipball/c978e7e3bb169a3cbd635c7f70e59150f0c60f82",
-                "reference": "c978e7e3bb169a3cbd635c7f70e59150f0c60f82",
+                "url": "https://api.github.com/repos/mimmi20/ua-device-type/zipball/b36f9cb0dbe263b6fd9014c8340985ddb400738c",
+                "reference": "b36f9cb0dbe263b6fd9014c8340985ddb400738c",
                 "shasum": ""
             },
             "require": {
@@ -349,11 +349,10 @@
                 "php": "^7.1"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.10 || ^3.0",
-                "localheinz/composer-normalize": "^0.6.0",
-                "phpstan/phpstan": "^0.9",
-                "phpunit/phpunit": "^6.5 || ^7.0",
-                "squizlabs/php_codesniffer": "^3.2"
+                "friendsofphp/php-cs-fixer": "^2.13",
+                "phpstan/phpstan": "^0.10",
+                "phpunit/phpunit": "^7.3",
+                "squizlabs/php_codesniffer": "^3.3"
             },
             "type": "library",
             "autoload": {
@@ -385,7 +384,7 @@
                 "user agent",
                 "user-agent"
             ],
-            "time": "2018-03-08T18:50:12+00:00"
+            "time": "2018-08-31T19:48:13+00:00"
         },
         {
             "name": "monolog/monolog",

--- a/resources/devices/desktop/hp.json
+++ b/resources/devices/desktop/hp.json
@@ -1,13 +1,13 @@
 {
-    "HP SlateBook 14": {
-        "type": "desktop",
-        "properties": {
-            "Device_Name": "SlateBook 14",
-            "Device_Code_Name": "SlateBook 14",
-            "Device_Maker": "HP",
-            "Device_Pointing_Method": "mouse",
-            "Device_Brand_Name": "HP"
-        },
-        "standard": true
-    }
+  "HP SlateBook 14": {
+    "type": "desktop",
+    "properties": {
+      "Device_Name": "SlateBook 14",
+      "Device_Code_Name": "SlateBook 14",
+      "Device_Maker": "HP",
+      "Device_Pointing_Method": "mouse",
+      "Device_Brand_Name": "HP"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/desktop/lenovo.json
+++ b/resources/devices/desktop/lenovo.json
@@ -1,13 +1,13 @@
 {
-    "Lenovo N23 Yoga/Flex 11 Chromebook": {
-        "type": "desktop",
-        "properties": {
-            "Device_Name": "N23 Yoga/Flex 11",
-            "Device_Code_Name": "N23 Yoga/Flex 11",
-            "Device_Maker": "Lenovo",
-            "Device_Pointing_Method": "mouse",
-            "Device_Brand_Name": "Lenovo"
-        },
-        "standard": true
-    }
+  "Lenovo N23 Yoga/Flex 11 Chromebook": {
+    "type": "desktop",
+    "properties": {
+      "Device_Name": "N23 Yoga/Flex 11",
+      "Device_Code_Name": "N23 Yoga/Flex 11",
+      "Device_Maker": "Lenovo",
+      "Device_Pointing_Method": "mouse",
+      "Device_Brand_Name": "Lenovo"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/desktop/toshiba.json
+++ b/resources/devices/desktop/toshiba.json
@@ -1,13 +1,13 @@
 {
-    "Toshiba CB35-C3300": {
-        "type": "desktop",
-        "properties": {
-            "Device_Name": "Chromebook 2 - 2015 Edition",
-            "Device_Code_Name": "CB35-C3300",
-            "Device_Maker": "Toshiba",
-            "Device_Pointing_Method": "mouse",
-            "Device_Brand_Name": "Toshiba"
-        },
-        "standard": true
-    }
+  "Toshiba CB35-C3300": {
+    "type": "desktop",
+    "properties": {
+      "Device_Name": "Chromebook 2 - 2015 Edition",
+      "Device_Code_Name": "CB35-C3300",
+      "Device_Maker": "Toshiba",
+      "Device_Pointing_Method": "mouse",
+      "Device_Brand_Name": "Toshiba"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/mobile-device/gosh.json
+++ b/resources/devices/mobile-device/gosh.json
@@ -1,13 +1,13 @@
 {
-    "gosh! easyPlay": {
-        "type": "mobile-device",
-        "properties": {
-            "Device_Name": "easyPlay",
-            "Device_Code_Name": "easyPlay",
-            "Device_Maker": "gosh!",
-            "Device_Pointing_Method": "touchscreen",
-            "Device_Brand_Name": "gosh!"
-        },
-        "standard": true
-    }
+  "gosh! easyPlay": {
+    "type": "mobile-device",
+    "properties": {
+      "Device_Name": "easyPlay",
+      "Device_Code_Name": "easyPlay",
+      "Device_Maker": "gosh!",
+      "Device_Pointing_Method": "touchscreen",
+      "Device_Brand_Name": "gosh!"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tablet/bluebiit.json
+++ b/resources/devices/tablet/bluebiit.json
@@ -1,13 +1,13 @@
 {
-    "Bluebiit 2RockeR+": {
-        "type": "tablet",
-        "properties": {
-            "Device_Name": "2RockeR+",
-            "Device_Code_Name": "2RockeR+",
-            "Device_Maker": "Bluebiit",
-            "Device_Pointing_Method": "touchscreen",
-            "Device_Brand_Name": "Bluebiit"
-        },
-        "standard": true
-    }
+  "Bluebiit 2RockeR+": {
+    "type": "tablet",
+    "properties": {
+      "Device_Name": "2RockeR+",
+      "Device_Code_Name": "2RockeR+",
+      "Device_Maker": "Bluebiit",
+      "Device_Pointing_Method": "touchscreen",
+      "Device_Brand_Name": "Bluebiit"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tablet/carbayta.json
+++ b/resources/devices/tablet/carbayta.json
@@ -1,13 +1,13 @@
 {
-    "CARBAYTA S109": {
-        "type": "tablet",
-        "properties": {
-            "Device_Name": "S109",
-            "Device_Code_Name": "S109",
-            "Device_Maker": "CARBAYTA",
-            "Device_Pointing_Method": "touchscreen",
-            "Device_Brand_Name": "CARBAYTA"
-        },
-        "standard": true
-    }
+  "CARBAYTA S109": {
+    "type": "tablet",
+    "properties": {
+      "Device_Name": "S109",
+      "Device_Code_Name": "S109",
+      "Device_Maker": "CARBAYTA",
+      "Device_Pointing_Method": "touchscreen",
+      "Device_Brand_Name": "CARBAYTA"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tablet/chuwi.json
+++ b/resources/devices/tablet/chuwi.json
@@ -1,13 +1,13 @@
 {
-    "Chuwi CW-HI8-Super": {
-        "type": "tablet",
-        "properties": {
-            "Device_Name": "CW-HI8-Super",
-            "Device_Code_Name": "CW-HI8-Super",
-            "Device_Maker": "Chuwi",
-            "Device_Pointing_Method": "touchscreen",
-            "Device_Brand_Name": "Chuwi"
-        },
-        "standard": true
-    }
+  "Chuwi CW-HI8-Super": {
+    "type": "tablet",
+    "properties": {
+      "Device_Name": "CW-HI8-Super",
+      "Device_Code_Name": "CW-HI8-Super",
+      "Device_Maker": "Chuwi",
+      "Device_Pointing_Method": "touchscreen",
+      "Device_Brand_Name": "Chuwi"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tablet/estar.json
+++ b/resources/devices/tablet/estar.json
@@ -1,13 +1,13 @@
 {
-    "eSTAR Beauty 2 HD": {
-        "type": "tablet",
-        "properties": {
-            "Device_Name": "Beauty 2 HD",
-            "Device_Code_Name": "Beauty 2 HD",
-            "Device_Maker": "eSTAR",
-            "Device_Pointing_Method": "touchscreen",
-            "Device_Brand_Name": "eSTAR"
-        },
-        "standard": true
-    }
+  "eSTAR Beauty 2 HD": {
+    "type": "tablet",
+    "properties": {
+      "Device_Name": "Beauty 2 HD",
+      "Device_Code_Name": "Beauty 2 HD",
+      "Device_Maker": "eSTAR",
+      "Device_Pointing_Method": "touchscreen",
+      "Device_Brand_Name": "eSTAR"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tablet/fnf.json
+++ b/resources/devices/tablet/fnf.json
@@ -1,13 +1,13 @@
 {
-    "FNF Ifive Mini 4S": {
-        "type": "tablet",
-        "properties": {
-            "Device_Name": "Ifive Mini 4S",
-            "Device_Code_Name": "Ifive Mini 4S",
-            "Device_Maker": "FNF",
-            "Device_Pointing_Method": "touchscreen",
-            "Device_Brand_Name": "FNF"
-        },
-        "standard": true
-    }
+  "FNF Ifive Mini 4S": {
+    "type": "tablet",
+    "properties": {
+      "Device_Name": "Ifive Mini 4S",
+      "Device_Code_Name": "Ifive Mini 4S",
+      "Device_Maker": "FNF",
+      "Device_Pointing_Method": "touchscreen",
+      "Device_Brand_Name": "FNF"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tablet/freelander.json
+++ b/resources/devices/tablet/freelander.json
@@ -1,13 +1,13 @@
 {
-    "Freelander PX2": {
-        "type": "tablet",
-        "properties": {
-            "Device_Name": "PX2",
-            "Device_Code_Name": "PX2",
-            "Device_Maker": "Freelander",
-            "Device_Pointing_Method": "touchscreen",
-            "Device_Brand_Name": "Freelander"
-        },
-        "standard": true
-    }
+  "Freelander PX2": {
+    "type": "tablet",
+    "properties": {
+      "Device_Name": "PX2",
+      "Device_Code_Name": "PX2",
+      "Device_Maker": "Freelander",
+      "Device_Pointing_Method": "touchscreen",
+      "Device_Brand_Name": "Freelander"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tablet/gdippo.json
+++ b/resources/devices/tablet/gdippo.json
@@ -1,13 +1,13 @@
 {
-    "GDIPPO P706": {
-        "type": "tablet",
-        "properties": {
-            "Device_Name": "P706",
-            "Device_Code_Name": "P706",
-            "Device_Maker": "GDIPPO",
-            "Device_Pointing_Method": "touchscreen",
-            "Device_Brand_Name": "GDIPPO"
-        },
-        "standard": true
-    }
+  "GDIPPO P706": {
+    "type": "tablet",
+    "properties": {
+      "Device_Name": "P706",
+      "Device_Code_Name": "P706",
+      "Device_Maker": "GDIPPO",
+      "Device_Pointing_Method": "touchscreen",
+      "Device_Brand_Name": "GDIPPO"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tablet/gigabyte.json
+++ b/resources/devices/tablet/gigabyte.json
@@ -1,13 +1,13 @@
 {
-    "Gigabyte T1005": {
-        "type": "tablet",
-        "properties": {
-            "Device_Name": "T1005",
-            "Device_Code_Name": "T1005",
-            "Device_Maker": "Gigabyte Technology",
-            "Device_Pointing_Method": "touchscreen",
-            "Device_Brand_Name": "Gigabyte"
-        },
-        "standard": true
-    }
+  "Gigabyte T1005": {
+    "type": "tablet",
+    "properties": {
+      "Device_Name": "T1005",
+      "Device_Code_Name": "T1005",
+      "Device_Maker": "Gigabyte Technology",
+      "Device_Pointing_Method": "touchscreen",
+      "Device_Brand_Name": "Gigabyte"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tablet/gigaset.json
+++ b/resources/devices/tablet/gigaset.json
@@ -1,24 +1,24 @@
 {
-    "Gigaset QV830": {
-        "type": "tablet",
-        "properties": {
-            "Device_Name": "QV830",
-            "Device_Code_Name": "QV830",
-            "Device_Maker": "Gigaset",
-            "Device_Pointing_Method": "touchscreen",
-            "Device_Brand_Name": "Gigaset"
-        },
-        "standard": true
+  "Gigaset QV830": {
+    "type": "tablet",
+    "properties": {
+      "Device_Name": "QV830",
+      "Device_Code_Name": "QV830",
+      "Device_Maker": "Gigaset",
+      "Device_Pointing_Method": "touchscreen",
+      "Device_Brand_Name": "Gigaset"
     },
-    "Gigaset QV1030": {
-        "type": "tablet",
-        "properties": {
-            "Device_Name": "QV1030",
-            "Device_Code_Name": "QV1030",
-            "Device_Maker": "Gigaset",
-            "Device_Pointing_Method": "touchscreen",
-            "Device_Brand_Name": "Gigaset"
-        },
-        "standard": true
-    }
+    "standard": true
+  },
+  "Gigaset QV1030": {
+    "type": "tablet",
+    "properties": {
+      "Device_Name": "QV1030",
+      "Device_Code_Name": "QV1030",
+      "Device_Maker": "Gigaset",
+      "Device_Pointing_Method": "touchscreen",
+      "Device_Brand_Name": "Gigaset"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tablet/jizhao.json
+++ b/resources/devices/tablet/jizhao.json
@@ -1,13 +1,13 @@
 {
-    "JIZHAO JZ-V10L": {
-        "type": "tablet",
-        "properties": {
-            "Device_Name": "JZ-V10L",
-            "Device_Code_Name": "JZ-V10L",
-            "Device_Maker": "JIZHAO",
-            "Device_Pointing_Method": "touchscreen",
-            "Device_Brand_Name": "JIZHAO"
-        },
-        "standard": true
-    }
+  "JIZHAO JZ-V10L": {
+    "type": "tablet",
+    "properties": {
+      "Device_Name": "JZ-V10L",
+      "Device_Code_Name": "JZ-V10L",
+      "Device_Maker": "JIZHAO",
+      "Device_Pointing_Method": "touchscreen",
+      "Device_Brand_Name": "JIZHAO"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tablet/kurio.json
+++ b/resources/devices/tablet/kurio.json
@@ -1,13 +1,13 @@
 {
-    "Kurio C15100M": {
-        "type": "tablet",
-        "properties": {
-            "Device_Name": "Tab 2",
-            "Device_Code_Name": "C15100M",
-            "Device_Maker": "Kurio",
-            "Device_Pointing_Method": "touchscreen",
-            "Device_Brand_Name": "Kurio"
-        },
-        "standard": true
-    }
+  "Kurio C15100M": {
+    "type": "tablet",
+    "properties": {
+      "Device_Name": "Tab 2",
+      "Device_Code_Name": "C15100M",
+      "Device_Maker": "Kurio",
+      "Device_Pointing_Method": "touchscreen",
+      "Device_Brand_Name": "Kurio"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tablet/lonwalk.json
+++ b/resources/devices/tablet/lonwalk.json
@@ -1,13 +1,13 @@
 {
-    "Lonwalk T900": {
-        "type": "tablet",
-        "properties": {
-            "Device_Name": "T900",
-            "Device_Code_Name": "T900",
-            "Device_Maker": "Lonwalk",
-            "Device_Pointing_Method": "touchscreen",
-            "Device_Brand_Name": "Lonwalk"
-        },
-        "standard": true
-    }
+  "Lonwalk T900": {
+    "type": "tablet",
+    "properties": {
+      "Device_Name": "T900",
+      "Device_Code_Name": "T900",
+      "Device_Maker": "Lonwalk",
+      "Device_Pointing_Method": "touchscreen",
+      "Device_Brand_Name": "Lonwalk"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tablet/novus.json
+++ b/resources/devices/tablet/novus.json
@@ -1,24 +1,24 @@
 {
-    "Novus G8": {
-        "type": "tablet",
-        "properties": {
-            "Device_Name": "G8",
-            "Device_Code_Name": "G8",
-            "Device_Maker": "Novus",
-            "Device_Pointing_Method": "touchscreen",
-            "Device_Brand_Name": "Novus"
-        },
-        "standard": true
+  "Novus G8": {
+    "type": "tablet",
+    "properties": {
+      "Device_Name": "G8",
+      "Device_Code_Name": "G8",
+      "Device_Maker": "Novus",
+      "Device_Pointing_Method": "touchscreen",
+      "Device_Brand_Name": "Novus"
     },
-    "Novus 7.85": {
-        "type": "tablet",
-        "properties": {
-            "Device_Name": "7.85",
-            "Device_Code_Name": "7.85",
-            "Device_Maker": "Novus",
-            "Device_Pointing_Method": "touchscreen",
-            "Device_Brand_Name": "Novus"
-        },
-        "standard": true
-    }
+    "standard": true
+  },
+  "Novus 7.85": {
+    "type": "tablet",
+    "properties": {
+      "Device_Name": "7.85",
+      "Device_Code_Name": "7.85",
+      "Device_Maker": "Novus",
+      "Device_Pointing_Method": "touchscreen",
+      "Device_Brand_Name": "Novus"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tablet/nvidia.json
+++ b/resources/devices/tablet/nvidia.json
@@ -1,24 +1,24 @@
 {
-    "Nvidia Shield": {
-        "type": "tablet",
-        "properties": {
-            "Device_Name": "Shield",
-            "Device_Code_Name": "Shield",
-            "Device_Maker": "Nvidia",
-            "Device_Pointing_Method": "touchscreen",
-            "Device_Brand_Name": "Nvidia"
-        },
-        "standard": true
+  "Nvidia Shield": {
+    "type": "tablet",
+    "properties": {
+      "Device_Name": "Shield",
+      "Device_Code_Name": "Shield",
+      "Device_Maker": "Nvidia",
+      "Device_Pointing_Method": "touchscreen",
+      "Device_Brand_Name": "Nvidia"
     },
-    "Nvidia Shield K1": {
-        "type": "tablet",
-        "properties": {
-            "Device_Name": "Shield K1",
-            "Device_Code_Name": "Shield K1",
-            "Device_Maker": "Nvidia",
-            "Device_Pointing_Method": "touchscreen",
-            "Device_Brand_Name": "Nvidia"
-        },
-        "standard": true
-    }
+    "standard": true
+  },
+  "Nvidia Shield K1": {
+    "type": "tablet",
+    "properties": {
+      "Device_Name": "Shield K1",
+      "Device_Code_Name": "Shield K1",
+      "Device_Maker": "Nvidia",
+      "Device_Pointing_Method": "touchscreen",
+      "Device_Brand_Name": "Nvidia"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tablet/t-bao.json
+++ b/resources/devices/tablet/t-bao.json
@@ -1,13 +1,13 @@
 {
-    "T-Bao X101A": {
-        "type": "tablet",
-        "properties": {
-            "Device_Name": "X101A",
-            "Device_Code_Name": "X101A",
-            "Device_Maker": "T-Bao",
-            "Device_Pointing_Method": "touchscreen",
-            "Device_Brand_Name": "T-Bao"
-        },
-        "standard": true
-    }
+  "T-Bao X101A": {
+    "type": "tablet",
+    "properties": {
+      "Device_Name": "X101A",
+      "Device_Code_Name": "X101A",
+      "Device_Maker": "T-Bao",
+      "Device_Pointing_Method": "touchscreen",
+      "Device_Brand_Name": "T-Bao"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tablet/tcl.json
+++ b/resources/devices/tablet/tcl.json
@@ -1,13 +1,13 @@
 {
-    "TCL P17AA": {
-        "type": "tablet",
-        "properties": {
-            "Device_Name": "Xess",
-            "Device_Code_Name": "P17AA",
-            "Device_Maker": "TCL",
-            "Device_Pointing_Method": "touchscreen",
-            "Device_Brand_Name": "TCL"
-        },
-        "standard": true
-    }
+  "TCL P17AA": {
+    "type": "tablet",
+    "properties": {
+      "Device_Name": "Xess",
+      "Device_Code_Name": "P17AA",
+      "Device_Maker": "TCL",
+      "Device_Pointing_Method": "touchscreen",
+      "Device_Brand_Name": "TCL"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tablet/tesco.json
+++ b/resources/devices/tablet/tesco.json
@@ -1,13 +1,13 @@
 {
-    "Tesco Hudl 2": {
-        "type": "tablet",
-        "properties": {
-            "Device_Name": "Hudl 2",
-            "Device_Code_Name": "Hudl 2",
-            "Device_Maker": "Tesco",
-            "Device_Pointing_Method": "touchscreen",
-            "Device_Brand_Name": "Tesco"
-        },
-        "standard": true
-    }
+  "Tesco Hudl 2": {
+    "type": "tablet",
+    "properties": {
+      "Device_Name": "Hudl 2",
+      "Device_Code_Name": "Hudl 2",
+      "Device_Maker": "Tesco",
+      "Device_Pointing_Method": "touchscreen",
+      "Device_Brand_Name": "Tesco"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tablet/waltter.json
+++ b/resources/devices/tablet/waltter.json
@@ -1,13 +1,13 @@
 {
-    "Waltter Neo 10.1": {
-        "type": "tablet",
-        "properties": {
-            "Device_Name": "Neo 10.1",
-            "Device_Code_Name": "Neo 10.1",
-            "Device_Maker": "Waltter",
-            "Device_Pointing_Method": "touchscreen",
-            "Device_Brand_Name": "Waltter"
-        },
-        "standard": true
-    }
+  "Waltter Neo 10.1": {
+    "type": "tablet",
+    "properties": {
+      "Device_Name": "Neo 10.1",
+      "Device_Code_Name": "Neo 10.1",
+      "Device_Maker": "Waltter",
+      "Device_Pointing_Method": "touchscreen",
+      "Device_Brand_Name": "Waltter"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tablet/woxter.json
+++ b/resources/devices/tablet/woxter.json
@@ -1,13 +1,13 @@
 {
-    "Woxter QX105": {
-        "type": "tablet",
-        "properties": {
-            "Device_Name": "QX105",
-            "Device_Code_Name": "QX105",
-            "Device_Maker": "Woxter",
-            "Device_Pointing_Method": "touchscreen",
-            "Device_Brand_Name": "Woxter"
-        },
-        "standard": true
-    }
+  "Woxter QX105": {
+    "type": "tablet",
+    "properties": {
+      "Device_Name": "QX105",
+      "Device_Code_Name": "QX105",
+      "Device_Maker": "Woxter",
+      "Device_Pointing_Method": "touchscreen",
+      "Device_Brand_Name": "Woxter"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tablet/xcody.json
+++ b/resources/devices/tablet/xcody.json
@@ -1,13 +1,13 @@
 {
-    "Xgody K109": {
-        "type": "tablet",
-        "properties": {
-            "Device_Name": "K109",
-            "Device_Code_Name": "K109",
-            "Device_Maker": "Xgody",
-            "Device_Pointing_Method": "touchscreen",
-            "Device_Brand_Name": "Xgody"
-        },
-        "standard": true
-    }
+  "Xgody K109": {
+    "type": "tablet",
+    "properties": {
+      "Device_Name": "K109",
+      "Device_Code_Name": "K109",
+      "Device_Maker": "Xgody",
+      "Device_Pointing_Method": "touchscreen",
+      "Device_Brand_Name": "Xgody"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tablet/xido.json
+++ b/resources/devices/tablet/xido.json
@@ -1,13 +1,13 @@
 {
-    "XIDO X111": {
-        "type": "tablet",
-        "properties": {
-            "Device_Name": "X111",
-            "Device_Code_Name": "X111",
-            "Device_Maker": "XIDO",
-            "Device_Pointing_Method": "touchscreen",
-            "Device_Brand_Name": "XIDO"
-        },
-        "standard": true
-    }
+  "XIDO X111": {
+    "type": "tablet",
+    "properties": {
+      "Device_Name": "X111",
+      "Device_Code_Name": "X111",
+      "Device_Maker": "XIDO",
+      "Device_Pointing_Method": "touchscreen",
+      "Device_Brand_Name": "XIDO"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tablet/yuntab.json
+++ b/resources/devices/tablet/yuntab.json
@@ -1,13 +1,13 @@
 {
-    "Yuntab K107": {
-        "type": "tablet",
-        "properties": {
-            "Device_Name": "K107",
-            "Device_Code_Name": "K107",
-            "Device_Maker": "Yuntab",
-            "Device_Pointing_Method": "touchscreen",
-            "Device_Brand_Name": "Yuntab"
-        },
-        "standard": true
-    }
+  "Yuntab K107": {
+    "type": "tablet",
+    "properties": {
+      "Device_Name": "K107",
+      "Device_Code_Name": "K107",
+      "Device_Maker": "Yuntab",
+      "Device_Pointing_Method": "touchscreen",
+      "Device_Brand_Name": "Yuntab"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/alfawise.json
+++ b/resources/devices/tv-device/alfawise.json
@@ -1,46 +1,46 @@
 {
-    "Alfawise H96 Pro+": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "H96 Pro+",
-            "Device_Code_Name": "H96 Pro+",
-            "Device_Maker": "Alfawise",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Alfawise"
-        },
-        "standard": true
+  "Alfawise H96 Pro+": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "H96 Pro+",
+      "Device_Code_Name": "H96 Pro+",
+      "Device_Maker": "Alfawise",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Alfawise"
     },
-    "Alfawise H96 Pro": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "H96 Pro",
-            "Device_Code_Name": "H96 Pro",
-            "Device_Maker": "Alfawise",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Alfawise"
-        },
-        "standard": true
+    "standard": true
+  },
+  "Alfawise H96 Pro": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "H96 Pro",
+      "Device_Code_Name": "H96 Pro",
+      "Device_Maker": "Alfawise",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Alfawise"
     },
-    "Alfawise A95X R1": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "A95X R1",
-            "Device_Code_Name": "A95X R1",
-            "Device_Maker": "Alfawise",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Alfawise"
-        },
-        "standard": true
+    "standard": true
+  },
+  "Alfawise A95X R1": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "A95X R1",
+      "Device_Code_Name": "A95X R1",
+      "Device_Maker": "Alfawise",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Alfawise"
     },
-    "Alfawise S92": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "S92",
-            "Device_Code_Name": "S92",
-            "Device_Maker": "Alfawise",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Alfawise"
-        },
-        "standard": true
-    }
+    "standard": true
+  },
+  "Alfawise S92": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "S92",
+      "Device_Code_Name": "S92",
+      "Device_Maker": "Alfawise",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Alfawise"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/beelink.json
+++ b/resources/devices/tv-device/beelink.json
@@ -1,24 +1,24 @@
 {
-    "Beelink GT1": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "GT1",
-            "Device_Code_Name": "GT1",
-            "Device_Maker": "Beelink",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Beelink"
-        },
-        "standard": true
+  "Beelink GT1": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "GT1",
+      "Device_Code_Name": "GT1",
+      "Device_Maker": "Beelink",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Beelink"
     },
-    "Beelink Mini MXIII II": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "Mini MXIII II",
-            "Device_Code_Name": "Mini MXIII II",
-            "Device_Maker": "Beelink",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Beelink"
-        },
-        "standard": true
-    }
+    "standard": true
+  },
+  "Beelink Mini MXIII II": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "Mini MXIII II",
+      "Device_Code_Name": "Mini MXIII II",
+      "Device_Maker": "Beelink",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Beelink"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/bomix.json
+++ b/resources/devices/tv-device/bomix.json
@@ -1,46 +1,46 @@
 {
-    "BOMIX MXQpro": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "MXQ Pro",
-            "Device_Code_Name": "MXQ Pro",
-            "Device_Maker": "BOMIX",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "BOMIX"
-        },
-        "standard": true
+  "BOMIX MXQpro": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "MXQ Pro",
+      "Device_Code_Name": "MXQ Pro",
+      "Device_Maker": "BOMIX",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "BOMIX"
     },
-    "BOMIX HX 3229": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "MXQ Pro",
-            "Device_Code_Name": "HX 3229",
-            "Device_Maker": "BOMIX",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "BOMIX"
-        },
-        "standard": true
+    "standard": true
+  },
+  "BOMIX HX 3229": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "MXQ Pro",
+      "Device_Code_Name": "HX 3229",
+      "Device_Maker": "BOMIX",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "BOMIX"
     },
-    "BOMIX MXQ": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "MXQ",
-            "Device_Code_Name": "MXQ",
-            "Device_Maker": "BOMIX",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "BOMIX"
-        },
-        "standard": true
+    "standard": true
+  },
+  "BOMIX MXQ": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "MXQ",
+      "Device_Code_Name": "MXQ",
+      "Device_Maker": "BOMIX",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "BOMIX"
     },
-    "BOMIX MXQ Pro P281": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "MXQ Pro P281",
-            "Device_Code_Name": "MXQ Pro P281",
-            "Device_Maker": "BOMIX",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "BOMIX"
-        },
-        "standard": true
-    }
+    "standard": true
+  },
+  "BOMIX MXQ Pro P281": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "MXQ Pro P281",
+      "Device_Code_Name": "MXQ Pro P281",
+      "Device_Maker": "BOMIX",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "BOMIX"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/canal-digital.json
+++ b/resources/devices/tv-device/canal-digital.json
@@ -1,13 +1,13 @@
 {
-    "Canal Digital S70CDS": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "OnePlace",
-            "Device_Code_Name": "S70CDS",
-            "Device_Maker": "Canal Digital",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Canal Digital"
-        },
-        "standard": true
-    }
+  "Canal Digital S70CDS": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "OnePlace",
+      "Device_Code_Name": "S70CDS",
+      "Device_Maker": "Canal Digital",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Canal Digital"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/dna.json
+++ b/resources/devices/tv-device/dna.json
@@ -1,13 +1,13 @@
 {
-    "DNA TV-hubi": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "TV-hubi",
-            "Device_Code_Name": "TV-hubi",
-            "Device_Maker": "DNA",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "DNA"
-        },
-        "standard": true
-    }
+  "DNA TV-hubi": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "TV-hubi",
+      "Device_Code_Name": "TV-hubi",
+      "Device_Maker": "DNA",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "DNA"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/docooler.json
+++ b/resources/devices/tv-device/docooler.json
@@ -1,24 +1,24 @@
 {
-    "Docooler A5X Plus": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "A5X Plus",
-            "Device_Code_Name": "A5X Plus",
-            "Device_Maker": "Docooler",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Docooler"
-        },
-        "standard": true
+  "Docooler A5X Plus": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "A5X Plus",
+      "Device_Code_Name": "A5X Plus",
+      "Device_Maker": "Docooler",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Docooler"
     },
-    "Docooler Z28": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "Z28",
-            "Device_Code_Name": "Z28",
-            "Device_Maker": "Docooler",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Docooler"
-        },
-        "standard": true
-    }
+    "standard": true
+  },
+  "Docooler Z28": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "Z28",
+      "Device_Code_Name": "Z28",
+      "Device_Maker": "Docooler",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Docooler"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/edal.json
+++ b/resources/devices/tv-device/edal.json
@@ -1,13 +1,13 @@
 {
-    "Edal KM8 Pro": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "KM8 Pro",
-            "Device_Code_Name": "KM8 Pro",
-            "Device_Maker": "Edal",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Edal"
-        },
-        "standard": true
-    }
+  "Edal KM8 Pro": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "KM8 Pro",
+      "Device_Code_Name": "KM8 Pro",
+      "Device_Maker": "Edal",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Edal"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/etbotu.json
+++ b/resources/devices/tv-device/etbotu.json
@@ -1,13 +1,13 @@
 {
-    "Etbotu MiniM8S II": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "MiniM8S II",
-            "Device_Code_Name": "MiniM8S II",
-            "Device_Maker": "Etbotu",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Etbotu"
-        },
-        "standard": true
-    }
+  "Etbotu MiniM8S II": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "MiniM8S II",
+      "Device_Code_Name": "MiniM8S II",
+      "Device_Maker": "Etbotu",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Etbotu"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/ferguson.json
+++ b/resources/devices/tv-device/ferguson.json
@@ -1,13 +1,13 @@
 {
-    "Ferguson FBOX ATV": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "FBOX ATV",
-            "Device_Code_Name": "FBOX ATV",
-            "Device_Maker": "Ferguson sp. z o.o.",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Ferguson"
-        },
-        "standard": true
-    }
+  "Ferguson FBOX ATV": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "FBOX ATV",
+      "Device_Code_Name": "FBOX ATV",
+      "Device_Maker": "Ferguson sp. z o.o.",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Ferguson"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/gimi.json
+++ b/resources/devices/tv-device/gimi.json
@@ -1,13 +1,13 @@
 {
-    "GIMI XGIMI TV": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "XGIMI TV",
-            "Device_Code_Name": "XGIMI TV",
-            "Device_Maker": "GIMI",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "GIMI"
-        },
-        "standard": true
-    }
+  "GIMI XGIMI TV": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "XGIMI TV",
+      "Device_Code_Name": "XGIMI TV",
+      "Device_Maker": "GIMI",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "GIMI"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/hxws.json
+++ b/resources/devices/tv-device/hxws.json
@@ -1,13 +1,13 @@
 {
-    "HXWS HX S905": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "HX S905",
-            "Device_Code_Name": "HX S905",
-            "Device_Maker": "HXWS",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "HXWS"
-        },
-        "standard": true
-    }
+  "HXWS HX S905": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "HX S905",
+      "Device_Code_Name": "HX S905",
+      "Device_Maker": "HXWS",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "HXWS"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/koenig.json
+++ b/resources/devices/tv-device/koenig.json
@@ -1,13 +1,13 @@
 {
-    "Koenig 4KASB": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "DVB-TS2",
-            "Device_Code_Name": "4KASB",
-            "Device_Maker": "Koenig",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Koenig"
-        },
-        "standard": true
-    }
+  "Koenig 4KASB": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "DVB-TS2",
+      "Device_Code_Name": "4KASB",
+      "Device_Maker": "Koenig",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Koenig"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/leelbox.json
+++ b/resources/devices/tv-device/leelbox.json
@@ -1,13 +1,13 @@
 {
-    "Leelbox Leelbox": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "Leelbox",
-            "Device_Code_Name": "Leelbox",
-            "Device_Maker": "Leelbox",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Leelbox"
-        },
-        "standard": true
-    }
+  "Leelbox Leelbox": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "Leelbox",
+      "Device_Code_Name": "Leelbox",
+      "Device_Maker": "Leelbox",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Leelbox"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/magicsee.json
+++ b/resources/devices/tv-device/magicsee.json
@@ -1,13 +1,13 @@
 {
-    "Magicsee C300PRO": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "C300PRO",
-            "Device_Code_Name": "C300PRO",
-            "Device_Maker": "Magicsee",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Magicsee"
-        },
-        "standard": true
-    }
+  "Magicsee C300PRO": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "C300PRO",
+      "Device_Code_Name": "C300PRO",
+      "Device_Maker": "Magicsee",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Magicsee"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/mecool.json
+++ b/resources/devices/tv-device/mecool.json
@@ -1,46 +1,46 @@
 {
-    "Mecool M8S Pro": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "M8S Pro",
-            "Device_Code_Name": "M8S Pro",
-            "Device_Maker": "Mecool",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Mecool"
-        },
-        "standard": true
+  "Mecool M8S Pro": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "M8S Pro",
+      "Device_Code_Name": "M8S Pro",
+      "Device_Maker": "Mecool",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Mecool"
     },
-    "Mecool M8S Pro L": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "M8S Pro L",
-            "Device_Code_Name": "M8S Pro L",
-            "Device_Maker": "Mecool",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Mecool"
-        },
-        "standard": true
+    "standard": true
+  },
+  "Mecool M8S Pro L": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "M8S Pro L",
+      "Device_Code_Name": "M8S Pro L",
+      "Device_Maker": "Mecool",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Mecool"
     },
-    "Mecool BB2 Pro": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "BB2 Pro",
-            "Device_Code_Name": "BB2 Pro",
-            "Device_Maker": "Mecool",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Mecool"
-        },
-        "standard": true
+    "standard": true
+  },
+  "Mecool BB2 Pro": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "BB2 Pro",
+      "Device_Code_Name": "BB2 Pro",
+      "Device_Maker": "Mecool",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Mecool"
     },
-    "Mecool KIII Pro": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "KIII Pro",
-            "Device_Code_Name": "KIII Pro",
-            "Device_Maker": "Mecool",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Mecool"
-        },
-        "standard": true
-    }
+    "standard": true
+  },
+  "Mecool KIII Pro": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "KIII Pro",
+      "Device_Code_Name": "KIII Pro",
+      "Device_Maker": "Mecool",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Mecool"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/mstar.json
+++ b/resources/devices/tv-device/mstar.json
@@ -1,13 +1,13 @@
 {
-    "MStar Set-Top Box": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "Set-Top Box",
-            "Device_Code_Name": "Set-Top Box",
-            "Device_Maker": "MStar",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "MStar"
-        },
-        "standard": true
-    }
+  "MStar Set-Top Box": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "Set-Top Box",
+      "Device_Code_Name": "Set-Top Box",
+      "Device_Maker": "MStar",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "MStar"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/mxr.json
+++ b/resources/devices/tv-device/mxr.json
@@ -1,13 +1,13 @@
 {
-    "MXR Pro": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "Pro",
-            "Device_Code_Name": "Pro",
-            "Device_Maker": "MXR",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "MXR"
-        },
-        "standard": true
-    }
+  "MXR Pro": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "Pro",
+      "Device_Code_Name": "Pro",
+      "Device_Maker": "MXR",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "MXR"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/nexbox.json
+++ b/resources/devices/tv-device/nexbox.json
@@ -1,24 +1,24 @@
 {
-    "Nexbox A95X": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "A95X",
-            "Device_Code_Name": "A95X",
-            "Device_Maker": "Nexbox",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Nexbox"
-        },
-        "standard": true
+  "Nexbox A95X": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "A95X",
+      "Device_Code_Name": "A95X",
+      "Device_Maker": "Nexbox",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Nexbox"
     },
-    "Nexbox A95X A2": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "A95X A2",
-            "Device_Code_Name": "A95X A2",
-            "Device_Maker": "Nexbox",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Nexbox"
-        },
-        "standard": true
-    }
+    "standard": true
+  },
+  "Nexbox A95X A2": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "A95X A2",
+      "Device_Code_Name": "A95X A2",
+      "Device_Maker": "Nexbox",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Nexbox"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/nvidia.json
+++ b/resources/devices/tv-device/nvidia.json
@@ -1,13 +1,13 @@
 {
-    "Nvidia Shield TV": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "Shield TV",
-            "Device_Code_Name": "Shield TV",
-            "Device_Maker": "Nvidia",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Nvidia"
-        },
-        "standard": true
-    }
+  "Nvidia Shield TV": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "Shield TV",
+      "Device_Code_Name": "Shield TV",
+      "Device_Maker": "Nvidia",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Nvidia"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/r-box.json
+++ b/resources/devices/tv-device/r-box.json
@@ -1,13 +1,13 @@
 {
-    "R-Box Pro 3G": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "Pro 3G",
-            "Device_Code_Name": "Pro 3G",
-            "Device_Maker": "R-Box",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "R-Box"
-        },
-        "standard": true
-    }
+  "R-Box Pro 3G": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "Pro 3G",
+      "Device_Code_Name": "Pro 3G",
+      "Device_Maker": "R-Box",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "R-Box"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/r-tv-box.json
+++ b/resources/devices/tv-device/r-tv-box.json
@@ -1,35 +1,35 @@
 {
-    "R-TV Box S10": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "S10",
-            "Device_Code_Name": "S10",
-            "Device_Maker": "R-TV Box",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "R-TV Box"
-        },
-        "standard": true
+  "R-TV Box S10": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "S10",
+      "Device_Code_Name": "S10",
+      "Device_Maker": "R-TV Box",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "R-TV Box"
     },
-    "R-TV Box Mini+": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "Mini+",
-            "Device_Code_Name": "Mini+",
-            "Device_Maker": "R-TV Box",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "R-TV Box"
-        },
-        "standard": true
+    "standard": true
+  },
+  "R-TV Box Mini+": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "Mini+",
+      "Device_Code_Name": "Mini+",
+      "Device_Maker": "R-TV Box",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "R-TV Box"
     },
-    "R-TV Box Mini 00": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "Mini 00",
-            "Device_Code_Name": "Mini 00",
-            "Device_Maker": "R-TV Box",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "R-TV Box"
-        },
-        "standard": true
-    }
+    "standard": true
+  },
+  "R-TV Box Mini 00": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "Mini 00",
+      "Device_Code_Name": "Mini 00",
+      "Device_Maker": "R-TV Box",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "R-TV Box"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/rikomagic.json
+++ b/resources/devices/tv-device/rikomagic.json
@@ -1,13 +1,13 @@
 {
-    "Rikomagic RKM MK68": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "RKM MK68",
-            "Device_Code_Name": "RKM MK68",
-            "Device_Maker": "Rikomagic",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Rikomagic"
-        },
-        "standard": true
-    }
+  "Rikomagic RKM MK68": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "RKM MK68",
+      "Device_Code_Name": "RKM MK68",
+      "Device_Maker": "Rikomagic",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Rikomagic"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/scishion.json
+++ b/resources/devices/tv-device/scishion.json
@@ -1,13 +1,13 @@
 {
-    "SCISHION V88": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "V88",
-            "Device_Code_Name": "V88",
-            "Device_Maker": "SCISHION",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "SCISHION"
-        },
-        "standard": true
-    }
+  "SCISHION V88": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "V88",
+      "Device_Code_Name": "V88",
+      "Device_Maker": "SCISHION",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "SCISHION"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/shysky.json
+++ b/resources/devices/tv-device/shysky.json
@@ -1,24 +1,24 @@
 {
-    "ShySky X96": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "X96",
-            "Device_Code_Name": "X96",
-            "Device_Maker": "ShySky",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "ShySky"
-        },
-        "standard": true
+  "ShySky X96": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "X96",
+      "Device_Code_Name": "X96",
+      "Device_Maker": "ShySky",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "ShySky"
     },
-    "ShySky X96 mini": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "X96 mini",
-            "Device_Code_Name": "X96 mini",
-            "Device_Maker": "ShySky",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "ShySky"
-        },
-        "standard": true
-    }
+    "standard": true
+  },
+  "ShySky X96 mini": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "X96 mini",
+      "Device_Code_Name": "X96 mini",
+      "Device_Maker": "ShySky",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "ShySky"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/sunvell.json
+++ b/resources/devices/tv-device/sunvell.json
@@ -1,13 +1,13 @@
 {
-    "Sunvell T95Kpro": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "T95Kpro",
-            "Device_Code_Name": "T95Kpro",
-            "Device_Maker": "Sunvell",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Sunvell"
-        },
-        "standard": true
-    }
+  "Sunvell T95Kpro": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "T95Kpro",
+      "Device_Code_Name": "T95Kpro",
+      "Device_Maker": "Sunvell",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Sunvell"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/tanix.json
+++ b/resources/devices/tv-device/tanix.json
@@ -1,35 +1,35 @@
 {
-    "Tanix TX2": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "TX2",
-            "Device_Code_Name": "TX2",
-            "Device_Maker": "Tanix",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Tanix"
-        },
-        "standard": true
+  "Tanix TX2": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "TX2",
+      "Device_Code_Name": "TX2",
+      "Device_Maker": "Tanix",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Tanix"
     },
-    "Tanix TX3 Mini": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "TX3 Mini",
-            "Device_Code_Name": "TX3 Mini",
-            "Device_Maker": "Tanix",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Tanix"
-        },
-        "standard": true
+    "standard": true
+  },
+  "Tanix TX3 Mini": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "TX3 Mini",
+      "Device_Code_Name": "TX3 Mini",
+      "Device_Maker": "Tanix",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Tanix"
     },
-    "Tanix TX3 Pro": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "TX3 Pro",
-            "Device_Code_Name": "TX3 Pro",
-            "Device_Maker": "Tanix",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Tanix"
-        },
-        "standard": true
-    }
+    "standard": true
+  },
+  "Tanix TX3 Pro": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "TX3 Pro",
+      "Device_Code_Name": "TX3 Pro",
+      "Device_Maker": "Tanix",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Tanix"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/tcl.json
+++ b/resources/devices/tv-device/tcl.json
@@ -1,13 +1,13 @@
 {
-    "TCL Percee TV": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "Percee TV",
-            "Device_Code_Name": "Percee TV",
-            "Device_Maker": "TCL",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "TCL"
-        },
-        "standard": true
-    }
+  "TCL Percee TV": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "Percee TV",
+      "Device_Code_Name": "Percee TV",
+      "Device_Maker": "TCL",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "TCL"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/tizzbird.json
+++ b/resources/devices/tv-device/tizzbird.json
@@ -1,13 +1,13 @@
 {
-    "TizzBird N1": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "N1",
-            "Device_Code_Name": "N1",
-            "Device_Maker": "TizzBird",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "TizzBird"
-        },
-        "standard": true
-    }
+  "TizzBird N1": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "N1",
+      "Device_Code_Name": "N1",
+      "Device_Maker": "TizzBird",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "TizzBird"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/topfield.json
+++ b/resources/devices/tv-device/topfield.json
@@ -1,13 +1,13 @@
 {
-    "Topfield TF6200HD Smart": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "TF6200HD Smart",
-            "Device_Code_Name": "TF6200HD Smart",
-            "Device_Maker": "Topfield",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Topfield"
-        },
-        "standard": true
-    }
+  "Topfield TF6200HD Smart": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "TF6200HD Smart",
+      "Device_Code_Name": "TF6200HD Smart",
+      "Device_Maker": "Topfield",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Topfield"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/toumei.json
+++ b/resources/devices/tv-device/toumei.json
@@ -1,13 +1,13 @@
 {
-    "Toumei C800": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "C800",
-            "Device_Code_Name": "C800",
-            "Device_Maker": "Toumei",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Toumei"
-        },
-        "standard": true
-    }
+  "Toumei C800": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "C800",
+      "Device_Code_Name": "C800",
+      "Device_Maker": "Toumei",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Toumei"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/tronsmart.json
+++ b/resources/devices/tv-device/tronsmart.json
@@ -1,46 +1,46 @@
 {
-    "Tronsmart MK903V": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "MK903V",
-            "Device_Code_Name": "MK903V",
-            "Device_Maker": "Tronsmart",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Tronsmart"
-        },
-        "standard": true
+  "Tronsmart MK903V": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "MK903V",
+      "Device_Code_Name": "MK903V",
+      "Device_Maker": "Tronsmart",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Tronsmart"
     },
-    "Tronsmart MK908": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "MK908",
-            "Device_Code_Name": "MK908",
-            "Device_Maker": "Tronsmart",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Tronsmart"
-        },
-        "standard": true
+    "standard": true
+  },
+  "Tronsmart MK908": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "MK908",
+      "Device_Code_Name": "MK908",
+      "Device_Maker": "Tronsmart",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Tronsmart"
     },
-    "Tronsmart MXIII Plus": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "MXIII Plus",
-            "Device_Code_Name": "MXIII Plus",
-            "Device_Maker": "Tronsmart",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Tronsmart"
-        },
-        "standard": true
+    "standard": true
+  },
+  "Tronsmart MXIII Plus": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "MXIII Plus",
+      "Device_Code_Name": "MXIII Plus",
+      "Device_Maker": "Tronsmart",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Tronsmart"
     },
-    "Tronsmart CX-919": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "CX-919",
-            "Device_Code_Name": "CX-919",
-            "Device_Maker": "Tronsmart",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Tronsmart"
-        },
-        "standard": true
-    }
+    "standard": true
+  },
+  "Tronsmart CX-919": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "CX-919",
+      "Device_Code_Name": "CX-919",
+      "Device_Maker": "Tronsmart",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Tronsmart"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/uuvision.json
+++ b/resources/devices/tv-device/uuvision.json
@@ -1,13 +1,13 @@
 {
-    "Uuvision T95Zplus": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "T95Zplus",
-            "Device_Code_Name": "T95Zplus",
-            "Device_Maker": "Uuvision",
-            "Device_Pointing_Method": "Uuvision",
-            "Device_Brand_Name": "Andoer"
-        },
-        "standard": true
-    }
+  "Uuvision T95Zplus": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "T95Zplus",
+      "Device_Code_Name": "T95Zplus",
+      "Device_Maker": "Uuvision",
+      "Device_Pointing_Method": "Uuvision",
+      "Device_Brand_Name": "Andoer"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/vigica.json
+++ b/resources/devices/tv-device/vigica.json
@@ -1,24 +1,24 @@
 {
-    "VIGICA MX9": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "MX9",
-            "Device_Code_Name": "MX9",
-            "Device_Maker": "VIGICA",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "VIGICA"
-        },
-        "standard": true
+  "VIGICA MX9": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "MX9",
+      "Device_Code_Name": "MX9",
+      "Device_Maker": "VIGICA",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "VIGICA"
     },
-    "VIGICA MX9 Pro": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "MX9 Pro",
-            "Device_Code_Name": "MX9 Pro",
-            "Device_Maker": "VIGICA",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "VIGICA"
-        },
-        "standard": true
-    }
+    "standard": true
+  },
+  "VIGICA MX9 Pro": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "MX9 Pro",
+      "Device_Code_Name": "MX9 Pro",
+      "Device_Maker": "VIGICA",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "VIGICA"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/vorke.json
+++ b/resources/devices/tv-device/vorke.json
@@ -1,13 +1,13 @@
 {
-    "Vorke Z1": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "Z1",
-            "Device_Code_Name": "Z1",
-            "Device_Maker": "Vorke",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Vorke"
-        },
-        "standard": true
-    }
+  "Vorke Z1": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "Z1",
+      "Device_Code_Name": "Z1",
+      "Device_Maker": "Vorke",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Vorke"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/wetek.json
+++ b/resources/devices/tv-device/wetek.json
@@ -1,13 +1,13 @@
 {
-    "WeTek Play 2": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "Play 2",
-            "Device_Code_Name": "Play 2",
-            "Device_Maker": "WeTek",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "WeTek"
-        },
-        "standard": true
-    }
+  "WeTek Play 2": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "Play 2",
+      "Device_Code_Name": "Play 2",
+      "Device_Maker": "WeTek",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "WeTek"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/xiaomi.json
+++ b/resources/devices/tv-device/xiaomi.json
@@ -1,13 +1,13 @@
 {
-    "Xiaomi Mi Box 3": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "Mi Box 3",
-            "Device_Code_Name": "Mi Box 3",
-            "Device_Maker": "Xiaomi Tech",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Xiaomi"
-        },
-        "standard": true
-    }
+  "Xiaomi Mi Box 3": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "Mi Box 3",
+      "Device_Code_Name": "Mi Box 3",
+      "Device_Maker": "Xiaomi Tech",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Xiaomi"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/xtreamer.json
+++ b/resources/devices/tv-device/xtreamer.json
@@ -1,13 +1,13 @@
 {
-    "Xtreamer Wonder": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "Wonder",
-            "Device_Code_Name": "Wonder",
-            "Device_Maker": "Xtreamer",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Xtreamer"
-        },
-        "standard": true
-    }
+  "Xtreamer Wonder": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "Wonder",
+      "Device_Code_Name": "Wonder",
+      "Device_Maker": "Xtreamer",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Xtreamer"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/yundoo.json
+++ b/resources/devices/tv-device/yundoo.json
@@ -1,13 +1,13 @@
 {
-    "Yundoo Y8": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "Y8",
-            "Device_Code_Name": "Y8",
-            "Device_Maker": "Yundoo",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Yundoo"
-        },
-        "standard": true
-    }
+  "Yundoo Y8": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "Y8",
+      "Device_Code_Name": "Y8",
+      "Device_Maker": "Yundoo",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Yundoo"
+    },
+    "standard": true
+  }
 }

--- a/resources/devices/tv-device/zidoo.json
+++ b/resources/devices/tv-device/zidoo.json
@@ -1,24 +1,24 @@
 {
-    "Zidoo X6 Pro": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "X6 Pro",
-            "Device_Code_Name": "X6 Pro",
-            "Device_Maker": "Zidoo",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Zidoo"
-        },
-        "standard": true
+  "Zidoo X6 Pro": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "X6 Pro",
+      "Device_Code_Name": "X6 Pro",
+      "Device_Maker": "Zidoo",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Zidoo"
     },
-    "Zidoo X7": {
-        "type": "tv",
-        "properties": {
-            "Device_Name": "X7",
-            "Device_Code_Name": "X7",
-            "Device_Maker": "Zidoo",
-            "Device_Pointing_Method": "unknown",
-            "Device_Brand_Name": "Zidoo"
-        },
-        "standard": true
-    }
+    "standard": true
+  },
+  "Zidoo X7": {
+    "type": "tv",
+    "properties": {
+      "Device_Name": "X7",
+      "Device_Code_Name": "X7",
+      "Device_Maker": "Zidoo",
+      "Device_Pointing_Method": "unknown",
+      "Device_Brand_Name": "Zidoo"
+    },
+    "standard": true
+  }
 }

--- a/resources/engines.json
+++ b/resources/engines.json
@@ -1,523 +1,521 @@
 {
-  "engines": {
-    "unknown": {
-      "properties": {
-        "RenderingEngine_Name": "unknown",
-        "RenderingEngine_Version": "unknown",
-        "RenderingEngine_Description": "unknown",
-        "RenderingEngine_Maker": "unknown",
-        "VBScript": false,
-        "JavaApplets": false,
-        "ActiveXControls": false,
-        "BackgroundSounds": false,
-        "Frames": false,
-        "IFrames": false,
-        "Tables": false,
-        "Cookies": false,
-        "JavaScript": false,
-        "CssVersion": 0
-      }
-    },
-    "WebKit": {
-      "properties": {
-        "RenderingEngine_Name": "WebKit",
-        "RenderingEngine_Version": "unknown",
-        "RenderingEngine_Description": "For Google Chrome, iOS (including both mobile Safari, WebViews within third-party apps, and web clips), Safari, Arora, Midori, OmniWeb, Shiira, iCab since version 4, Web, SRWare Iron, Rekonq, and in Maxthon 3.",
-        "RenderingEngine_Maker": "Apple Inc",
-        "VBScript": false,
-        "JavaApplets": true,
-        "ActiveXControls": false,
-        "BackgroundSounds": false,
-        "Frames": true,
-        "IFrames": true,
-        "Tables": true,
-        "Cookies": true,
-        "JavaScript": true,
-        "CssVersion": 3
-      }
-    },
-    "Gecko": {
-      "properties": {
-        "RenderingEngine_Name": "Gecko",
-        "RenderingEngine_Version": "unknown",
-        "RenderingEngine_Description": "For Firefox, Camino, K-Meleon, SeaMonkey, Netscape, and other Gecko-based browsers.",
-        "RenderingEngine_Maker": "Mozilla Foundation",
-        "VBScript": false,
-        "JavaApplets": true,
-        "ActiveXControls": false,
-        "BackgroundSounds": false,
-        "Frames": true,
-        "IFrames": true,
-        "Tables": true,
-        "Cookies": true,
-        "JavaScript": true,
-        "CssVersion": 2
-      }
-    },
-    "Gecko_1": {
-      "inherits": "Gecko",
-      "properties": {
-        "RenderingEngine_Version": "1.0"
-      }
-    },
-    "Gecko_1_8": {
-      "inherits": "Gecko",
-      "properties": {
-        "RenderingEngine_Version": "1.8"
-      }
-    },
-    "Gecko_1_8_1": {
-      "inherits": "Gecko",
-      "properties": {
-        "RenderingEngine_Version": "1.8.1"
-      }
-    },
-    "Gecko_1_9": {
-      "inherits": "Gecko",
-      "properties": {
-        "RenderingEngine_Version": "1.9.0"
-      }
-    },
-    "Gecko_1_9_1": {
-      "inherits": "Gecko",
-      "properties": {
-        "RenderingEngine_Version": "1.9.1"
-      }
-    },
-    "Gecko_1_9_2": {
-      "inherits": "Gecko",
-      "properties": {
-        "RenderingEngine_Version": "1.9.2",
-        "CssVersion": 3
-      }
-    },
-    "Gecko_1_9_3": {
-      "inherits": "Gecko",
-      "properties": {
-        "RenderingEngine_Version": "1.9.3",
-        "CssVersion": 3
-      }
-    },
-    "Gecko_2": {
-      "inherits": "Gecko",
-      "properties": {
-        "RenderingEngine_Version": "2.0",
-        "CssVersion": 3
-      }
-    },
-    "Gecko_2_2": {
-      "inherits": "Gecko",
-      "properties": {
-        "RenderingEngine_Version": "2.2",
-        "CssVersion": 3
-      }
-    },
-    "Gecko_20": {
-      "inherits": "Gecko",
-      "properties": {
-        "RenderingEngine_Version": "20.0",
-        "CssVersion": 3
-      }
-    },
-    "Gecko_22": {
-      "inherits": "Gecko",
-      "properties": {
-        "RenderingEngine_Version": "22.0",
-        "CssVersion": 3
-      }
-    },
-    "Gecko_23": {
-      "inherits": "Gecko",
-      "properties": {
-        "RenderingEngine_Version": "23.0",
-        "CssVersion": 3
-      }
-    },
-    "Gecko_25": {
-      "inherits": "Gecko",
-      "properties": {
-        "RenderingEngine_Version": "25.0",
-        "CssVersion": 3
-      }
-    },
-    "Gecko_26": {
-      "inherits": "Gecko",
-      "properties": {
-        "RenderingEngine_Version": "26.0",
-        "CssVersion": 3
-      }
-    },
-    "Gecko_27": {
-      "inherits": "Gecko",
-      "properties": {
-        "RenderingEngine_Version": "27.0",
-        "CssVersion": 3
-      }
-    },
-    "Gecko_Major_Dynamic": {
-      "inherits": "Gecko",
-      "properties": {
-        "RenderingEngine_Version": "#MAJORVER#.0",
-        "CssVersion": 3
-      }
-    },
-    "Gecko_Dynamic": {
-      "inherits": "Gecko",
-      "properties": {
-        "RenderingEngine_Version": "#MAJORVER#.#MINORVER#",
-        "CssVersion": 3
-      }
-    },
-    "Trident": {
-      "properties": {
-        "RenderingEngine_Name": "Trident",
-        "RenderingEngine_Version": "unknown",
-        "RenderingEngine_Description": "For Internet Explorer since version 4.0 and embedded WebBrowser controls (such as Internet Explorer shells, Maxthon and some media players).",
-        "RenderingEngine_Maker": "Microsoft Corporation",
-        "VBScript": true,
-        "JavaApplets": true,
-        "ActiveXControls": true,
-        "BackgroundSounds": true,
-        "Frames": true,
-        "IFrames": true,
-        "Cookies": true,
-        "JavaScript": true,
-        "CssVersion": 2,
-        "Tables": true
-      }
-    },
-    "Trident_3_1": {
-      "inherits": "Trident",
-      "properties": {
-        "RenderingEngine_Version": "3.1"
-      }
-    },
-    "Trident_4": {
-      "inherits": "Trident",
-      "properties": {
-        "RenderingEngine_Version": "4.0"
-      }
-    },
-    "Trident_5": {
-      "inherits": "Trident",
-      "properties": {
-        "RenderingEngine_Version": "5.0"
-      }
-    },
-    "Trident_6": {
-      "inherits": "Trident",
-      "properties": {
-        "RenderingEngine_Version": "6.0",
-        "CssVersion": 3
-      }
-    },
-    "Trident_7": {
-      "inherits": "Trident",
-      "properties": {
-        "RenderingEngine_Version": "7.0",
-        "CssVersion": 3
-      }
-    },
-    "Trident_8": {
-      "inherits": "Trident",
-      "properties": {
-        "RenderingEngine_Version": "8.0",
-        "CssVersion": 3
-      }
-    },
-    "Edge": {
-      "properties": {
-        "RenderingEngine_Name": "Edge",
-        "RenderingEngine_Version": "unknown",
-        "RenderingEngine_Description": "For the Edge Browser since version 12.0",
-        "RenderingEngine_Maker": "Microsoft Corporation",
-        "VBScript": false,
-        "JavaApplets": false,
-        "ActiveXControls": false,
-        "BackgroundSounds": false,
-        "Frames": true,
-        "IFrames": true,
-        "Tables": true,
-        "Cookies": true,
-        "JavaScript": true,
-        "CssVersion": 3
-      }
-    },
-    "Edge_12": {
-      "inherits": "Edge",
-      "properties": {
-        "RenderingEngine_Version": "12.0"
-      }
-    },
-    "Edge_13": {
-      "inherits": "Edge",
-      "properties": {
-        "RenderingEngine_Version": "13.0"
-      }
-    },
-    "Edge_Dynamic": {
-      "inherits": "Edge",
-      "properties": {
-        "RenderingEngine_Version": "#MAJORVER#.#MINORVER#"
-      }
-    },
-    "Presto": {
-      "properties": {
-        "RenderingEngine_Name": "Presto",
-        "RenderingEngine_Version": "unknown",
-        "RenderingEngine_Description": "For Opera 7 and above, Macromedia Dreamweaver MX and MX 2004 (Mac), and Adobe Creative Suite 2.",
-        "RenderingEngine_Maker": "Opera Software ASA",
-        "VBScript": false,
-        "JavaApplets": false,
-        "ActiveXControls": false,
-        "BackgroundSounds": false,
-        "Frames": true,
-        "IFrames": true,
-        "Tables": true,
-        "Cookies": true,
-        "JavaScript": true,
-        "CssVersion": 3
-      }
-    },
-    "Presto_1_0": {
-      "inherits": "Presto",
-      "properties": {
-        "RenderingEngine_Version": "1.0"
-      }
-    },
-    "Presto_2_0": {
-      "inherits": "Presto",
-      "properties": {
-        "RenderingEngine_Version": "2.0"
-      }
-    },
-    "Presto_2_2": {
-      "inherits": "Presto",
-      "properties": {
-        "RenderingEngine_Version": "2.2"
-      }
-    },
-    "Presto_2_7": {
-      "inherits": "Presto",
-      "properties": {
-        "RenderingEngine_Version": "2.7"
-      }
-    },
-    "Presto_2_8": {
-      "inherits": "Presto",
-      "properties": {
-        "RenderingEngine_Version": "2.8"
-      }
-    },
-    "Presto_2_9": {
-      "inherits": "Presto",
-      "properties": {
-        "RenderingEngine_Version": "2.9"
-      }
-    },
-    "Presto_2_10": {
-      "inherits": "Presto",
-      "properties": {
-        "RenderingEngine_Version": "2.10"
-      }
-    },
-    "Presto_2_12": {
-      "inherits": "Presto",
-      "properties": {
-        "RenderingEngine_Version": "2.12"
-      }
-    },
-    "NetFront": {
-      "properties": {
-        "RenderingEngine_Name": "NetFront",
-        "RenderingEngine_Version": "unknown",
-        "RenderingEngine_Description": "For Access NetFront.",
-        "RenderingEngine_Maker": "Access",
-        "VBScript": false,
-        "JavaApplets": false,
-        "ActiveXControls": false,
-        "BackgroundSounds": false,
-        "Frames": true,
-        "IFrames": true,
-        "Tables": true,
-        "Cookies": true,
-        "JavaScript": true,
-        "CssVersion": 2
-      }
-    },
-    "T5": {
-      "properties": {
-        "RenderingEngine_Name": "T5",
-        "RenderingEngine_Version": "unknown",
-        "RenderingEngine_Description": "a WebKit Fork by Baidu",
-        "RenderingEngine_Maker": "Baidu",
-        "VBScript": false,
-        "JavaApplets": false,
-        "ActiveXControls": false,
-        "BackgroundSounds": false,
-        "Frames": true,
-        "IFrames": true,
-        "Tables": true,
-        "Cookies": true,
-        "JavaScript": true,
-        "CssVersion": 3
-      }
-    },
-    "T7": {
-      "properties": {
-        "RenderingEngine_Name": "T7",
-        "RenderingEngine_Version": "unknown",
-        "RenderingEngine_Description": "a Blink Fork by Baidu",
-        "RenderingEngine_Maker": "Baidu",
-        "VBScript": false,
-        "JavaApplets": false,
-        "ActiveXControls": false,
-        "BackgroundSounds": false,
-        "Frames": true,
-        "IFrames": true,
-        "Tables": true,
-        "Cookies": true,
-        "JavaScript": true,
-        "CssVersion": 3
-      }
-    },
-    "Tasman": {
-      "properties": {
-        "RenderingEngine_Name": "Tasman",
-        "RenderingEngine_Version": "unknown",
-        "RenderingEngine_Description": "For Internet Explorer 5 for Mac, Microsoft Office 2004 for Mac, and Microsoft Office 2008 for Mac.",
-        "RenderingEngine_Maker": "Apple Inc",
-        "VBScript": false,
-        "JavaApplets": true,
-        "ActiveXControls": false,
-        "BackgroundSounds": false
-      }
-    },
-    "KHTML": {
-      "properties": {
-        "RenderingEngine_Name": "KHTML",
-        "RenderingEngine_Version": "unknown",
-        "RenderingEngine_Description": "For Konqueror.",
-        "RenderingEngine_Maker": "KDE e.V.",
-        "VBScript": false,
-        "JavaApplets": true,
-        "ActiveXControls": false,
-        "BackgroundSounds": false,
-        "Frames": true,
-        "IFrames": true,
-        "Tables": true,
-        "Cookies": true,
-        "JavaScript": true,
-        "CssVersion": 2
-      }
-    },
-    "KHTML_Dynamic": {
-      "inherits": "KHTML",
-      "properties": {
-        "RenderingEngine_Version": "#MAJORVER#.#MINORVER#"
-      }
-    },
-    "U2": {
-      "properties": {
-        "RenderingEngine_Name": "U2",
-        "RenderingEngine_Version": "unknown",
-        "RenderingEngine_Description": "a WebKit Fork by UC Web",
-        "RenderingEngine_Maker": "UCWeb Inc.",
-        "VBScript": false,
-        "JavaApplets": false,
-        "ActiveXControls": false,
-        "BackgroundSounds": false,
-        "Frames": true,
-        "IFrames": true,
-        "Tables": true,
-        "Cookies": true,
-        "JavaScript": true,
-        "CssVersion": 3
-      }
-    },
-    "U3": {
-      "properties": {
-        "RenderingEngine_Name": "U3",
-        "RenderingEngine_Version": "unknown",
-        "RenderingEngine_Description": "a WebKit Fork by UC Web",
-        "RenderingEngine_Maker": "UCWeb Inc.",
-        "VBScript": false,
-        "JavaApplets": false,
-        "ActiveXControls": false,
-        "BackgroundSounds": false,
-        "Frames": true,
-        "IFrames": true,
-        "Tables": true,
-        "Cookies": true,
-        "JavaScript": true,
-        "CssVersion": 3
-      }
-    },
-    "Blink": {
-      "properties": {
-        "RenderingEngine_Name": "Blink",
-        "RenderingEngine_Version": "unknown",
-        "RenderingEngine_Description": "a WebKit Fork by Google",
-        "RenderingEngine_Maker": "Google Inc",
-        "VBScript": false,
-        "JavaApplets": false,
-        "ActiveXControls": false,
-        "BackgroundSounds": false,
-        "Frames": true,
-        "IFrames": true,
-        "Tables": true,
-        "Cookies": true,
-        "JavaScript": true,
-        "CssVersion": 3
-      }
-    },
-    "Goanna": {
-      "properties": {
-        "RenderingEngine_Name": "Goanna",
-        "RenderingEngine_Version": "unknown",
-        "RenderingEngine_Description": "a Gecko Fork by Moonchild Productions",
-        "RenderingEngine_Maker": "Moonchild Productions",
-        "VBScript": false,
-        "JavaApplets": true,
-        "ActiveXControls": false,
-        "BackgroundSounds": false,
-        "Frames": true,
-        "IFrames": true,
-        "Tables": true,
-        "Cookies": true,
-        "JavaScript": true,
-        "CssVersion": 3
-      }
-    },
-    "Goanna_2": {
-      "inherits": "Goanna",
-      "properties": {
-        "RenderingEngine_Version": "2.0"
-      }
-    },
-    "Goanna_3": {
-      "inherits": "Goanna",
-      "properties": {
-        "RenderingEngine_Version": "3.0"
-      }
-    },
-    "Goanna_4": {
-      "inherits": "Goanna",
-      "properties": {
-        "RenderingEngine_Version": "4.0"
-      }
-    },
-    "Clecko": {
-      "properties": {
-        "RenderingEngine_Name": "Clecko",
-        "RenderingEngine_Version": "unknown",
-        "RenderingEngine_Description": "a Gecko Fork for Classilla",
-        "RenderingEngine_Maker": "unknown",
-        "VBScript": false,
-        "JavaApplets": true,
-        "ActiveXControls": false,
-        "BackgroundSounds": false
-      }
+  "unknown": {
+    "properties": {
+      "RenderingEngine_Name": "unknown",
+      "RenderingEngine_Version": "unknown",
+      "RenderingEngine_Description": "unknown",
+      "RenderingEngine_Maker": "unknown",
+      "VBScript": false,
+      "JavaApplets": false,
+      "ActiveXControls": false,
+      "BackgroundSounds": false,
+      "Frames": false,
+      "IFrames": false,
+      "Tables": false,
+      "Cookies": false,
+      "JavaScript": false,
+      "CssVersion": 0
+    }
+  },
+  "WebKit": {
+    "properties": {
+      "RenderingEngine_Name": "WebKit",
+      "RenderingEngine_Version": "unknown",
+      "RenderingEngine_Description": "For Google Chrome, iOS (including both mobile Safari, WebViews within third-party apps, and web clips), Safari, Arora, Midori, OmniWeb, Shiira, iCab since version 4, Web, SRWare Iron, Rekonq, and in Maxthon 3.",
+      "RenderingEngine_Maker": "Apple Inc",
+      "VBScript": false,
+      "JavaApplets": true,
+      "ActiveXControls": false,
+      "BackgroundSounds": false,
+      "Frames": true,
+      "IFrames": true,
+      "Tables": true,
+      "Cookies": true,
+      "JavaScript": true,
+      "CssVersion": 3
+    }
+  },
+  "Gecko": {
+    "properties": {
+      "RenderingEngine_Name": "Gecko",
+      "RenderingEngine_Version": "unknown",
+      "RenderingEngine_Description": "For Firefox, Camino, K-Meleon, SeaMonkey, Netscape, and other Gecko-based browsers.",
+      "RenderingEngine_Maker": "Mozilla Foundation",
+      "VBScript": false,
+      "JavaApplets": true,
+      "ActiveXControls": false,
+      "BackgroundSounds": false,
+      "Frames": true,
+      "IFrames": true,
+      "Tables": true,
+      "Cookies": true,
+      "JavaScript": true,
+      "CssVersion": 2
+    }
+  },
+  "Gecko_1": {
+    "inherits": "Gecko",
+    "properties": {
+      "RenderingEngine_Version": "1.0"
+    }
+  },
+  "Gecko_1_8": {
+    "inherits": "Gecko",
+    "properties": {
+      "RenderingEngine_Version": "1.8"
+    }
+  },
+  "Gecko_1_8_1": {
+    "inherits": "Gecko",
+    "properties": {
+      "RenderingEngine_Version": "1.8.1"
+    }
+  },
+  "Gecko_1_9": {
+    "inherits": "Gecko",
+    "properties": {
+      "RenderingEngine_Version": "1.9.0"
+    }
+  },
+  "Gecko_1_9_1": {
+    "inherits": "Gecko",
+    "properties": {
+      "RenderingEngine_Version": "1.9.1"
+    }
+  },
+  "Gecko_1_9_2": {
+    "inherits": "Gecko",
+    "properties": {
+      "RenderingEngine_Version": "1.9.2",
+      "CssVersion": 3
+    }
+  },
+  "Gecko_1_9_3": {
+    "inherits": "Gecko",
+    "properties": {
+      "RenderingEngine_Version": "1.9.3",
+      "CssVersion": 3
+    }
+  },
+  "Gecko_2": {
+    "inherits": "Gecko",
+    "properties": {
+      "RenderingEngine_Version": "2.0",
+      "CssVersion": 3
+    }
+  },
+  "Gecko_2_2": {
+    "inherits": "Gecko",
+    "properties": {
+      "RenderingEngine_Version": "2.2",
+      "CssVersion": 3
+    }
+  },
+  "Gecko_20": {
+    "inherits": "Gecko",
+    "properties": {
+      "RenderingEngine_Version": "20.0",
+      "CssVersion": 3
+    }
+  },
+  "Gecko_22": {
+    "inherits": "Gecko",
+    "properties": {
+      "RenderingEngine_Version": "22.0",
+      "CssVersion": 3
+    }
+  },
+  "Gecko_23": {
+    "inherits": "Gecko",
+    "properties": {
+      "RenderingEngine_Version": "23.0",
+      "CssVersion": 3
+    }
+  },
+  "Gecko_25": {
+    "inherits": "Gecko",
+    "properties": {
+      "RenderingEngine_Version": "25.0",
+      "CssVersion": 3
+    }
+  },
+  "Gecko_26": {
+    "inherits": "Gecko",
+    "properties": {
+      "RenderingEngine_Version": "26.0",
+      "CssVersion": 3
+    }
+  },
+  "Gecko_27": {
+    "inherits": "Gecko",
+    "properties": {
+      "RenderingEngine_Version": "27.0",
+      "CssVersion": 3
+    }
+  },
+  "Gecko_Major_Dynamic": {
+    "inherits": "Gecko",
+    "properties": {
+      "RenderingEngine_Version": "#MAJORVER#.0",
+      "CssVersion": 3
+    }
+  },
+  "Gecko_Dynamic": {
+    "inherits": "Gecko",
+    "properties": {
+      "RenderingEngine_Version": "#MAJORVER#.#MINORVER#",
+      "CssVersion": 3
+    }
+  },
+  "Trident": {
+    "properties": {
+      "RenderingEngine_Name": "Trident",
+      "RenderingEngine_Version": "unknown",
+      "RenderingEngine_Description": "For Internet Explorer since version 4.0 and embedded WebBrowser controls (such as Internet Explorer shells, Maxthon and some media players).",
+      "RenderingEngine_Maker": "Microsoft Corporation",
+      "VBScript": true,
+      "JavaApplets": true,
+      "ActiveXControls": true,
+      "BackgroundSounds": true,
+      "Frames": true,
+      "IFrames": true,
+      "Cookies": true,
+      "JavaScript": true,
+      "CssVersion": 2,
+      "Tables": true
+    }
+  },
+  "Trident_3_1": {
+    "inherits": "Trident",
+    "properties": {
+      "RenderingEngine_Version": "3.1"
+    }
+  },
+  "Trident_4": {
+    "inherits": "Trident",
+    "properties": {
+      "RenderingEngine_Version": "4.0"
+    }
+  },
+  "Trident_5": {
+    "inherits": "Trident",
+    "properties": {
+      "RenderingEngine_Version": "5.0"
+    }
+  },
+  "Trident_6": {
+    "inherits": "Trident",
+    "properties": {
+      "RenderingEngine_Version": "6.0",
+      "CssVersion": 3
+    }
+  },
+  "Trident_7": {
+    "inherits": "Trident",
+    "properties": {
+      "RenderingEngine_Version": "7.0",
+      "CssVersion": 3
+    }
+  },
+  "Trident_8": {
+    "inherits": "Trident",
+    "properties": {
+      "RenderingEngine_Version": "8.0",
+      "CssVersion": 3
+    }
+  },
+  "Edge": {
+    "properties": {
+      "RenderingEngine_Name": "Edge",
+      "RenderingEngine_Version": "unknown",
+      "RenderingEngine_Description": "For the Edge Browser since version 12.0",
+      "RenderingEngine_Maker": "Microsoft Corporation",
+      "VBScript": false,
+      "JavaApplets": false,
+      "ActiveXControls": false,
+      "BackgroundSounds": false,
+      "Frames": true,
+      "IFrames": true,
+      "Tables": true,
+      "Cookies": true,
+      "JavaScript": true,
+      "CssVersion": 3
+    }
+  },
+  "Edge_12": {
+    "inherits": "Edge",
+    "properties": {
+      "RenderingEngine_Version": "12.0"
+    }
+  },
+  "Edge_13": {
+    "inherits": "Edge",
+    "properties": {
+      "RenderingEngine_Version": "13.0"
+    }
+  },
+  "Edge_Dynamic": {
+    "inherits": "Edge",
+    "properties": {
+      "RenderingEngine_Version": "#MAJORVER#.#MINORVER#"
+    }
+  },
+  "Presto": {
+    "properties": {
+      "RenderingEngine_Name": "Presto",
+      "RenderingEngine_Version": "unknown",
+      "RenderingEngine_Description": "For Opera 7 and above, Macromedia Dreamweaver MX and MX 2004 (Mac), and Adobe Creative Suite 2.",
+      "RenderingEngine_Maker": "Opera Software ASA",
+      "VBScript": false,
+      "JavaApplets": false,
+      "ActiveXControls": false,
+      "BackgroundSounds": false,
+      "Frames": true,
+      "IFrames": true,
+      "Tables": true,
+      "Cookies": true,
+      "JavaScript": true,
+      "CssVersion": 3
+    }
+  },
+  "Presto_1_0": {
+    "inherits": "Presto",
+    "properties": {
+      "RenderingEngine_Version": "1.0"
+    }
+  },
+  "Presto_2_0": {
+    "inherits": "Presto",
+    "properties": {
+      "RenderingEngine_Version": "2.0"
+    }
+  },
+  "Presto_2_2": {
+    "inherits": "Presto",
+    "properties": {
+      "RenderingEngine_Version": "2.2"
+    }
+  },
+  "Presto_2_7": {
+    "inherits": "Presto",
+    "properties": {
+      "RenderingEngine_Version": "2.7"
+    }
+  },
+  "Presto_2_8": {
+    "inherits": "Presto",
+    "properties": {
+      "RenderingEngine_Version": "2.8"
+    }
+  },
+  "Presto_2_9": {
+    "inherits": "Presto",
+    "properties": {
+      "RenderingEngine_Version": "2.9"
+    }
+  },
+  "Presto_2_10": {
+    "inherits": "Presto",
+    "properties": {
+      "RenderingEngine_Version": "2.10"
+    }
+  },
+  "Presto_2_12": {
+    "inherits": "Presto",
+    "properties": {
+      "RenderingEngine_Version": "2.12"
+    }
+  },
+  "NetFront": {
+    "properties": {
+      "RenderingEngine_Name": "NetFront",
+      "RenderingEngine_Version": "unknown",
+      "RenderingEngine_Description": "For Access NetFront.",
+      "RenderingEngine_Maker": "Access",
+      "VBScript": false,
+      "JavaApplets": false,
+      "ActiveXControls": false,
+      "BackgroundSounds": false,
+      "Frames": true,
+      "IFrames": true,
+      "Tables": true,
+      "Cookies": true,
+      "JavaScript": true,
+      "CssVersion": 2
+    }
+  },
+  "T5": {
+    "properties": {
+      "RenderingEngine_Name": "T5",
+      "RenderingEngine_Version": "unknown",
+      "RenderingEngine_Description": "a WebKit Fork by Baidu",
+      "RenderingEngine_Maker": "Baidu",
+      "VBScript": false,
+      "JavaApplets": false,
+      "ActiveXControls": false,
+      "BackgroundSounds": false,
+      "Frames": true,
+      "IFrames": true,
+      "Tables": true,
+      "Cookies": true,
+      "JavaScript": true,
+      "CssVersion": 3
+    }
+  },
+  "T7": {
+    "properties": {
+      "RenderingEngine_Name": "T7",
+      "RenderingEngine_Version": "unknown",
+      "RenderingEngine_Description": "a Blink Fork by Baidu",
+      "RenderingEngine_Maker": "Baidu",
+      "VBScript": false,
+      "JavaApplets": false,
+      "ActiveXControls": false,
+      "BackgroundSounds": false,
+      "Frames": true,
+      "IFrames": true,
+      "Tables": true,
+      "Cookies": true,
+      "JavaScript": true,
+      "CssVersion": 3
+    }
+  },
+  "Tasman": {
+    "properties": {
+      "RenderingEngine_Name": "Tasman",
+      "RenderingEngine_Version": "unknown",
+      "RenderingEngine_Description": "For Internet Explorer 5 for Mac, Microsoft Office 2004 for Mac, and Microsoft Office 2008 for Mac.",
+      "RenderingEngine_Maker": "Apple Inc",
+      "VBScript": false,
+      "JavaApplets": true,
+      "ActiveXControls": false,
+      "BackgroundSounds": false
+    }
+  },
+  "KHTML": {
+    "properties": {
+      "RenderingEngine_Name": "KHTML",
+      "RenderingEngine_Version": "unknown",
+      "RenderingEngine_Description": "For Konqueror.",
+      "RenderingEngine_Maker": "KDE e.V.",
+      "VBScript": false,
+      "JavaApplets": true,
+      "ActiveXControls": false,
+      "BackgroundSounds": false,
+      "Frames": true,
+      "IFrames": true,
+      "Tables": true,
+      "Cookies": true,
+      "JavaScript": true,
+      "CssVersion": 2
+    }
+  },
+  "KHTML_Dynamic": {
+    "inherits": "KHTML",
+    "properties": {
+      "RenderingEngine_Version": "#MAJORVER#.#MINORVER#"
+    }
+  },
+  "U2": {
+    "properties": {
+      "RenderingEngine_Name": "U2",
+      "RenderingEngine_Version": "unknown",
+      "RenderingEngine_Description": "a WebKit Fork by UC Web",
+      "RenderingEngine_Maker": "UCWeb Inc.",
+      "VBScript": false,
+      "JavaApplets": false,
+      "ActiveXControls": false,
+      "BackgroundSounds": false,
+      "Frames": true,
+      "IFrames": true,
+      "Tables": true,
+      "Cookies": true,
+      "JavaScript": true,
+      "CssVersion": 3
+    }
+  },
+  "U3": {
+    "properties": {
+      "RenderingEngine_Name": "U3",
+      "RenderingEngine_Version": "unknown",
+      "RenderingEngine_Description": "a WebKit Fork by UC Web",
+      "RenderingEngine_Maker": "UCWeb Inc.",
+      "VBScript": false,
+      "JavaApplets": false,
+      "ActiveXControls": false,
+      "BackgroundSounds": false,
+      "Frames": true,
+      "IFrames": true,
+      "Tables": true,
+      "Cookies": true,
+      "JavaScript": true,
+      "CssVersion": 3
+    }
+  },
+  "Blink": {
+    "properties": {
+      "RenderingEngine_Name": "Blink",
+      "RenderingEngine_Version": "unknown",
+      "RenderingEngine_Description": "a WebKit Fork by Google",
+      "RenderingEngine_Maker": "Google Inc",
+      "VBScript": false,
+      "JavaApplets": false,
+      "ActiveXControls": false,
+      "BackgroundSounds": false,
+      "Frames": true,
+      "IFrames": true,
+      "Tables": true,
+      "Cookies": true,
+      "JavaScript": true,
+      "CssVersion": 3
+    }
+  },
+  "Goanna": {
+    "properties": {
+      "RenderingEngine_Name": "Goanna",
+      "RenderingEngine_Version": "unknown",
+      "RenderingEngine_Description": "a Gecko Fork by Moonchild Productions",
+      "RenderingEngine_Maker": "Moonchild Productions",
+      "VBScript": false,
+      "JavaApplets": true,
+      "ActiveXControls": false,
+      "BackgroundSounds": false,
+      "Frames": true,
+      "IFrames": true,
+      "Tables": true,
+      "Cookies": true,
+      "JavaScript": true,
+      "CssVersion": 3
+    }
+  },
+  "Goanna_2": {
+    "inherits": "Goanna",
+    "properties": {
+      "RenderingEngine_Version": "2.0"
+    }
+  },
+  "Goanna_3": {
+    "inherits": "Goanna",
+    "properties": {
+      "RenderingEngine_Version": "3.0"
+    }
+  },
+  "Goanna_4": {
+    "inherits": "Goanna",
+    "properties": {
+      "RenderingEngine_Version": "4.0"
+    }
+  },
+  "Clecko": {
+    "properties": {
+      "RenderingEngine_Name": "Clecko",
+      "RenderingEngine_Version": "unknown",
+      "RenderingEngine_Description": "a Gecko Fork for Classilla",
+      "RenderingEngine_Maker": "unknown",
+      "VBScript": false,
+      "JavaApplets": true,
+      "ActiveXControls": false,
+      "BackgroundSounds": false
     }
   }
 }

--- a/resources/platforms.json
+++ b/resources/platforms.json
@@ -1,6532 +1,6530 @@
 {
-  "platforms": {
-    "WinXPa_cygwin": {
-      "match": "*CYGWIN_NT-5.1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinXP",
-        "Platform_Version": "5.1",
-        "Platform_Description": "Windows XP"
-      }
-    },
-    "CygWin": {
-      "match": "*CygWin*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "CygWin",
-        "Platform_Maker": "Microsoft Corporation",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "Win10_x64_B": {
-      "match": "*Windows NT 10.0*Win64? x64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform": "Win10",
-        "Platform_Bits": 64,
-        "Platform_Version": "10.0",
-        "Platform_Description": "Windows 10",
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "Win10_64_B": {
-      "match": "*Windows NT 10.0*WOW64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "Win10",
-        "Platform_Bits": 64,
-        "Platform_Version": "10.0",
-        "Platform_Description": "Windows 10",
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "Win10_32_B": {
-      "match": "*Windows NT 10.0*",
-      "lite": true,
-      "standard": true,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "Win10",
-        "Platform_Version": "10.0",
-        "Platform_Description": "Windows 10"
-      }
-    },
-    "Win10_x64": {
-      "match": "*Windows NT 6.4*Win64? x64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform": "Win10",
-        "Platform_Bits": 64,
-        "Platform_Version": "6.4",
-        "Platform_Description": "Windows 10",
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "Win10_64": {
-      "match": "*Windows NT 6.4*WOW64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "Win10",
-        "Platform_Bits": 64,
-        "Platform_Version": "6.4",
-        "Platform_Description": "Windows 10",
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "Win10_32": {
-      "match": "*Windows NT 6.4*",
-      "lite": true,
-      "standard": true,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "Win10",
-        "Platform_Version": "6.4",
-        "Platform_Description": "Windows 10"
-      }
-    },
-    "WinRT8_1_32": {
-      "match": "*Windows NT 6.3; ARM*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinRT8.1",
-        "Platform_Version": "6.3",
-        "Platform_Description": "Windows RT 8.1",
-        "Win32": false
-      }
-    },
-    "Win8_1_x64": {
-      "match": "*Windows NT 6.3*Win64? x64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform": "Win8.1",
-        "Platform_Bits": 64,
-        "Platform_Version": "6.3",
-        "Platform_Description": "Windows 8.1",
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "Win8_1_64": {
-      "match": "*Windows NT 6.3*WOW64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "Win8.1",
-        "Platform_Bits": 64,
-        "Platform_Version": "6.3",
-        "Platform_Description": "Windows 8.1",
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "Win8_1_32": {
-      "match": "*Windows NT 6.3*",
-      "lite": true,
-      "standard": true,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "Win8.1",
-        "Platform_Version": "6.3",
-        "Platform_Description": "Windows 8.1"
-      }
-    },
-    "WinRT8_32": {
-      "match": "*Windows NT 6.2; ARM*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinRT8",
-        "Platform_Version": "6.2",
-        "Platform_Description": "Windows RT 8",
-        "Win32": false
-      }
-    },
-    "Win8_x64_2": {
-      "match": "*Windows NT 6.2 x64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform": "Win8",
-        "Platform_Bits": 64,
-        "Platform_Version": "6.2",
-        "Platform_Description": "Windows 8",
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "Win8_x64": {
-      "match": "*Windows NT 6.2*Win64? x64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform": "Win8",
-        "Platform_Bits": 64,
-        "Platform_Version": "6.2",
-        "Platform_Description": "Windows 8",
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "Win8_64": {
-      "match": "*Windows NT 6.2*WOW64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "Win8",
-        "Platform_Bits": 64,
-        "Platform_Version": "6.2",
-        "Platform_Description": "Windows 8",
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "Win8_32": {
-      "match": "*Windows NT 6.2*",
-      "lite": true,
-      "standard": true,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "Win8",
-        "Platform_Version": "6.2",
-        "Platform_Description": "Windows 8"
-      }
-    },
-    "Win7_x64_2": {
-      "match": "*Windows NT 6.1*x64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform": "Win7",
-        "Platform_Bits": 64,
-        "Platform_Version": "6.1",
-        "Platform_Description": "Windows 7",
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "Win7_x64_Trident": {
-      "match": "*Windows NT 6.1*Trident/?.0*Win64? x64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform": "Win7",
-        "Platform_Bits": 64,
-        "Platform_Version": "6.1",
-        "Platform_Description": "Windows 7",
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "Win7_x64": {
-      "match": "*Windows NT 6.1*Win64? x64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform": "Win7",
-        "Platform_Bits": 64,
-        "Platform_Version": "6.1",
-        "Platform_Description": "Windows 7",
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "Win7_64_Trident": {
-      "match": "*Windows NT 6.1*Trident/?.0*WOW64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "Win7",
-        "Platform_Bits": 64,
-        "Platform_Version": "6.1",
-        "Platform_Description": "Windows 7",
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "Win7_64": {
-      "match": "*Windows NT 6.1*WOW64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "Win7",
-        "Platform_Bits": 64,
-        "Platform_Version": "6.1",
-        "Platform_Description": "Windows 7",
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "Win7_32": {
-      "match": "*Windows NT 6.1*",
-      "lite": true,
-      "standard": true,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "Win7",
-        "Platform_Version": "6.1",
-        "Platform_Description": "Windows 7"
-      }
-    },
-    "Win7_32_2": {
-      "match": "*Windows;Microsoft Windows (6.1*)*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "Win7",
-        "Platform_Version": "6.1",
-        "Platform_Description": "Windows 7"
-      }
-    },
-    "Vista_x64_2": {
-      "match": "*Windows NT 6.0 x64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform": "WinVista",
-        "Platform_Bits": 64,
-        "Platform_Version": "6.0",
-        "Platform_Description": "Windows Vista",
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "Vista_x64": {
-      "match": "*Windows NT 6.0;*Win64? x64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform": "WinVista",
-        "Platform_Bits": 64,
-        "Platform_Version": "6.0",
-        "Platform_Description": "Windows Vista",
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "Vista_64_Trident": {
-      "match": "*Windows NT 6.0*Trident/?.0*WOW64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinVista",
-        "Platform_Bits": 64,
-        "Platform_Version": "6.0",
-        "Platform_Description": "Windows Vista",
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "Vista_64": {
-      "match": "*Windows NT 6.0*WOW64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinVista",
-        "Platform_Bits": 64,
-        "Platform_Version": "6.0",
-        "Platform_Description": "Windows Vista",
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "Vista_32": {
-      "match": "*Windows NT 6.0*",
-      "lite": true,
-      "standard": true,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinVista",
-        "Platform_Version": "6.0",
-        "Platform_Description": "Windows Vista"
-      }
-    },
-    "WinXPb_x64_3": {
-      "match": "*Windows NT 5.2;*Win64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinXP",
-        "Platform_Bits": 64,
-        "Platform_Version": "5.2",
-        "Platform_Description": "Windows XP",
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "WinXPb_x64_2": {
-      "match": "*Windows NT 5.2 x64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform": "WinXP",
-        "Platform_Bits": 64,
-        "Platform_Version": "5.2",
-        "Platform_Description": "Windows XP",
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "WinXPb_x64": {
-      "match": "*Windows NT 5.2;*Win64? x64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform": "WinXP",
-        "Platform_Bits": 64,
-        "Platform_Version": "5.2",
-        "Platform_Description": "Windows XP",
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "WinXPb_64": {
-      "match": "*Windows NT 5.2*WOW64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinXP",
-        "Platform_Bits": 64,
-        "Platform_Version": "5.2",
-        "Platform_Description": "Windows XP",
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "WinXPb_32": {
-      "match": "*Windows NT 5.2*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinXP",
-        "Platform_Version": "5.2",
-        "Platform_Description": "Windows XP"
-      }
-    },
-    "WinXPa_x64_2": {
-      "match": "*Windows NT 5.1 x64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform": "WinXP",
-        "Platform_Bits": 64,
-        "Platform_Version": "5.1",
-        "Platform_Description": "Windows XP",
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "WinXPa_x64": {
-      "match": "*Windows NT 5.1;*Win64? x64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform": "WinXP",
-        "Platform_Bits": 64,
-        "Platform_Version": "5.1",
-        "Platform_Description": "Windows XP",
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "WinXPa_64": {
-      "match": "*Windows NT 5.1*WOW64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinXP",
-        "Platform_Bits": 64,
-        "Platform_Version": "5.1",
-        "Platform_Description": "Windows XP",
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "WinXPa_32": {
-      "match": "*Windows NT 5.1*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinXP",
-        "Platform_Version": "5.1",
-        "Platform_Description": "Windows XP"
-      }
-    },
-    "WinXPa_v2": {
-      "match": "*Windows XP*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinXP",
-        "Platform_Version": "5.1",
-        "Platform_Description": "Windows XP"
-      }
-    },
-    "Win2000_3": {
-      "match": "*Windows NT 5.01*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "Win2000",
-        "Platform_Version": "5.01",
-        "Platform_Description": "Windows 2000"
-      }
-    },
-    "Win2000_2": {
-      "match": "*Windows 2000*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "Win2000",
-        "Platform_Version": "5.0",
-        "Platform_Description": "Windows 2000"
-      }
-    },
-    "Win2000_x64": {
-      "match": "*Windows NT 5.0;*Win64? x64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform": "Win2000",
-        "Platform_Bits": 64,
-        "Platform_Version": "5.0",
-        "Platform_Description": "Windows 2000",
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "Win2000_64": {
-      "match": "*Windows NT 5.0; *WOW64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "Win2000",
-        "Platform_Bits": 64,
-        "Platform_Version": "5.0",
-        "Platform_Description": "Windows 2000",
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "Win2000": {
-      "match": "*Windows NT 5.0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "Win2000",
-        "Platform_Version": "5.0",
-        "Platform_Description": "Windows 2000"
-      }
-    },
-    "Win2000_5": {
-      "match": "*Windows NT5.0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "Win2000",
-        "Platform_Version": "5.0",
-        "Platform_Description": "Windows 2000"
-      }
-    },
-    "NT4_1": {
-      "match": "*Windows NT 4.1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinNT",
-        "Platform_Version": "4.1",
-        "Platform_Description": "Windows NT"
-      }
-    },
-    "NT4_64": {
-      "match": "*Windows NT 4.0; *WOW64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinNT",
-        "Platform_Bits": 64,
-        "Platform_Version": "4.0",
-        "Platform_Description": "Windows NT",
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "NT4": {
-      "match": "*Windows NT 4.0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinNT",
-        "Platform_Version": "4.0",
-        "Platform_Description": "Windows NT"
-      }
-    },
-    "NT3.5": {
-      "match": "*Windows NT 3.5*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinNT",
-        "Platform_Version": "3.5",
-        "Platform_Description": "Windows NT"
-      }
-    },
-    "NT3.1": {
-      "match": "*Windows NT 3.1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinNT",
-        "Platform_Version": "3.1",
-        "Platform_Description": "Windows NT"
-      }
-    },
-    "NT_x64": {
-      "match": "*Windows NT; Win64? x64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform": "WinNT",
-        "Platform_Bits": 64,
-        "Platform_Description": "Windows NT",
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "NT_64": {
-      "match": "*Windows NT; *WOW64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinNT",
-        "Platform_Bits": 64,
-        "Platform_Description": "Windows NT",
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "NT": {
-      "match": "*Windows NT*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinNT",
-        "Platform_Description": "Windows NT"
-      }
-    },
-    "NT4_1_B": {
-      "match": "*Windows 4.10*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinNT",
-        "Platform_Version": "4.1",
-        "Platform_Description": "Windows NT"
-      }
-    },
-    "WinME_2": {
-      "match": "*Windows ME*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinME",
-        "Platform_Version": "ME",
-        "Platform_Description": "Windows ME"
-      }
-    },
-    "WinME_3": {
-      "match": "*Windows 98; Win 9x4.90*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinME",
-        "Platform_Version": "ME",
-        "Platform_Description": "Windows ME"
-      }
-    },
-    "Win98_2": {
-      "match": "*Windows 98*",
-      "inherits": "Win98",
-      "lite": false,
-      "standard": false
-    },
-    "Win98_3": {
-      "match": "*Windows*98*",
-      "inherits": "Win98",
-      "lite": false,
-      "standard": false
-    },
-    "Win95_2": {
-      "match": "*Windows 95*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "Win95",
-        "Platform_Version": "95",
-        "Platform_Description": "Windows 95"
-      }
-    },
-    "Win3.11_B": {
-      "match": "*Windows 3.11*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "Win31",
-        "Platform_Version": "3.11",
-        "Platform_Description": "Windows 3.11",
-        "Win16": true,
-        "Win32": false
-      }
-    },
-    "Win3.1_B": {
-      "match": "*Windows 3.1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Browser_Bits": 16,
-        "Platform": "Win31",
-        "Platform_Bits": 16,
-        "Platform_Version": "3.1",
-        "Platform_Description": "Windows 3.1",
-        "Win16": true,
-        "Win32": false
-      }
-    },
-    "Windows_x64": {
-      "match": "*Windows*x64*",
-      "lite": true,
-      "standard": true,
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform": "Win64",
-        "Platform_Bits": 64,
-        "Platform_Version": "unknown",
-        "Platform_Maker": "Microsoft Corporation",
-        "Platform_Description": "Windows",
-        "Win16": false,
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "Windows_64": {
-      "match": "*Windows*WOW64*",
-      "lite": true,
-      "standard": true,
-      "properties": {
-        "Browser_Bits": 32,
-        "Platform": "Win64",
-        "Platform_Bits": 64,
-        "Platform_Version": "unknown",
-        "Platform_Maker": "Microsoft Corporation",
-        "Platform_Description": "Windows",
-        "Win16": false,
-        "Win32": false,
-        "Win64": true
-      }
-    },
-    "Windows": {
-      "match": "*Windows*",
-      "lite": true,
-      "standard": true,
-      "properties": {
-        "Browser_Bits": 32,
-        "Platform": "Win32",
-        "Platform_Bits": 32,
-        "Platform_Version": "unknown",
-        "Platform_Maker": "Microsoft Corporation",
-        "Platform_Description": "Windows",
-        "Win16": false,
-        "Win32": true,
-        "Win64": false
-      }
-    },
-    "WinXPb_v2": {
-      "match": "*WinNT5.2*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinXP",
-        "Platform_Version": "5.2",
-        "Platform_Description": "Windows XP"
-      }
-    },
-    "WinXPa_v3": {
-      "match": "*WinNT5.1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinXP",
-        "Platform_Version": "5.1",
-        "Platform_Description": "Windows XP"
-      }
-    },
-    "Win2000_6": {
-      "match": "*WinNT5.0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "Win2000",
-        "Platform_Version": "5.0",
-        "Platform_Description": "Windows 2000"
-      }
-    },
-    "Win2000_4": {
-      "match": "*Win2000*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "Win2000",
-        "Platform_Version": "5.0",
-        "Platform_Description": "Windows 2000"
-      }
-    },
-    "NT4_B": {
-      "match": "*WinNT4.0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinNT",
-        "Platform_Version": "4.0",
-        "Platform_Description": "Windows NT"
-      }
-    },
-    "NT3.51": {
-      "match": "*WinNT3.51*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinNT",
-        "Platform_Version": "3.51",
-        "Platform_Description": "Windows NT"
-      }
-    },
-    "NT_2": {
-      "match": "*WinNT*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinNT",
-        "Platform_Description": "Windows NT"
-      }
-    },
-    "WinME": {
-      "match": "*Win 9x 4.90*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinME",
-        "Platform_Version": "ME",
-        "Platform_Description": "Windows ME"
-      }
-    },
-    "Win98": {
-      "match": "*Win98*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "Win98",
-        "Platform_Version": "98",
-        "Platform_Description": "Windows 98"
-      }
-    },
-    "Win95": {
-      "match": "*Win95*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "Win95",
-        "Platform_Version": "95",
-        "Platform_Description": "Windows 95"
-      }
-    },
-    "Win3.11": {
-      "match": "*Win3.11*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Browser_Bits": 16,
-        "Platform": "Win31",
-        "Platform_Bits": 16,
-        "Platform_Version": "3.11",
-        "Platform_Description": "Windows 3.11",
-        "Win16": true,
-        "Win32": false
-      }
-    },
-    "Win3.1": {
-      "match": "*Win3.1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Browser_Bits": 16,
-        "Platform": "Win31",
-        "Platform_Bits": 16,
-        "Platform_Version": "3.1",
-        "Platform_Description": "Windows 3.1",
-        "Win16": true,
-        "Win32": false
-      }
-    },
-    "Win32": {
-      "match": "*Win32*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows"
-    },
-    "Win16": {
-      "match": "*Win16*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Browser_Bits": 16,
-        "Platform": "Win16",
-        "Platform_Bits": 16,
-        "Win16": true,
-        "Win32": false
-      }
-    },
-    "OSX_PPC_3": {
-      "match": "*Macintosh*PPC* Mac OS X*",
-      "lite": false,
-      "standard": false,
-      "inherits": "OSX_PPC"
-    },
-    "OSX_PPC_10_5": {
-      "match": "*PPC Mac OS X 10?5*",
-      "lite": false,
-      "standard": false,
-      "inherits": "OSX_PPC",
-      "properties": {
-        "Platform_Version": "10.5"
-      }
-    },
-    "OSX_PPC_10_4": {
-      "match": "*PPC Mac OS X 10?4*",
-      "lite": false,
-      "standard": false,
-      "inherits": "OSX_PPC",
-      "properties": {
-        "Platform_Version": "10.4"
-      }
-    },
-    "OSX_PPC": {
-      "match": "*PPC* Mac OS X*",
-      "lite": false,
-      "standard": false,
-      "inherits": "OSX",
-      "properties": {
-        "Platform_Description": "Mac OS X for Power PC"
-      }
-    },
-    "OSX_PPC_2": {
-      "match": "*Mac_PowerPC* Mac OS X*",
-      "lite": false,
-      "standard": false,
-      "inherits": "OSX_PPC"
-    },
-    "OSX_10_14": {
-      "match": "*Mac OS X 10?14*",
-      "lite": false,
-      "standard": true,
-      "inherits": "OSX",
-      "properties": {
-        "Platform": "macOS",
-        "Platform_Description": "macOS",
-        "Platform_Version": "10.14"
-      }
-    },
-    "OSX_10_13": {
-      "match": "*Mac OS X 10?13*",
-      "lite": false,
-      "standard": true,
-      "inherits": "OSX",
-      "properties": {
-        "Platform": "macOS",
-        "Platform_Description": "macOS",
-        "Platform_Version": "10.13"
-      }
-    },
-    "OSX_10_12": {
-      "match": "*Mac OS X 10?12*",
-      "lite": false,
-      "standard": true,
-      "inherits": "OSX",
-      "properties": {
-        "Platform": "macOS",
-        "Platform_Description": "macOS",
-        "Platform_Version": "10.12"
-      }
-    },
-    "OSX_10_11": {
-      "match": "*Mac OS X 10?11*",
-      "lite": false,
-      "standard": true,
-      "inherits": "OSX",
-      "properties": {
-        "Platform_Version": "10.11"
-      }
-    },
-    "OSX_10_10": {
-      "match": "*Mac OS X 10?10*",
-      "lite": false,
-      "standard": true,
-      "inherits": "OSX",
-      "properties": {
-        "Platform_Version": "10.10"
-      }
-    },
-    "OSX_10_9": {
-      "match": "*Mac OS X 10?9*",
-      "lite": false,
-      "standard": true,
-      "inherits": "OSX",
-      "properties": {
-        "Platform_Version": "10.9"
-      }
-    },
-    "OSX_10_8": {
-      "match": "*Mac OS X 10?8*",
-      "lite": false,
-      "standard": false,
-      "inherits": "OSX",
-      "properties": {
-        "Platform_Version": "10.8"
-      }
-    },
-    "OSX_10_7": {
-      "match": "*Mac OS X 10?7*",
-      "lite": false,
-      "standard": false,
-      "inherits": "OSX",
-      "properties": {
-        "Platform_Version": "10.7"
-      }
-    },
-    "OSX_10_6": {
-      "match": "*Mac OS X 10?6*",
-      "lite": false,
-      "standard": false,
-      "inherits": "OSX",
-      "properties": {
-        "Platform_Version": "10.6"
-      }
-    },
-    "OSX_10_5": {
-      "match": "*Mac OS X 10?5*",
-      "lite": false,
-      "standard": false,
-      "inherits": "OSX",
-      "properties": {
-        "Platform_Version": "10.5"
-      }
-    },
-    "OSX_10_4": {
-      "match": "*Mac OS X 10?4*",
-      "lite": false,
-      "standard": false,
-      "inherits": "OSX",
-      "properties": {
-        "Platform_Version": "10.4"
-      }
-    },
-    "OSX_10_3": {
-      "match": "*Mac OS X 10?3*",
-      "lite": false,
-      "standard": false,
-      "inherits": "OSX",
-      "properties": {
-        "Platform_Version": "10.3"
-      }
-    },
-    "OSX_10_2": {
-      "match": "*Mac OS X 10?2*",
-      "lite": false,
-      "standard": false,
-      "inherits": "OSX",
-      "properties": {
-        "Platform_Version": "10.2"
-      }
-    },
-    "OSX_10_1": {
-      "match": "*Mac OS X 10?1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "OSX",
-      "properties": {
-        "Platform_Version": "10.1"
-      }
-    },
-    "OSX": {
-      "match": "*Mac OS X*",
-      "lite": true,
-      "standard": true,
-      "properties": {
-        "Platform": "MacOSX",
-        "Platform_Description": "Mac OS X",
-        "Platform_Maker": "Apple Inc",
-        "Platform_Bits": 32,
-        "Platform_Version": "10",
-        "Browser_Bits": 32,
-        "Win16": false,
-        "Win32": false,
-        "Win64": false
-      }
-    },
-    "OSX_B_10_12": {
-      "match": "*Macintosh; OS X 10.12*",
-      "lite": false,
-      "standard": true,
-      "inherits": "OSX",
-      "properties": {
-        "Platform": "macOS",
-        "Platform_Description": "macOS",
-        "Platform_Version": "10.12"
-      }
-    },
-    "OSX_B_10_11": {
-      "match": "*Macintosh; OS X 10.11*",
-      "lite": false,
-      "standard": true,
-      "inherits": "OSX",
-      "properties": {
-        "Platform_Version": "10.11"
-      }
-    },
-    "OSX_B_10_10": {
-      "match": "*Macintosh; OS X 10.10*",
-      "lite": false,
-      "standard": true,
-      "inherits": "OSX",
-      "properties": {
-        "Platform_Version": "10.10"
-      }
-    },
-    "OSX_B_10_9": {
-      "match": "*Macintosh; OS X 10.9*",
-      "lite": false,
-      "standard": true,
-      "inherits": "OSX",
-      "properties": {
-        "Platform_Version": "10.9"
-      }
-    },
-    "OSX_B_10_8": {
-      "match": "*Macintosh; OS X 10.8*",
-      "inherits": "OSX",
-      "lite": false,
-      "standard": false,
-      "properties": {
-        "Platform_Version": "10.8"
-      }
-    },
-    "OSX_B_10_7": {
-      "match": "*Macintosh; OS X 10.7*",
-      "inherits": "OSX",
-      "lite": false,
-      "standard": false,
-      "properties": {
-        "Platform_Version": "10.7"
-      }
-    },
-    "OSX_B_10_6": {
-      "match": "*Macintosh; OS X 10.6*",
-      "inherits": "OSX",
-      "lite": false,
-      "standard": false,
-      "properties": {
-        "Platform_Version": "10.6"
-      }
-    },
-    "OSX_B_10_5": {
-      "match": "*Macintosh; OS X 10.5*",
-      "inherits": "OSX",
-      "lite": false,
-      "standard": false,
-      "properties": {
-        "Platform_Version": "10.5"
-      }
-    },
-    "OSX_B_10_4": {
-      "match": "*Macintosh; OS X 10.4*",
-      "inherits": "OSX",
-      "lite": false,
-      "standard": false,
-      "properties": {
-        "Platform_Version": "10.4"
-      }
-    },
-    "OSX_B_10_3": {
-      "match": "*Macintosh; OS X 10.3*",
-      "inherits": "OSX",
-      "lite": false,
-      "standard": false,
-      "properties": {
-        "Platform_Version": "10.3"
-      }
-    },
-    "OSX_B_10_2": {
-      "match": "*Macintosh; OS X 10.2*",
-      "inherits": "OSX",
-      "lite": false,
-      "standard": false,
-      "properties": {
-        "Platform_Version": "10.2"
-      }
-    },
-    "OSX_B_10_1": {
-      "match": "*Macintosh; OS X 10.1*",
-      "inherits": "OSX",
-      "lite": false,
-      "standard": false,
-      "properties": {
-        "Platform_Version": "10.1"
-      }
-    },
-    "OSX_B": {
-      "match": "*Macintosh; OS X *",
-      "lite": true,
-      "standard": true,
-      "inherits": "OSX"
-    },
-    "OSX_C_10_12": {
-      "match": "*MacOS X 10?12*",
-      "lite": false,
-      "standard": true,
-      "inherits": "OSX",
-      "properties": {
-        "Platform": "macOS",
-        "Platform_Description": "macOS",
-        "Platform_Version": "10.12"
-      }
-    },
-    "OSX_C_10_11": {
-      "match": "*MacOS X 10?11*",
-      "lite": false,
-      "standard": true,
-      "inherits": "OSX",
-      "properties": {
-        "Platform_Version": "10.11"
-      }
-    },
-    "OSX_C_10_10": {
-      "match": "*MacOS X 10?10*",
-      "lite": false,
-      "standard": true,
-      "inherits": "OSX",
-      "properties": {
-        "Platform_Version": "10.10"
-      }
-    },
-    "OSX_C_10_9": {
-      "match": "*MacOS X 10?9*",
-      "lite": false,
-      "standard": true,
-      "inherits": "OSX",
-      "properties": {
-        "Platform_Version": "10.9"
-      }
-    },
-    "OSX_C_10_8": {
-      "match": "*MacOS X 10?8*",
-      "lite": false,
-      "standard": false,
-      "inherits": "OSX",
-      "properties": {
-        "Platform_Version": "10.8"
-      }
-    },
-    "OSX_C_10_7": {
-      "match": "*MacOS X 10?7*",
-      "lite": false,
-      "standard": false,
-      "inherits": "OSX",
-      "properties": {
-        "Platform_Version": "10.7"
-      }
-    },
-    "OSX_C_10_6": {
-      "match": "*MacOS X 10?6*",
-      "lite": false,
-      "standard": false,
-      "inherits": "OSX",
-      "properties": {
-        "Platform_Version": "10.6"
-      }
-    },
-    "OSX_C_10_5": {
-      "match": "*MacOS X 10?5*",
-      "lite": false,
-      "standard": false,
-      "inherits": "OSX",
-      "properties": {
-        "Platform_Version": "10.5"
-      }
-    },
-    "OSX_C": {
-      "match": "*MacOS X*",
-      "lite": true,
-      "standard": true,
-      "properties": {
-        "Platform": "MacOSX",
-        "Platform_Description": "Mac OS X",
-        "Platform_Maker": "Apple Inc",
-        "Platform_Bits": 32,
-        "Platform_Version": "10",
-        "Browser_Bits": 32,
-        "Win16": false,
-        "Win32": false,
-        "Win64": false
-      }
-    },
-    "ATV_OSX_8_3": {
-      "match": "*CPU OS 8_3* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "ATV_OSX",
-      "properties": {
-        "Platform_Version": "8.3"
-      }
-    },
-    "ATV_OSX": {
-      "match": "*CPU*OS* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform": "ATV OS X",
-        "Platform_Description": "ATV OS X is a special variant of iOS optimized for Apple TV"
-      }
-    },
-    "MacPPC_3": {
-      "match": "*Macintosh*PPC*",
-      "lite": false,
-      "standard": false,
-      "inherits": "MacPPC"
-    },
-    "MacPPC_2": {
-      "match": "*Mac_PowerPC*",
-      "lite": false,
-      "standard": false,
-      "inherits": "MacPPC"
-    },
-    "MacPPC": {
-      "match": "*PPC*",
-      "lite": false,
-      "standard": false,
-      "inherits": "OSX",
-      "properties": {
-        "Platform": "MacPPC",
-        "Platform_Version": "unknown",
-        "Platform_Description": "Mac OS for Power PC"
-      }
-    },
-    "Mac68K_2": {
-      "match": "*Mac_68K*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Mac68K"
-    },
-    "Mac68K": {
-      "match": "*Macintosh*68K*",
-      "lite": false,
-      "standard": false,
-      "inherits": "OSX",
-      "properties": {
-        "Platform": "Mac68K",
-        "Platform_Version": "unknown",
-        "Platform_Description": "Mac OS for Motorola 68000 Series"
-      }
-    },
-    "FreeBSD_64": {
-      "match": "*FreeBSD x86_64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "FreeBSD",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform_Bits": 64
-      }
-    },
-    "FreeBSD_64_2": {
-      "match": "*FreeBSD amd64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "FreeBSD",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform_Bits": 64
-      }
-    },
-    "FreeBSD": {
-      "match": "*FreeBSD*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "FreeBSD",
-        "Platform_Maker": "FreeBSD Foundation",
-        "Platform_Description": "FreeBSD",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "OpenBSD_64": {
-      "match": "*OpenBSD x86_64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "OpenBSD",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform_Bits": 64
-      }
-    },
-    "OpenBSD_64_2": {
-      "match": "*OpenBSD amd64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "OpenBSD",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform_Bits": 64
-      }
-    },
-    "OpenBSD_64_3": {
-      "match": "*OpenBSD sparc64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "OpenBSD",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform_Bits": 64
-      }
-    },
-    "OpenBSD": {
-      "match": "*OpenBSD*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "OpenBSD",
-        "Platform_Maker": "unknown",
-        "Platform_Description": "OpenBSD",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "NetBSD_64_2": {
-      "match": "*NetBSD amd64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "NetBSD",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform_Bits": 64
-      }
-    },
-    "NetBSD": {
-      "match": "*NetBSD*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "NetBSD",
-        "Platform_Maker": "unknown",
-        "Platform_Description": "NetBSD",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "DragonFlyBSD_64": {
-      "match": "*DragonFly x86_64*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "DragonFly BSD",
-        "Platform_Maker": "unknown",
-        "Platform_Description": "DragonFlyBSD",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 64,
-        "Platform_Bits": 64
-      }
-    },
-    "DragonFlyBSD": {
-      "match": "*DragonFly*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "DragonFly BSD",
-        "Platform_Maker": "unknown",
-        "Platform_Description": "DragonFlyBSD",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "BSD Four": {
-      "match": "*BSD Four*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "BSD",
-        "Platform_Maker": "University of California, Berkeley",
-        "Platform_Description": "BSD Four",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "HPUX": {
-      "match": "*HP-UX*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "HP-UX",
-        "Platform_Maker": "HP",
-        "Platform_Description": "HP-UX",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "HPUX_2": {
-      "match": "*HPUX*",
-      "lite": true,
-      "standard": true,
-      "inherits": "HPUX"
-    },
-    "IRIX64": {
-      "match": "*IRIX64*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "IRIX64",
-        "Platform_Maker": "SGI",
-        "Platform_Description": "IRIX64",
-        "Platform_Version": "unknown",
-        "Browser_Bits": 64,
-        "Platform_Bits": 64,
-        "Win16": false,
-        "Win32": false,
-        "Win64": false
-      }
-    },
-    "IRIX64_2": {
-      "match": "*IRIX*",
-      "lite": false,
-      "standard": true,
-      "inherits": "IRIX64"
-    },
-    "BeOS": {
-      "match": "*BeOS*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "BeOS",
-        "Platform_Maker": "Access",
-        "Platform_Description": "BeOS",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "SunOS": {
-      "match": "*SunOS*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "SunOS",
-        "Platform_Maker": "Oracle",
-        "Platform_Description": "SunOS",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "OS2": {
-      "match": "*OS/2*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "OS/2",
-        "Platform_Maker": "IBM",
-        "Platform_Description": "OS/2",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "Unix": {
-      "match": "*UNIX*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "Unix",
-        "Platform_Maker": "unknown",
-        "Platform_Description": "Unix",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "AIX": {
-      "match": "*AIX*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "AIX",
-        "Platform_Maker": "IBM",
-        "Platform_Description": "AIX",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "Tru64_Unix": {
-      "match": "*Digital Unix*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "Tru64 UNIX",
-        "Platform_Maker": "HP",
-        "Platform_Description": "Tru64 UNIX",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 64,
-        "Platform_Bits": 64
-      }
-    },
-    "Tru64_Unix_B": {
-      "match": "*OSF1*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "Tru64 UNIX",
-        "Platform_Maker": "HP",
-        "Platform_Description": "Tru64 UNIX",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 64,
-        "Platform_Bits": 64
-      }
-    },
-    "Solaris": {
-      "match": "*Solaris*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "Solaris",
-        "Platform_Maker": "Oracle",
-        "Platform_Description": "Solaris",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "iOS_A_dynamic": {
-      "match": "*CPU iPhone OS #MAJORVER#?#MINORVER#* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "#MAJORVER#.#MINORVER#"
-      }
-    },
-    "iOS_A_12_0": {
-      "match": "*CPU iPhone OS 12?0* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "12.0"
-      }
-    },
-    "iOS_A_11_4": {
-      "match": "*CPU iPhone OS 11?4* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "11.4"
-      }
-    },
-    "iOS_A_11_3": {
-      "match": "*CPU iPhone OS 11?3* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "11.3"
-      }
-    },
-    "iOS_A_11_2": {
-      "match": "*CPU iPhone OS 11?2* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "11.2"
-      }
-    },
-    "iOS_A_11_1": {
-      "match": "*CPU iPhone OS 11?1* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "11.1"
-      }
-    },
-    "iOS_A_11_0": {
-      "match": "*CPU iPhone OS 11?0* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "11.0"
-      }
-    },
-    "iOS_A_10_3": {
-      "match": "*CPU iPhone OS 10?3* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "10.3"
-      }
-    },
-    "iOS_A_10_2": {
-      "match": "*CPU iPhone OS 10?2* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "10.2"
-      }
-    },
-    "iOS_A_10_1": {
-      "match": "*CPU iPhone OS 10?1* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "10.1"
-      }
-    },
-    "iOS_A_10_0": {
-      "match": "*CPU iPhone OS 10?* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "10.0"
-      }
-    },
-    "iOS_A_9_3": {
-      "match": "*CPU iPhone OS 9?3* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "9.3"
-      }
-    },
-    "iOS_A_9_2": {
-      "match": "*CPU iPhone OS 9?2* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "9.2"
-      }
-    },
-    "iOS_A_9_1": {
-      "match": "*CPU iPhone OS 9?1* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "9.1"
-      }
-    },
-    "iOS_A_9_0": {
-      "match": "*CPU iPhone OS 9?* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "9.0"
-      }
-    },
-    "iOS_A_8_4": {
-      "match": "*CPU iPhone OS 8?4* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "8.4"
-      }
-    },
-    "iOS_A_8_3": {
-      "match": "*CPU iPhone OS 8?3* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "8.3"
-      }
-    },
-    "iOS_A_8_2": {
-      "match": "*CPU iPhone OS 8?2* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "8.2"
-      }
-    },
-    "iOS_A_8_1": {
-      "match": "*CPU iPhone OS 8?1* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "8.1"
-      }
-    },
-    "iOS_A_8_0": {
-      "match": "*CPU iPhone OS 8?* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "8.0"
-      }
-    },
-    "iOS_A_8_0_B": {
-      "match": "*CPU iPhone OS 10?10* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "8.0"
-      }
-    },
-    "iOS_A_7_1": {
-      "match": "*CPU iPhone OS 7?1* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "7.1"
-      }
-    },
-    "iOS_A_7_0": {
-      "match": "*CPU iPhone OS 7?* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "7.0"
-      }
-    },
-    "iOS_A_6_1": {
-      "match": "*CPU iPhone OS 6?1* like Mac OS X*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "6.1"
-      }
-    },
-    "iOS_A_6_0": {
-      "match": "*CPU iPhone OS 6?* like Mac OS X*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "6.0"
-      }
-    },
-    "iOS_A_5_1": {
-      "match": "*CPU iPhone OS 5?1* like Mac OS X*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "5.1"
-      }
-    },
-    "iOS_A_5_0": {
-      "match": "*CPU iPhone OS 5?* like Mac OS X*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "5.0"
-      }
-    },
-    "iOS_A_4_3": {
-      "match": "*CPU iPhone OS 4?3* like Mac OS X*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "4.3"
-      }
-    },
-    "iOS_A_4_2": {
-      "match": "*CPU iPhone OS 4?2* like Mac OS X*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "4.2"
-      }
-    },
-    "iOS_A_4_1": {
-      "match": "*CPU iPhone OS 4?1* like Mac OS X*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "4.1"
-      }
-    },
-    "iOS_A_4_0": {
-      "match": "*CPU iPhone OS 4?* like Mac OS X*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "4.0"
-      }
-    },
-    "iOS_A_3_2": {
-      "match": "*CPU iPhone OS 3?2 like Mac OS X**",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "3.2"
-      }
-    },
-    "iOS_A_3_1": {
-      "match": "*CPU iPhone OS 3?1* like Mac OS X*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "3.1"
-      }
-    },
-    "iOS_A_3_0": {
-      "match": "*CPU iPhone OS 3?* like Mac OS X*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "3.0"
-      }
-    },
-    "iOS_A_2_2": {
-      "match": "*CPU iPhone OS 2?2* like Mac OS X*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "2.2"
-      }
-    },
-    "iOS_A_2_1": {
-      "match": "*CPU iPhone OS 2?1* like Mac OS X*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "2.1"
-      }
-    },
-    "iOS_A_2_0": {
-      "match": "*CPU iPhone OS 2?* like Mac OS X*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "2.0"
-      }
-    },
-    "iOS_A": {
-      "match": "*CPU iPhone OS * like Mac OS X*",
-      "lite": true,
-      "standard": true,
-      "inherits": "iOS"
-    },
-    "iOS_C_dynamic": {
-      "match": "*CPU OS #MAJORVER#_#MINORVER#* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "#MAJORVER#.#MINORVER#"
-      }
-    },
-    "iOS_C_12_0": {
-      "match": "*CPU OS 12_0* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "12.0"
-      }
-    },
-    "iOS_C_11_4": {
-      "match": "*CPU OS 11_4* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "11.4"
-      }
-    },
-    "iOS_C_11_3": {
-      "match": "*CPU OS 11_3* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "11.3"
-      }
-    },
-    "iOS_C_11_2": {
-      "match": "*CPU OS 11_2* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "11.2"
-      }
-    },
-    "iOS_C_11_1": {
-      "match": "*CPU OS 11_1* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "11.1"
-      }
-    },
-    "iOS_C_11_0": {
-      "match": "*CPU OS 11_0* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "11.0"
-      }
-    },
-    "iOS_C_10_3": {
-      "match": "*CPU OS 10_3* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "10.3"
-      }
-    },
-    "iOS_C_10_2": {
-      "match": "*CPU OS 10_2* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "10.2"
-      }
-    },
-    "iOS_C_10_1": {
-      "match": "*CPU OS 10_1* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "10.1"
-      }
-    },
-    "iOS_C_10_0": {
-      "match": "*CPU OS 10* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "10.0"
-      }
-    },
-    "iOS_C_9_3": {
-      "match": "*CPU OS 9_3* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "9.3"
-      }
-    },
-    "iOS_C_9_2": {
-      "match": "*CPU OS 9_2* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "9.2"
-      }
-    },
-    "iOS_C_9_1": {
-      "match": "*CPU OS 9_1* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "9.1"
-      }
-    },
-    "iOS_C_9_0": {
-      "match": "*CPU OS 9* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "9.0"
-      }
-    },
-    "iOS_C_8_4": {
-      "match": "*CPU OS 8_4* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "8.4"
-      }
-    },
-    "iOS_C_8_3": {
-      "match": "*CPU OS 8_3* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "8.3"
-      }
-    },
-    "iOS_C_8_2": {
-      "match": "*CPU OS 8_2* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "8.2"
-      }
-    },
-    "iOS_C_8_1": {
-      "match": "*CPU OS 8_1* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "8.1"
-      }
-    },
-    "iOS_C_8_0": {
-      "match": "*CPU OS 8* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "8.0"
-      }
-    },
-    "iOS_C_7_1": {
-      "match": "*CPU OS 7_1* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "7.1"
-      }
-    },
-    "iOS_C_7_0": {
-      "match": "*CPU OS 7* like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "7.0"
-      }
-    },
-    "iOS_C_6_1": {
-      "match": "*CPU OS 6_1* like Mac OS X*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "6.1"
-      }
-    },
-    "iOS_C_6_0": {
-      "match": "*CPU OS 6* like Mac OS X*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "6.0"
-      }
-    },
-    "iOS_C_5_1": {
-      "match": "*CPU OS 5_1* like Mac OS X*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "5.1"
-      }
-    },
-    "iOS_C_5_0": {
-      "match": "*CPU OS 5* like Mac OS X*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "5.0"
-      }
-    },
-    "iOS_C_4_3": {
-      "match": "*CPU OS 4_3* like Mac OS X*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "4.3"
-      }
-    },
-    "iOS_C_4_2": {
-      "match": "*CPU OS 4_2* like Mac OS X*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "4.2"
-      }
-    },
-    "iOS_C_4_1": {
-      "match": "*CPU OS 4_1* like Mac OS X*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "4.1"
-      }
-    },
-    "iOS_C_4_0": {
-      "match": "*CPU OS 4* like Mac OS X*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "4.0"
-      }
-    },
-    "iOS_C_3_2": {
-      "match": "*CPU OS 3_2* like Mac OS X*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "3.2"
-      }
-    },
-    "iOS_C_3_1": {
-      "match": "*CPU OS 3_1* like Mac OS X*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "3.1"
-      }
-    },
-    "iOS_C_3_0": {
-      "match": "*CPU OS 3* like Mac OS X*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "3.0"
-      }
-    },
-    "iOS_C": {
-      "match": "*CPU*OS* like Mac OS X*",
-      "lite": true,
-      "standard": true,
-      "inherits": "iOS"
-    },
-    "iOS_N": {
-      "match": "*iOS*",
-      "lite": true,
-      "standard": true,
-      "inherits": "iOS"
-    },
-    "iOS_I_11_3": {
-      "match": "* iOS?11.3*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "11.3"
-      }
-    },
-    "iOS_I_11_2": {
-      "match": "* iOS?11.2*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "11.2"
-      }
-    },
-    "iOS_I_11_1": {
-      "match": "* iOS?11.1*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "11.1"
-      }
-    },
-    "iOS_I_11_0": {
-      "match": "* iOS?11.0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "11.0"
-      }
-    },
-    "iOS_I_10_3": {
-      "match": "* iOS?10.3*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "10.3"
-      }
-    },
-    "iOS_I_10_2": {
-      "match": "* iOS?10.2*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "10.2"
-      }
-    },
-    "iOS_I_10_1": {
-      "match": "* iOS?10.1*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "10.1"
-      }
-    },
-    "iOS_I_8_4": {
-      "match": "* iOS?8.4*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "8.4"
-      }
-    },
-    "iOS_I_8_0": {
-      "match": "* iOS?8.0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "8.0"
-      }
-    },
-    "iOS_I_7_1": {
-      "match": "* iOS?7.1*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "7.1"
-      }
-    },
-    "iOS_I_7_0": {
-      "match": "* iOS?7.0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "7.0"
-      }
-    },
-    "iOS_I": {
-      "match": "* iOS?*",
-      "lite": true,
-      "standard": true,
-      "inherits": "iOS"
-    },
-    "iOS_J_11_1": {
-      "match": "iOS/11.1*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "11.1"
-      }
-    },
-    "iOS_J_11_0": {
-      "match": "iOS/11.0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "11.0"
-      }
-    },
-    "iOS_J_10_3": {
-      "match": "iOS/10.3*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "10.3"
-      }
-    },
-    "iOS_J_8_0": {
-      "match": "iOS/8.0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "8.0"
-      }
-    },
-    "iOS_J_7_1": {
-      "match": "iOS/7.1*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "7.1"
-      }
-    },
-    "iOS_J_7_0": {
-      "match": "iOS/7.0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "7.0"
-      }
-    },
-    "iOS_J_6_1": {
-      "match": "iOS/6.1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "6.1"
-      }
-    },
-    "iOS_J_6_0": {
-      "match": "iOS/6.0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "6.0"
-      }
-    },
-    "iOS_J_5_1": {
-      "match": "iOS/5.1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "5.1"
-      }
-    },
-    "iOS_J": {
-      "match": "iOS/*",
-      "lite": true,
-      "standard": true,
-      "inherits": "iOS"
-    },
-    "iOS_E_10_3": {
-      "match": "*iPhone OS?10?3*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "10.3"
-      }
-    },
-    "iOS_E_10_2": {
-      "match": "*iPhone OS?10?2*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "10.2"
-      }
-    },
-    "iOS_E_10_1": {
-      "match": "*iPhone OS?10?1*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "10.1"
-      }
-    },
-    "iOS_E_10_0": {
-      "match": "*iPhone OS?10?0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "10.0"
-      }
-    },
-    "iOS_E_9_3": {
-      "match": "*iPhone OS?9?3*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "9.3"
-      }
-    },
-    "iOS_E_9_2": {
-      "match": "*iPhone OS?9?2*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "9.2"
-      }
-    },
-    "iOS_E_9_1": {
-      "match": "*iPhone OS?9?1*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "9.1"
-      }
-    },
-    "iOS_E_9_0": {
-      "match": "*iPhone OS?9?0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "9.0"
-      }
-    },
-    "iOS_E_8_1": {
-      "match": "*iPhone OS?8?1*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "8.1"
-      }
-    },
-    "iOS_E_8_0": {
-      "match": "*iPhone OS?8?0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "8.0"
-      }
-    },
-    "iOS_E_7_1": {
-      "match": "*iPhone OS?7?1*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "7.1"
-      }
-    },
-    "iOS_E_7_0": {
-      "match": "*iPhone OS?7?0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "7.0"
-      }
-    },
-    "iOS_E_6_1": {
-      "match": "*iPhone OS?6?1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "6.1"
-      }
-    },
-    "iOS_E_6_0": {
-      "match": "*iPhone OS?6?0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "6.0"
-      }
-    },
-    "iOS_E_5_1": {
-      "match": "*iPhone OS?5?1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "5.1"
-      }
-    },
-    "iOS_E_5_0": {
-      "match": "*iPhone OS?5?0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "5.0"
-      }
-    },
-    "iOS_E_4_3": {
-      "match": "*iPhone OS?4?3*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "4.3"
-      }
-    },
-    "iOS_E": {
-      "match": "*iPhone OS*",
-      "lite": true,
-      "standard": true,
-      "inherits": "iOS"
-    },
-    "iOS_G_4_3": {
-      "match": "IUC(U;iOS 4.3*)*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "4.3"
-      }
-    },
-    "iOS_G": {
-      "match": "IUC(U;iOS*)*",
-      "lite": true,
-      "standard": true,
-      "inherits": "iOS"
-    },
-    "iOS_K_8_1": {
-      "match": "*iPhone OS 8.1*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "8.1"
-      }
-    },
-    "iOS_K_8_0": {
-      "match": "*iPhone OS 8.0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "8.0"
-      }
-    },
-    "iOS_K": {
-      "match": "*iPhone OS*",
-      "lite": true,
-      "standard": true,
-      "inherits": "iOS"
-    },
-    "iOS_O_10_3": {
-      "match": "*iOS Version 10.3*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "10.3"
-      }
-    },
-    "iOS_O_10_2": {
-      "match": "*iOS Version 10.2*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "10.2"
-      }
-    },
-    "iOS_O_10_1": {
-      "match": "*iOS Version 10.1*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "10.1"
-      }
-    },
-    "iOS_O_10_0": {
-      "match": "*iOS Version 10.0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "10.0"
-      }
-    },
-    "iOS_O_9_3": {
-      "match": "*iOS Version 9.3*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "9.3"
-      }
-    },
-    "iOS_O_9_2": {
-      "match": "*iOS Version 9.2*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "9.2"
-      }
-    },
-    "iOS_O_9_1": {
-      "match": "*iOS Version 9.1*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "9.1"
-      }
-    },
-    "iOS_O_9_0": {
-      "match": "*iOS Version 9.0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "9.0"
-      }
-    },
-    "iOS_O_8_4": {
-      "match": "*iOS Version 8.4*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "8.4"
-      }
-    },
-    "iOS_O_8_3": {
-      "match": "*iOS Version 8.3*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "8.3"
-      }
-    },
-    "iOS_O_8_2": {
-      "match": "*iOS Version 8.2*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "8.2"
-      }
-    },
-    "iOS_O_8_1": {
-      "match": "*iOS Version 8.1*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "8.1"
-      }
-    },
-    "iOS_O_8_0": {
-      "match": "*iOS Version 8.0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "8.0"
-      }
-    },
-    "iOS_O": {
-      "match": "*iOS Version*",
-      "lite": true,
-      "standard": true,
-      "inherits": "iOS"
-    },
-    "iOS_L_8_1": {
-      "match": "*iosv8.1*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "8.1"
-      }
-    },
-    "iOS_L_8_0": {
-      "match": "*iosv8.0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "8.0"
-      }
-    },
-    "iOS_L_7_1": {
-      "match": "*iosv7.1*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "7.1"
-      }
-    },
-    "iOS_L_7_0": {
-      "match": "*iosv7.0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "7.0"
-      }
-    },
-    "iOS_L": {
-      "match": "*iosv*",
-      "lite": true,
-      "standard": true,
-      "inherits": "iOS"
-    },
-    "iOS_H_5_0": {
-      "match": "iPhone_OS/5.0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "5.0"
-      }
-    },
-    "iOS_H": {
-      "match": "iPhone_OS/*",
-      "lite": true,
-      "standard": true,
-      "inherits": "iOS"
-    },
-    "iOS_M": {
-      "match": "*iOS; like Mac OS X*",
-      "lite": true,
-      "standard": true,
-      "inherits": "iOS"
-    },
-    "iOS_B_1_0": {
-      "match": "*CPU like Mac OS X*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "1.0"
-      }
-    },
-    "iOS_B": {
-      "match": "*CPU like Mac OS X*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS"
-    },
-    "iOS_D_8_3": {
-      "match": "*iOS; U; iPh OS 8_3*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "8.3"
-      }
-    },
-    "iOS_D_8_2": {
-      "match": "*iOS; U; iPh OS 8_2*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "8.2"
-      }
-    },
-    "iOS_D_8_1": {
-      "match": "*iOS; U; iPh OS 8_1*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "8.1"
-      }
-    },
-    "iOS_D_8_0": {
-      "match": "*iOS; U; iPh OS 8_0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "8.0"
-      }
-    },
-    "iOS_D_7_1": {
-      "match": "*iOS; U; iPh OS 7_1*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "7.1"
-      }
-    },
-    "iOS_D_7_0": {
-      "match": "*iOS; U; iPh OS 7_0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "7.0"
-      }
-    },
-    "iOS_D_6_1": {
-      "match": "*iOS; U; iPh OS 6_1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "6.1"
-      }
-    },
-    "iOS_D_6_0": {
-      "match": "*iOS; U; iPh OS 6_0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "6.0"
-      }
-    },
-    "iOS_D_5_1": {
-      "match": "*iOS; U; iPh OS 5_1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "5.1"
-      }
-    },
-    "iOS_D_5_0": {
-      "match": "*iOS; U; iPh OS 5_0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "iOS",
-      "properties": {
-        "Platform_Version": "5.0"
-      }
-    },
-    "iOS_D": {
-      "match": "*iOS; U; iPh OS*",
-      "lite": true,
-      "standard": true,
-      "inherits": "iOS"
-    },
-    "iOS": {
-      "match": "*CPU iPhone OS *",
-      "lite": true,
-      "standard": true,
-      "properties": {
-        "Platform": "iOS",
-        "Platform_Maker": "Apple Inc",
-        "Platform_Description": "iPod, iPhone & iPad",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "Darwin_64": {
-      "match": "*Darwin*(x86_64)*",
-      "lite": false,
-      "standard": false,
-      "properties": {
-        "Platform": "Darwin",
-        "Platform_Maker": "Apple Inc",
-        "Platform_Description": "Darwin is a Core Component of MacOSX and iOS",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 64,
-        "Platform_Bits": 64
-      }
-    },
-    "Darwin": {
-      "match": "*Darwin*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "Darwin",
-        "Platform_Maker": "Apple Inc",
-        "Platform_Description": "Darwin is a Core Component of MacOSX and iOS",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "Tizen_Dynamic": {
-      "match": "*Linux*Tizen #MAJORVER#.#MINORVER#*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Tizen",
-      "properties": {
-        "Platform_Version": "#MAJORVER#.#MINORVER#"
-      }
-    },
-    "Tizen_4_0": {
-      "match": "*Linux*Tizen 4.0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Tizen",
-      "properties": {
-        "Platform_Version": "4.0"
-      }
-    },
-    "Tizen_3_0": {
-      "match": "*Linux*Tizen 3.0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Tizen",
-      "properties": {
-        "Platform_Version": "3.0"
-      }
-    },
-    "Tizen_2_4": {
-      "match": "*Linux*Tizen 2.4*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Tizen",
-      "properties": {
-        "Platform_Version": "2.4"
-      }
-    },
-    "Tizen_2_3": {
-      "match": "*Linux*Tizen 2.3*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Tizen",
-      "properties": {
-        "Platform_Version": "2.3"
-      }
-    },
-    "Tizen_2_2": {
-      "match": "*Linux*Tizen 2.2*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Tizen",
-      "properties": {
-        "Platform_Version": "2.2"
-      }
-    },
-    "Tizen_2_1": {
-      "match": "*Linux*Tizen 2.1*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Tizen",
-      "properties": {
-        "Platform_Version": "2.1"
-      }
-    },
-    "Tizen_2_0": {
-      "match": "*Linux*Tizen 2.0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Tizen",
-      "properties": {
-        "Platform_Version": "2.0"
-      }
-    },
-    "Tizen": {
-      "match": "*Linux*Tizen*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "Tizen",
-        "Platform_Maker": "Linux Foundation",
-        "Platform_Description": "Tizen",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "Maemo_ARM": {
-      "match": "*Linux arm*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Maemo"
-    },
-    "Maemo": {
-      "match": "*Maemo; Linux*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "Maemo",
-        "Platform_Maker": "Linux Foundation",
-        "Platform_Description": "Maemo",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "ChromeOS_ARM": {
-      "match": "*CrOS armv*",
-      "lite": false,
-      "standard": false,
-      "inherits": "ChromeOS"
-    },
-    "ChromeOS_64_ARM_fake_windows": {
-      "match": "*Windows aarch64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "ChromeOS"
-    },
-    "ChromeOS_x64": {
-      "match": "*CrOS x86_64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "ChromeOS",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform_Bits": 64
-      }
-    },
-    "ChromeOS_x64_fake_windows": {
-      "match": "*Windows x86_64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "ChromeOS",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform_Bits": 64
-      }
-    },
-    "ChromeOS": {
-      "match": "*CrOS*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "ChromeOS",
-        "Platform_Description": "Google Chrome OS",
-        "Platform_Maker": "Google Inc",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "Ubuntu_Touch_15_04": {
-      "match": "*Ubuntu?15.04*like Android*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Ubuntu_Touch",
-      "properties": {
-        "Platform_Version": "15.04"
-      }
-    },
-    "Ubuntu_Touch_14_04": {
-      "match": "*Ubuntu?14.04*like Android*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Ubuntu_Touch",
-      "properties": {
-        "Platform_Version": "14.04"
-      }
-    },
-    "Ubuntu_Touch": {
-      "match": "*Ubuntu*like Android*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Ubuntu",
-      "properties": {
-        "Platform": "Ubuntu Touch",
-        "Platform_Description": "Ubuntu Linux for Mobile"
-      }
-    },
-    "Ubuntu_14_04_64": {
-      "match": "*Ubuntu?14.04*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Ubuntu",
-      "properties": {
-        "Platform_Version": "14.04",
-        "Browser_Bits": 64,
-        "Platform_Bits": 64
-      }
-    },
-    "Ubuntu_12_04_64": {
-      "match": "*Ubuntu/12.04*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Ubuntu",
-      "properties": {
-        "Platform_Version": "12.04",
-        "Browser_Bits": 64,
-        "Platform_Bits": 64
-      }
-    },
-    "Ubuntu_11_04_64": {
-      "match": "*Ubuntu/11.04*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Ubuntu",
-      "properties": {
-        "Platform_Version": "11.04",
-        "Browser_Bits": 64,
-        "Platform_Bits": 64
-      }
-    },
-    "Ubuntu_10_10_64": {
-      "match": "*Ubuntu/10.10*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Ubuntu",
-      "properties": {
-        "Platform_Version": "10.10",
-        "Browser_Bits": 64,
-        "Platform_Bits": 64
-      }
-    },
-    "Ubuntu_10_04_64": {
-      "match": "*Ubuntu/10.04*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Ubuntu",
-      "properties": {
-        "Platform_Version": "10.04",
-        "Browser_Bits": 64,
-        "Platform_Bits": 64
-      }
-    },
-    "Ubuntu_08_10_64": {
-      "match": "*Ubuntu/8.10*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Ubuntu",
-      "properties": {
-        "Platform_Version": "8.10",
-        "Browser_Bits": 64,
-        "Platform_Bits": 64
-      }
-    },
-    "Ubuntu_08_04_64": {
-      "match": "*Ubuntu/8.04*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Ubuntu",
-      "properties": {
-        "Platform_Version": "8.04",
-        "Browser_Bits": 64,
-        "Platform_Bits": 64
-      }
-    },
-    "Ubuntu_64": {
-      "match": "*Ubuntu; Linux x86_64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Ubuntu",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform_Bits": 64
-      }
-    },
-    "Ubuntu_14_04": {
-      "match": "*Ubuntu?14.04*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Ubuntu",
-      "properties": {
-        "Platform_Version": "14.04"
-      }
-    },
-    "Ubuntu_12_04": {
-      "match": "*Ubuntu/12.04*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Ubuntu",
-      "properties": {
-        "Platform_Version": "12.04"
-      }
-    },
-    "Ubuntu_11_10": {
-      "match": "*Ubuntu/11.10*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Ubuntu",
-      "properties": {
-        "Platform_Version": "11.10"
-      }
-    },
-    "Ubuntu_11_04": {
-      "match": "*Ubuntu/11.04*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Ubuntu",
-      "properties": {
-        "Platform_Version": "11.04"
-      }
-    },
-    "Ubuntu_10_10": {
-      "match": "*Ubuntu/10.10*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Ubuntu",
-      "properties": {
-        "Platform_Version": "10.10"
-      }
-    },
-    "Ubuntu_10_04": {
-      "match": "*Ubuntu/10.04*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Ubuntu",
-      "properties": {
-        "Platform_Version": "10.04"
-      }
-    },
-    "Ubuntu_09_25": {
-      "match": "*Ubuntu/9.25*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Ubuntu",
-      "properties": {
-        "Platform_Version": "9.25"
-      }
-    },
-    "Ubuntu_08_10": {
-      "match": "*Ubuntu/8.10*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Ubuntu",
-      "properties": {
-        "Platform_Version": "8.10"
-      }
-    },
-    "Ubuntu_08_04": {
-      "match": "*Ubuntu/8.04*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Ubuntu",
-      "properties": {
-        "Platform_Version": "8.04"
-      }
-    },
-    "Ubuntu": {
-      "match": "*Ubuntu*",
-      "lite": false,
-      "standard": false,
-      "properties": {
-        "Platform": "Ubuntu",
-        "Platform_Maker": "Canonical Foundation",
-        "Platform_Description": "Ubuntu Linux",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "CentOS": {
-      "match": "*CentOS*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "CentOS",
-        "Platform_Maker": "unknown",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "Debian_32_on_x64_2": {
-      "match": "*Linux i686 (x86_64)*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Debian",
-      "properties": {
-        "Platform_Bits": 64
-      }
-    },
-    "Debian_64": {
-      "match": "*Linux x86_64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Debian",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform_Bits": 64
-      }
-    },
-    "Debian": {
-      "match": "*Linux*",
-      "lite": false,
-      "standard": false,
-      "properties": {
-        "Platform": "Debian",
-        "Platform_Description": "Debian Linux",
-        "Platform_Maker": "Software in the Public Interest, Inc.",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "Fedora": {
-      "match": "*Fedora*",
-      "lite": false,
-      "standard": false,
-      "properties": {
-        "Platform": "Fedora",
-        "Platform_Maker": "Red Hat Inc",
-        "Platform_Description": "Fedora Linux",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "Red_Hat": {
-      "match": "*Red Hat*",
-      "lite": false,
-      "standard": false,
-      "properties": {
-        "Platform": "Red Hat",
-        "Platform_Maker": "Red Hat Inc",
-        "Platform_Description": "Red Hat Linux",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "Linux_32_on_x64": {
-      "match": "*Linux i686 on x86_64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Linux",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform_Bits": 64
-      }
-    },
-    "Linux_32_on_x64_2": {
-      "match": "*Linux i686 (x86_64)*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Linux",
-      "properties": {
-        "Platform_Bits": 64
-      }
-    },
-    "Linux_x64": {
-      "match": "*linux x64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Linux",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform_Bits": 64
-      }
-    },
-    "Linux_64_ARM": {
-      "match": "*Linux aarch64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Linux",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform_Bits": 64
-      }
-    },
-    "Linux_64_sparc": {
-      "match": "*linux sparc64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Linux",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform_Bits": 64
-      }
-    },
-    "Linux_64_amd": {
-      "match": "*Linux*amd64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Linux",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform_Bits": 64
-      }
-    },
-    "Linux_64": {
-      "match": "*Linux*x86_64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Linux",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform_Bits": 64
-      }
-    },
-    "Linux_64_B": {
-      "match": "*x86_64*linux*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Linux",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform_Bits": 64
-      }
-    },
-    "Linux_PPC": {
-      "match": "*Linux*; PPC*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Linux"
-    },
-    "Linux_MIPS": {
-      "match": "*Linux* mips*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Linux"
-    },
-    "Linux_ARM": {
-      "match": "*Linux* arm*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Linux"
-    },
-    "Linux_SH4": {
-      "match": "*Linux* sh4*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Linux"
-    },
-    "Mobilinux": {
-      "match": "*Linux*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Linux",
-      "properties": {
-        "Platform": "Mobilinux",
-        "Platform_Maker": "MontaVista",
-        "Platform_Description": "An Embedded-Linux-Distribution for Phones"
-      }
-    },
-    "Linux": {
-      "match": "*Linux*",
-      "lite": true,
-      "standard": true,
-      "properties": {
-        "Platform": "Linux",
-        "Platform_Maker": "Linux Foundation",
-        "Platform_Description": "Linux",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "WinPhone10_Continuum": {
-      "match": "*Windows NT 10.0*ARM;*",
-      "lite": false,
-      "standard": true,
-      "inherits": "WinPhone10",
-      "properties": {
-        "Browser_Modus": "Continuum Mode (Desktop)"
-      }
-    },
-    "WinPhone10_B": {
-      "match": "*Windows; U; wds 10.0*",
-      "lite": true,
-      "standard": true,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinPhone10",
-        "Platform_Version": "10.0",
-        "Platform_Description": "Windows Phone OS 10.0",
-        "Win32": false
-      }
-    },
-    "WinPhone10": {
-      "match": "*Windows Phone 10.0*",
-      "lite": true,
-      "standard": true,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinPhone10",
-        "Platform_Version": "10.0",
-        "Platform_Description": "Windows Phone OS 10.0",
-        "Win32": false
-      }
-    },
-    "WinPhone8.1_B": {
-      "match": "*Windows; U; wds 8.1*",
-      "lite": true,
-      "standard": true,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinPhone8.1",
-        "Platform_Version": "8.1",
-        "Platform_Description": "Windows Phone OS 8.1",
-        "Win32": false
-      }
-    },
-    "WinPhone8.1": {
-      "match": "*Windows Phone 8.1*",
-      "lite": true,
-      "standard": true,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinPhone8.1",
-        "Platform_Version": "8.1",
-        "Platform_Description": "Windows Phone OS 8.1",
-        "Win32": false
-      }
-    },
-    "WinPhone8_osmeta": {
-      "match": "*like iPhone; U; osmeta 8.*",
-      "lite": true,
-      "standard": true,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinPhone8",
-        "Platform_Version": "8.0",
-        "Platform_Description": "Windows Phone OS 8 (osmeta)",
-        "Win32": false
-      }
-    },
-    "WinPhone8_B": {
-      "match": "*Windows; U; wds 8*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinPhone8",
-        "Platform_Version": "8.0",
-        "Platform_Description": "Windows Phone OS 8",
-        "Win32": false
-      }
-    },
-    "WinPhone8": {
-      "match": "*Windows Phone 8*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinPhone8",
-        "Platform_Version": "8.0",
-        "Platform_Description": "Windows Phone OS 8",
-        "Win32": false
-      }
-    },
-    "WinPhone710": {
-      "match": "*Windows Phone OS 7.10*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinPhone7.10",
-        "Platform_Version": "7.10",
-        "Platform_Description": "Windows Phone OS 7.10",
-        "Win32": false
-      }
-    },
-    "WinPhone78": {
-      "match": "*Windows Phone OS 7.8*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinPhone7.8",
-        "Platform_Version": "7.8",
-        "Platform_Description": "Windows Phone OS 7.8",
-        "Win32": false
-      }
-    },
-    "WinPhone75": {
-      "match": "*Windows Phone OS 7.5*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinPhone7.5",
-        "Platform_Version": "7.5",
-        "Platform_Description": "Windows Phone OS 7.5",
-        "Win32": false
-      }
-    },
-    "WinPhone7_C": {
-      "match": "*Windows; U; wds 7*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinPhone7",
-        "Platform_Version": "7.0",
-        "Platform_Description": "Windows Phone OS 7",
-        "Win32": false
-      }
-    },
-    "WinPhone7": {
-      "match": "*Windows Phone OS 7.0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinPhone7",
-        "Platform_Version": "7.0",
-        "Platform_Description": "Windows Phone OS 7",
-        "Win32": false
-      }
-    },
-    "WinPhone65": {
-      "match": "*Windows Phone 6.5*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinPhone6",
-        "Platform_Version": "6.5",
-        "Platform_Description": "Windows Phone OS 6.5",
-        "Win32": false
-      }
-    },
-    "WinPhone": {
-      "match": "*Windows Phone*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinPhone",
-        "Platform_Description": "Windows Phone OS",
-        "Win32": false
-      }
-    },
-    "WinMobile": {
-      "match": "*Windows*Mobile*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinMobile",
-        "Platform_Description": "Windows Mobile OS",
-        "Win32": false
-      }
-    },
-    "WinCE": {
-      "match": "*Windows CE*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Windows",
-      "properties": {
-        "Platform": "WinCE",
-        "Platform_Description": "Windows CE",
-        "Win32": false
-      }
-    },
-    "Miui_OS_Dynamic": {
-      "match": "*MIUI/#MAJORVER#.#MINORVER#*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Miui_OS",
-      "properties": {
-        "Platform_Version": "#MAJORVER#.#MINORVER#"
-      }
-    },
-    "Miui_OS_Dynamic_B": {
-      "match": "*MIUI/V#MAJORVER#.#MINORVER#*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Miui_OS",
-      "properties": {
-        "Platform_Version": "#MAJORVER#.#MINORVER#"
-      }
-    },
-    "Miui_OS_8_2": {
-      "match": "*MIUI/V8.2*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Miui_OS",
-      "properties": {
-        "Platform_Version": "8.2"
-      }
-    },
-    "Miui_OS_7_3": {
-      "match": "*MIUI/V7.3*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Miui_OS",
-      "properties": {
-        "Platform_Version": "7.3"
-      }
-    },
-    "Miui_OS": {
-      "match": "*MIUI*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "Miui OS",
-        "Platform_Maker": "Xiaomi Tech",
-        "Platform_Version": "unknown",
-        "Platform_Description": "a fork of Android OS by Xiaomi",
-        "Win32": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "Android_Dynamic": {
-      "match": "*Linux*Android?#MAJORVER#.#MINORVER#*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "#MAJORVER#.#MINORVER#"
-      }
-    },
-    "Android_9_0": {
-      "match": "*Linux*Android?9;*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "9.0"
-      }
-    },
-    "Android_8_1": {
-      "match": "*Linux*Android?8.1*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "8.1"
-      }
-    },
-    "Android_8_0": {
-      "match": "*Linux*Android?8.0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "8.0"
-      }
-    },
-    "Android_7_1": {
-      "match": "*Linux*Android?7.1*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "7.1"
-      }
-    },
-    "Android_7_0": {
-      "match": "*Linux*Android?7.0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "7.0"
-      }
-    },
-    "Android_6_0": {
-      "match": "*Linux*Android?6.0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "6.0"
-      }
-    },
-    "Android_5_1": {
-      "match": "*Linux*Android?5.1*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "5.1"
-      }
-    },
-    "Android_5_0": {
-      "match": "*Linux*Android?5.0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "5.0"
-      }
-    },
-    "Android_4_4": {
-      "match": "*Linux*Android?4.4*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.4"
-      }
-    },
-    "Android_4_3": {
-      "match": "*Linux*Android?4.3*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.3"
-      }
-    },
-    "Android_4_2": {
-      "match": "*Linux*Android?4.2*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.2"
-      }
-    },
-    "Android_4_1": {
-      "match": "*Linux*Android?4.1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.1"
-      }
-    },
-    "Android_4_1_E": {
-      "match": "*Linux*Android; 4.1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.1"
-      }
-    },
-    "Android_4_0": {
-      "match": "*Linux*Android?4.0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.0"
-      }
-    },
-    "Android_3_2": {
-      "match": "*Linux*Android?3.2*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "3.2"
-      }
-    },
-    "Android_3_1": {
-      "match": "*Linux*Android?3.1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "3.1"
-      }
-    },
-    "Android_3_0": {
-      "match": "*Linux*Android?3.0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "3.0"
-      }
-    },
-    "Android_2_3": {
-      "match": "*Linux*Android?2.3*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.3"
-      }
-    },
-    "Android_2_2": {
-      "match": "*Linux*Android?2.2*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.2"
-      }
-    },
-    "Android_2_1": {
-      "match": "*Linux*Android?2.1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.1"
-      }
-    },
-    "Android_2_0": {
-      "match": "*Linux*Android?2.0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.0"
-      }
-    },
-    "Android_1_6": {
-      "match": "*Linux*Android?1.6*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "1.6"
-      }
-    },
-    "Android_1_5": {
-      "match": "*Linux*Android?1.5*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "1.5"
-      }
-    },
-    "Android_1_1": {
-      "match": "*Linux*Android?1.1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "1.1"
-      }
-    },
-    "Android_1_0": {
-      "match": "*Linux*Android?1.0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "1.0"
-      }
-    },
-    "Android_1_0_B": {
-      "match": "*Linux*Android?v1.0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "1.0"
-      }
-    },
-    "Android": {
-      "match": "*Linux*Android*",
-      "lite": true,
-      "standard": true,
-      "properties": {
-        "Platform": "Android",
-        "Platform_Description": "Android OS",
-        "Platform_Maker": "Google Inc",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "Android_H_8_1": {
-      "match": "*Android?8.1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "8.1"
-      }
-    },
-    "Android_H_8_0": {
-      "match": "*Android?8.0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "8.0"
-      }
-    },
-    "Android_H_7_1": {
-      "match": "*Android?7.1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "7.1"
-      }
-    },
-    "Android_H_7_0": {
-      "match": "*Android?7.0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "7.0"
-      }
-    },
-    "Android_H_6_0": {
-      "match": "*Android?6.0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "6.0"
-      }
-    },
-    "Android_H_5_1": {
-      "match": "*Android?5.1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "5.1"
-      }
-    },
-    "Android_H_5_0": {
-      "match": "*Android?5.0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "5.0"
-      }
-    },
-    "Android_H_4_4": {
-      "match": "*Android?4.4*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.4"
-      }
-    },
-    "Android_H_4_3": {
-      "match": "*Android?4.3*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.3"
-      }
-    },
-    "Android_H_4_2": {
-      "match": "*Android?4.2*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.2"
-      }
-    },
-    "Android_H_4_1": {
-      "match": "*Android?4.1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.1"
-      }
-    },
-    "Android_H_4_0": {
-      "match": "*Android?4.0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.0"
-      }
-    },
-    "Android_H_2_3": {
-      "match": "*Android?2.3*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.3"
-      }
-    },
-    "Android_H_2_2": {
-      "match": "*Android?2.2*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.2"
-      }
-    },
-    "Android_H_2_1": {
-      "match": "*Android?2.1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.1"
-      }
-    },
-    "Android_H_2_0": {
-      "match": "*Android?2.0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.0"
-      }
-    },
-    "Android_H": {
-      "match": "*Android*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android"
-    },
-    "Android_B_2_3": {
-      "match": "* Build/GINGERBREAD*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.3"
-      }
-    },
-    "Android_B": {
-      "match": "* Build/*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android"
-    },
-    "Android_F_8_0": {
-      "match": "*Android?8.0*Linux*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "8.0"
-      }
-    },
-    "Android_F_7_1": {
-      "match": "*Android?7.1*Linux*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "7.1"
-      }
-    },
-    "Android_F_7_0": {
-      "match": "*Android?7.0*Linux*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "7.0"
-      }
-    },
-    "Android_F_6_0": {
-      "match": "*Android?6.0*Linux*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "6.0"
-      }
-    },
-    "Android_F_5_1": {
-      "match": "*Android?5.1*Linux*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "5.1"
-      }
-    },
-    "Android_F_5_0": {
-      "match": "*Android?5.0*Linux*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "5.0"
-      }
-    },
-    "Android_F_4_4": {
-      "match": "*Android?4.4*Linux*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.4"
-      }
-    },
-    "Android_F_4_3": {
-      "match": "*Android?4.3*Linux*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.3"
-      }
-    },
-    "Android_F_4_2": {
-      "match": "*Android?4.2*Linux*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.2"
-      }
-    },
-    "Android_F_4_1": {
-      "match": "*Android?4.1*Linux*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.1"
-      }
-    },
-    "Android_F_4_0": {
-      "match": "*Android?4.0*Linux*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.0"
-      }
-    },
-    "Android_F_3_2": {
-      "match": "*Android?3.2*Linux*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "3.2"
-      }
-    },
-    "Android_F_3_1": {
-      "match": "*Android?3.1*Linux*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "3.1"
-      }
-    },
-    "Android_F_3_0": {
-      "match": "*Android?3.0*Linux*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "3.0"
-      }
-    },
-    "Android_F_2_3": {
-      "match": "*Android?2.3*Linux*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.3"
-      }
-    },
-    "Android_F_2_2": {
-      "match": "*Android?2.2*Linux*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.2"
-      }
-    },
-    "Android_F_2_1": {
-      "match": "*Android?2.1*Linux*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.1"
-      }
-    },
-    "Android_F_2_0": {
-      "match": "*Android?2.0*Linux*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.0"
-      }
-    },
-    "Android_F_1_6": {
-      "match": "*Android?1.6*Linux*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "1.6"
-      }
-    },
-    "Android_F": {
-      "match": "*Android?*Linux*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android"
-    },
-    "Android_D_5_1": {
-      "match": "JUC (Linux; U; 5.1*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "5.1"
-      }
-    },
-    "Android_D_5_0": {
-      "match": "JUC (Linux; U; 5.0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "5.0"
-      }
-    },
-    "Android_D_4_4": {
-      "match": "JUC (Linux; U; 4.4*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.4"
-      }
-    },
-    "Android_D_4_3": {
-      "match": "JUC (Linux; U; 4.3*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.3"
-      }
-    },
-    "Android_D_4_2": {
-      "match": "JUC (Linux; U; 4.2*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.2"
-      }
-    },
-    "Android_D_4_1": {
-      "match": "JUC (Linux; U; 4.1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.1"
-      }
-    },
-    "Android_D_4_0": {
-      "match": "JUC (Linux; U; 4.0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.0"
-      }
-    },
-    "Android_D_2_3": {
-      "match": "JUC (Linux; U; 2.3*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.3"
-      }
-    },
-    "Android_D_2_2": {
-      "match": "JUC (Linux; U; 2.2*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.2"
-      }
-    },
-    "Android_D_2_1": {
-      "match": "JUC (Linux; U; 2.1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.1"
-      }
-    },
-    "Android_D_2_0": {
-      "match": "JUC (Linux; U; 2.0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.0"
-      }
-    },
-    "Android_D_1_6": {
-      "match": "JUC (Linux; U; 1.6*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "1.6"
-      }
-    },
-    "Android_D_1_5": {
-      "match": "JUC (Linux; U; 1.5*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "1.5"
-      }
-    },
-    "Android_D": {
-      "match": "JUC (Linux; U; *",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android"
-    },
-    "Android_E_8_0": {
-      "match": "*; U; Adr 8.0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "8.0"
-      }
-    },
-    "Android_E_7_1": {
-      "match": "*; U; Adr 7.1*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "7.1"
-      }
-    },
-    "Android_E_7_0": {
-      "match": "*; U; Adr 7.0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "7.0"
-      }
-    },
-    "Android_E_6_0": {
-      "match": "*; U; Adr 6.0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "6.0"
-      }
-    },
-    "Android_E_5_1": {
-      "match": "*; U; Adr 5.1*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "5.1"
-      }
-    },
-    "Android_E_5_0": {
-      "match": "*; U; Adr 5.0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "5.0"
-      }
-    },
-    "Android_E_4_4": {
-      "match": "*; U; Adr 4.4*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.4"
-      }
-    },
-    "Android_E_4_3": {
-      "match": "*; U; Adr 4.3*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.3"
-      }
-    },
-    "Android_E_4_2": {
-      "match": "*; U; Adr 4.2*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.2"
-      }
-    },
-    "Android_E_4_1": {
-      "match": "*; U; Adr 4.1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.1"
-      }
-    },
-    "Android_E_4_0": {
-      "match": "*; U; Adr 4.0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.0"
-      }
-    },
-    "Android_E_3_2": {
-      "match": "*; U; Adr 3.2*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "3.2"
-      }
-    },
-    "Android_E_3_1": {
-      "match": "*; U; Adr 3.1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "3.1"
-      }
-    },
-    "Android_E_3_0": {
-      "match": "*; U; Adr 3.0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "3.0"
-      }
-    },
-    "Android_E_2_3": {
-      "match": "*; U; Adr 2.3*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.3"
-      }
-    },
-    "Android_E_2_2": {
-      "match": "*; U; Adr 2.2*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.2"
-      }
-    },
-    "Android_E_2_1": {
-      "match": "*; U; Adr 2.1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.1"
-      }
-    },
-    "Android_E_2_0": {
-      "match": "*; U; Adr 2.0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.0"
-      }
-    },
-    "Android_E": {
-      "match": "*; U; Adr *",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android"
-    },
-    "Android_C_4_4": {
-      "match": "JUC(Linux;U;Android4.4*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.4"
-      }
-    },
-    "Android_C_4_3": {
-      "match": "JUC(Linux;U;Android4.3*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.3"
-      }
-    },
-    "Android_C_4_2": {
-      "match": "JUC(Linux;U;Android4.2*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.2"
-      }
-    },
-    "Android_C_4_1": {
-      "match": "JUC(Linux;U;Android4.1*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.1"
-      }
-    },
-    "Android_C_4_0": {
-      "match": "JUC(Linux;U;Android4.0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.0"
-      }
-    },
-    "Android_C_3_2": {
-      "match": "JUC(Linux;U;Android3.2*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "3.2"
-      }
-    },
-    "Android_C_3_1": {
-      "match": "JUC(Linux;U;Android3.1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "3.1"
-      }
-    },
-    "Android_C_3_0": {
-      "match": "JUC(Linux;U;Android3.0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "3.0"
-      }
-    },
-    "Android_C_2_3": {
-      "match": "JUC(Linux;U;Android2.3*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.3"
-      }
-    },
-    "Android_C_2_2": {
-      "match": "JUC(Linux;U;Android2.2*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.2"
-      }
-    },
-    "Android_C_2_1": {
-      "match": "JUC(Linux;U;Android2.1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.1"
-      }
-    },
-    "Android_C_2_0": {
-      "match": "JUC(Linux;U;Android2.0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.0"
-      }
-    },
-    "Android_C_1_6": {
-      "match": "JUC(Linux;U;Android1.6*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "1.6"
-      }
-    },
-    "Android_C_1_5": {
-      "match": "JUC(Linux;U;Android1.5*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "1.5"
-      }
-    },
-    "Android_C": {
-      "match": "JUC(Linux;U;Android*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android"
-    },
-    "Android_G_2_3": {
-      "match": "JUC(Linux;?;2.3*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.3"
-      }
-    },
-    "Android_G_2_2": {
-      "match": "JUC(Linux;?;2.2*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.2"
-      }
-    },
-    "Android_G_2_1": {
-      "match": "JUC(Linux;?;2.1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.1"
-      }
-    },
-    "Android_G_1_5": {
-      "match": "JUC(Linux;?;1.5*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "1.5"
-      }
-    },
-    "Android_G": {
-      "match": "JUC(Linux;?;*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android"
-    },
-    "Android_I_4_4": {
-      "match": "*Linux* 4.4*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.4"
-      }
-    },
-    "Android_I_4_3": {
-      "match": "*Linux* 4.3*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.3"
-      }
-    },
-    "Android_I_4_2": {
-      "match": "*Linux* 4.2*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.2"
-      }
-    },
-    "Android_I_4_1": {
-      "match": "*Linux* 4.1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.1"
-      }
-    },
-    "Android_I_4_0": {
-      "match": "*Linux* 4.0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.0"
-      }
-    },
-    "Android_I_2_3": {
-      "match": "*Linux* 2.3*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.3"
-      }
-    },
-    "Android_I": {
-      "match": "*Linux*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android"
-    },
-    "AndroidTablet_8_1": {
-      "match": "*Android 8.1*Tablet*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "8.1"
-      }
-    },
-    "AndroidTablet_8_0": {
-      "match": "*Android 8.0*Tablet*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "8.0"
-      }
-    },
-    "AndroidTablet_7_1": {
-      "match": "*Android 7.1*Tablet*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "7.1"
-      }
-    },
-    "AndroidTablet_7_0": {
-      "match": "*Android 7.0*Tablet*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "7.0"
-      }
-    },
-    "AndroidTablet_6_0": {
-      "match": "*Android 6.0*Tablet*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "6.0"
-      }
-    },
-    "AndroidTablet_5_1": {
-      "match": "*Android 5.1*Tablet*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "5.1"
-      }
-    },
-    "AndroidTablet_5_0": {
-      "match": "*Android 5.0*Tablet*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "5.0"
-      }
-    },
-    "AndroidTablet_4_4": {
-      "match": "*Android 4.4*Tablet*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.4"
-      }
-    },
-    "AndroidTablet_4_3": {
-      "match": "*Android 4.3*Tablet*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.3"
-      }
-    },
-    "AndroidTablet_4_2": {
-      "match": "*Android 4.2*Tablet*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.2"
-      }
-    },
-    "AndroidTablet_4_1": {
-      "match": "*Android 4.1*Tablet*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.1"
-      }
-    },
-    "AndroidTablet_4_0": {
-      "match": "*Android 4.0*Tablet*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.0"
-      }
-    },
-    "AndroidTablet_3_2": {
-      "match": "*Android 3.2*Tablet*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "3.2"
-      }
-    },
-    "AndroidTablet_3_1": {
-      "match": "*Android 3.1*Tablet*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "3.1"
-      }
-    },
-    "AndroidTablet_3_0": {
-      "match": "*Android 3.0*Tablet*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "3.0"
-      }
-    },
-    "AndroidTablet_2_3": {
-      "match": "*Android 2.3*Tablet*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.3"
-      }
-    },
-    "AndroidTablet_2_2": {
-      "match": "*Android 2.2*Tablet*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.2"
-      }
-    },
-    "AndroidTablet_2_1": {
-      "match": "*Android 2.1*Tablet*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.1"
-      }
-    },
-    "AndroidTablet_2_0": {
-      "match": "*Android 2.0*Tablet*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.0"
-      }
-    },
-    "AndroidTablet": {
-      "match": "*Android*Tablet*",
-      "lite": true,
-      "standard": true,
-      "inherits": "Android"
-    },
-    "AndroidMobile_8_1": {
-      "match": "*Android 8.1*Mobile*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "8.1"
-      }
-    },
-    "AndroidMobile_8_0": {
-      "match": "*Android 8.0*Mobile*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "8.0"
-      }
-    },
-    "AndroidMobile_7_1": {
-      "match": "*Android 7.1*Mobile*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "7.1"
-      }
-    },
-    "AndroidMobile_7_0": {
-      "match": "*Android 7.0*Mobile*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "7.0"
-      }
-    },
-    "AndroidMobile_6_0": {
-      "match": "*Android 6.0*Mobile*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "6.0"
-      }
-    },
-    "AndroidMobile_5_1": {
-      "match": "*Android 5.1*Mobile*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "5.1"
-      }
-    },
-    "AndroidMobile_5_0": {
-      "match": "*Android 5.0*Mobile*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "5.0"
-      }
-    },
-    "AndroidMobile_4_4": {
-      "match": "*Android 4.4*Mobile*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.4"
-      }
-    },
-    "AndroidMobile_4_3": {
-      "match": "*Android 4.3*Mobile*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.3"
-      }
-    },
-    "AndroidMobile_4_2": {
-      "match": "*Android 4.2*Mobile*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.2"
-      }
-    },
-    "AndroidMobile_4_1": {
-      "match": "*Android 4.1*Mobile*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.1"
-      }
-    },
-    "AndroidMobile_4_0": {
-      "match": "*Android 4.0*Mobile*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "4.0"
-      }
-    },
-    "AndroidMobile_2_3": {
-      "match": "*Android 2.3*Mobile*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.3"
-      }
-    },
-    "AndroidMobile_2_2": {
-      "match": "*Android 2.2*Mobile*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.2"
-      }
-    },
-    "AndroidMobile_2_1": {
-      "match": "*Android 2.1*Mobile*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.1"
-      }
-    },
-    "AndroidMobile_2_0": {
-      "match": "*Android 2.0*Mobile*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform_Version": "2.0"
-      }
-    },
-    "AndroidMobile": {
-      "match": "*Android*Mobile*",
-      "lite": true,
-      "standard": true,
-      "inherits": "Android"
-    },
-    "Android_GoogleTV_3_2": {
-      "match": "*Linux*GoogleTV 3.2*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Android",
-      "properties": {
-        "Platform": "Android for GoogleTV",
-        "Platform_Version": "3.2",
-        "Platform_Description": "Android OS for GoogleTV"
-      }
-    },
-    "Android_GoogleTV": {
-      "match": "*Linux*GoogleTV*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Android",
-      "properties": {
-        "Platform": "Android for GoogleTV",
-        "Platform_Description": "Android OS for GoogleTV"
-      }
-    },
-    "AndroidGeneric": {
-      "match": "*Android*",
-      "lite": true,
-      "standard": true,
-      "inherits": "Android"
-    },
-    "Maui": {
-      "match": "*MAUI*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "MAUI",
-        "Platform_Maker": "MediaTek",
-        "Platform_Description": "MAUI Runtime Environment (MRE)",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "Chromecast_OS_64_ARM": {
-      "match": "*Linux aarch64*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Chromecast_OS_ARM",
-      "properties": {
-        "Browser_Bits": 64,
-        "Platform_Bits": 64
-      }
-    },
-    "Chromecast_OS_ARM": {
-      "match": "*Linux* arm*",
-      "lite": false,
-      "standard": false,
-      "properties": {
-        "Platform": "Chromecast OS",
-        "Platform_Maker": "Google Inc",
-        "Platform_Description": "Chromecast OS is a Linux/Android based Platform for the Chromecast",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "Brew_MP": {
-      "match": "*Brew MP*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Brew",
-      "properties": {
-        "Platform_Version": "5.0",
-        "Platform": "Brew MP"
-      }
-    },
-    "Brew_4_0": {
-      "match": "*Brew 4.0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Brew",
-      "properties": {
-        "Platform_Version": "4.0"
-      }
-    },
-    "Brew_3_1": {
-      "match": "*Brew 3.1*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Brew",
-      "properties": {
-        "Platform_Version": "3.1"
-      }
-    },
-    "Brew_3_0": {
-      "match": "*Brew 3.0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Brew",
-      "properties": {
-        "Platform_Version": "3.0"
-      }
-    },
-    "Brew": {
-      "match": "*BREW*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "Brew",
-        "Platform_Version": "2.0",
-        "Platform_Description": "Qualcomm Brew",
-        "Platform_Maker": "Qualcomm",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "Syllable": {
-      "match": "*Syllable*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "Syllable",
-        "Platform_Maker": "Syllable Project",
-        "Platform_Version": "unknown",
-        "Win32": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "SymbianOS": {
-      "match": "*SymbianOS*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "SymbianOS",
-        "Platform_Maker": "Symbian Foundation",
-        "Platform_Description": "Symbian OS",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "SymbianOS_B": {
-      "match": "*Symbian; U; *",
-      "lite": false,
-      "standard": true,
-      "inherits": "SymbianOS"
-    },
-    "SymbianOS_C": {
-      "match": "*SymbOS*",
-      "lite": false,
-      "standard": true,
-      "inherits": "SymbianOS"
-    },
-    "SymbianOS_D": {
-      "match": "*Symbian OS*",
-      "lite": false,
-      "standard": true,
-      "inherits": "SymbianOS"
-    },
-    "JAVA": {
-      "match": "*/MIDP*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "JAVA",
-        "Platform_Maker": "Oracle",
-        "Platform_Version": "unknown",
-        "Platform_Description": "unknown",
-        "Win32": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "Amiga": {
-      "match": "*AmigaOS*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "Amiga OS",
-        "Platform_Maker": "Commodore International",
-        "Platform_Version": "unknown",
-        "Platform_Description": "Amiga OS",
-        "Win32": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "RIM_Tablet_OS_2_1": {
-      "match": "*RIM Tablet OS*",
-      "lite": false,
-      "standard": true,
-      "inherits": "RIM_Tablet_OS",
-      "properties": {
-        "Platform_Version": "2.1"
-      }
-    },
-    "RIM_Tablet_OS_2_0": {
-      "match": "*RIM Tablet OS*",
-      "lite": false,
-      "standard": true,
-      "inherits": "RIM_Tablet_OS",
-      "properties": {
-        "Platform_Version": "2.0"
-      }
-    },
-    "RIM_Tablet_OS_1": {
-      "match": "*RIM Tablet OS*",
-      "lite": false,
-      "standard": true,
-      "inherits": "RIM_Tablet_OS",
-      "properties": {
-        "Platform_Version": "1.0"
-      }
-    },
-    "RIM_Tablet_OS": {
-      "match": "*RIM Tablet OS*",
-      "lite": false,
-      "standard": true,
-      "inherits": "RIMOS",
-      "properties": {
-        "Platform": "RIM Tablet OS"
-      }
-    },
-    "RIMOS_10_X": {
-      "match": "*BB10*",
-      "lite": false,
-      "standard": true,
-      "inherits": "RIMOS",
-      "properties": {
-        "Platform_Version": "#MAJORVER#.#MINORVER#"
-      }
-    },
-    "RIMOS_Dynamic": {
-      "match": "*BlackBerry; U*",
-      "lite": false,
-      "standard": true,
-      "inherits": "RIMOS",
-      "properties": {
-        "Platform_Version": "#MAJORVER#.#MINORVER#"
-      }
-    },
-    "RIMOS_7_1": {
-      "match": "*BlackBerry; U*",
-      "lite": false,
-      "standard": true,
-      "inherits": "RIMOS",
-      "properties": {
-        "Platform_Version": "7.1"
-      }
-    },
-    "RIMOS_7_0": {
-      "match": "*BlackBerry; U*",
-      "lite": false,
-      "standard": true,
-      "inherits": "RIMOS",
-      "properties": {
-        "Platform_Version": "7.0"
-      }
-    },
-    "RIMOS_6_0": {
-      "match": "*BlackBerry; U*",
-      "lite": false,
-      "standard": false,
-      "inherits": "RIMOS",
-      "properties": {
-        "Platform_Version": "6.0"
-      }
-    },
-    "RIMOS_5_0": {
-      "match": "*BlackBerry; U*",
-      "lite": false,
-      "standard": false,
-      "inherits": "RIMOS",
-      "properties": {
-        "Platform_Version": "5.0"
-      }
-    },
-    "RIMOS_4_7": {
-      "match": "*BlackBerry; U*",
-      "lite": false,
-      "standard": false,
-      "inherits": "RIMOS",
-      "properties": {
-        "Platform_Version": "4.7"
-      }
-    },
-    "RIMOS_4_6": {
-      "match": "*BlackBerry; U*",
-      "lite": false,
-      "standard": false,
-      "inherits": "RIMOS",
-      "properties": {
-        "Platform_Version": "4.6"
-      }
-    },
-    "RIMOS_4_5": {
-      "match": "*BlackBerry; U*",
-      "lite": false,
-      "standard": false,
-      "inherits": "RIMOS",
-      "properties": {
-        "Platform_Version": "4.5"
-      }
-    },
-    "RIMOS_4_3": {
-      "match": "*BlackBerry; U*",
-      "lite": false,
-      "standard": false,
-      "inherits": "RIMOS",
-      "properties": {
-        "Platform_Version": "4.3"
-      }
-    },
-    "RIMOS_4_2_B": {
-      "match": "*BlackBerry; U; 4.2*",
-      "lite": false,
-      "standard": false,
-      "inherits": "RIMOS",
-      "properties": {
-        "Platform_Version": "4.2"
-      }
-    },
-    "RIMOS_4_2": {
-      "match": "*BlackBerry; U*",
-      "lite": false,
-      "standard": false,
-      "inherits": "RIMOS",
-      "properties": {
-        "Platform_Version": "4.2"
-      }
-    },
-    "RIMOS_4_1": {
-      "match": "*BlackBerry; U*",
-      "lite": false,
-      "standard": false,
-      "inherits": "RIMOS",
-      "properties": {
-        "Platform_Version": "4.1"
-      }
-    },
-    "RIMOS_4_0": {
-      "match": "*BlackBerry; U*",
-      "lite": false,
-      "standard": false,
-      "inherits": "RIMOS",
-      "properties": {
-        "Platform_Version": "4.0"
-      }
-    },
-    "RIMOS_3_8": {
-      "match": "*BlackBerry; U*",
-      "lite": false,
-      "standard": false,
-      "inherits": "RIMOS",
-      "properties": {
-        "Platform_Version": "3.8"
-      }
-    },
-    "RIMOS_3_7": {
-      "match": "*BlackBerry; U*",
-      "lite": false,
-      "standard": false,
-      "inherits": "RIMOS",
-      "properties": {
-        "Platform_Version": "3.7"
-      }
-    },
-    "RIMOS_3_6": {
-      "match": "*BlackBerry; U*",
-      "lite": false,
-      "standard": false,
-      "inherits": "RIMOS",
-      "properties": {
-        "Platform_Version": "3.6"
-      }
-    },
-    "RIMOS": {
-      "match": "*BlackBerry; U*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "RIM OS",
-        "Platform_Description": "RIM OS",
-        "Platform_Maker": "Research In Motion Limited",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "webOS 3.0 (LG)": {
-      "match": "*web0S*Linux/SmartTV*",
-      "lite": false,
-      "standard": true,
-      "inherits": "webOS (LG)",
-      "properties": {
-        "Platform_Version": "3.0"
-      }
-    },
-    "webOS 2.0 (LG)": {
-      "match": "*web0S*Linux/SmartTV*",
-      "lite": false,
-      "standard": true,
-      "inherits": "webOS (LG)",
-      "properties": {
-        "Platform_Version": "2.0"
-      }
-    },
-    "webOS (LG)": {
-      "match": "*web0S*Linux/SmartTV*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "webOS",
-        "Platform_Description": "LG webOS",
-        "Platform_Maker": "LG",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "webOS_B_30": {
-      "match": "*hpwOS/3.*",
-      "lite": false,
-      "standard": true,
-      "inherits": "webOS",
-      "properties": {
-        "Platform_Version": "3.0"
-      }
-    },
-    "webOS_B": {
-      "match": "*hpwOS/*",
-      "lite": false,
-      "standard": true,
-      "inherits": "webOS"
-    },
-    "webOS_22": {
-      "match": "*webOS/2.2*",
-      "lite": false,
-      "standard": true,
-      "inherits": "webOS",
-      "properties": {
-        "Platform_Version": "2.2"
-      }
-    },
-    "webOS_21": {
-      "match": "*webOS/2.1*",
-      "lite": false,
-      "standard": true,
-      "inherits": "webOS",
-      "properties": {
-        "Platform_Version": "2.1"
-      }
-    },
-    "webOS_20": {
-      "match": "*webOS/2.0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "webOS",
-      "properties": {
-        "Platform_Version": "2.0"
-      }
-    },
-    "webOS_14": {
-      "match": "*webOS/1.4*",
-      "lite": false,
-      "standard": false,
-      "inherits": "webOS",
-      "properties": {
-        "Platform_Version": "1.4"
-      }
-    },
-    "webOS_13": {
-      "match": "*webOS/1.3*",
-      "lite": false,
-      "standard": false,
-      "inherits": "webOS",
-      "properties": {
-        "Platform_Version": "1.3"
-      }
-    },
-    "webOS_12": {
-      "match": "*webOS/1.2*",
-      "lite": false,
-      "standard": false,
-      "inherits": "webOS",
-      "properties": {
-        "Platform_Version": "1.2"
-      }
-    },
-    "webOS_11": {
-      "match": "*webOS/1.1*",
-      "lite": false,
-      "standard": false,
-      "inherits": "webOS",
-      "properties": {
-        "Platform_Version": "1.1"
-      }
-    },
-    "webOS_10": {
-      "match": "*webOS/1.0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "webOS",
-      "properties": {
-        "Platform_Version": "1.0"
-      }
-    },
-    "webOS": {
-      "match": "*webOS/*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "webOS",
-        "Platform_Description": "HP webOS",
-        "Platform_Maker": "HP",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "Bada_2_0": {
-      "match": "*Bada/2.*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Bada",
-      "properties": {
-        "Platform_Version": "2.0"
-      }
-    },
-    "Bada_1_2": {
-      "match": "*Bada/1.2*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Bada",
-      "properties": {
-        "Platform_Version": "1.2"
-      }
-    },
-    "Bada_1_0": {
-      "match": "*Bada/1.*",
-      "lite": false,
-      "standard": false,
-      "inherits": "Bada",
-      "properties": {
-        "Platform_Version": "1.0"
-      }
-    },
-    "Bada": {
-      "match": "*Bada*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "Bada",
-        "Platform_Version": "unknown",
-        "Platform_Description": "Samsung Bada",
-        "Platform_Maker": "Samsung",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "Xbox_OS_10_Mobile": {
-      "match": "*Windows Phone 10.0*",
-      "lite": true,
-      "standard": true,
-      "inherits": "Xbox_OS_10",
-      "properties": {
-        "Platform": "Xbox OS 10 (Mobile View)"
-      }
-    },
-    "Xbox_OS_10": {
-      "match": "*Windows NT 10.0*Win64? x64*",
-      "lite": true,
-      "standard": true,
-      "inherits": "Xbox_OS",
-      "properties": {
-        "Platform": "Xbox OS 10",
-        "Platform_Description": "Windows 10 on Xbox One"
-      }
-    },
-    "Xbox_OS_Mobile_A": {
-      "match": "*Windows Phone OS 7.5*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Xbox_OS_Mobile"
-    },
-    "Xbox_OS_Mobile": {
-      "match": "*Windows Phone 8.0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Xbox_OS",
-      "properties": {
-        "Platform": "Xbox OS (Mobile View)"
-      }
-    },
-    "Xbox_OS": {
-      "match": "*Windows NT 6.2*",
-      "lite": true,
-      "standard": true,
-      "properties": {
-        "Platform": "Xbox OS",
-        "Platform_Maker": "Microsoft Corporation",
-        "Platform_Version": "unknown",
-        "Platform_Description": "Xbox One System Software",
-        "Win64": true,
-        "Browser_Bits": 64,
-        "Platform_Bits": 64
-      }
-    },
-    "Xbox_360_Mobile": {
-      "match": "*Windows Phone OS 7.5*",
-      "lite": false,
-      "standard": true,
-      "inherits": "Xbox_360",
-      "properties": {
-        "Platform": "Xbox 360 (Mobile View)"
-      }
-    },
-    "Xbox_360": {
-      "match": "*Windows NT 6.1*",
-      "lite": true,
-      "standard": true,
-      "properties": {
-        "Platform": "Xbox 360",
-        "Platform_Maker": "Microsoft Corporation",
-        "Platform_Version": "unknown",
-        "Platform_Description": "Xbox 360 System Software",
-        "Win32": true,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "RISC_OS": {
-      "match": "*RISC*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "RISC OS",
-        "Platform_Maker": "unknown",
-        "Platform_Description": "RISC OS",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "FirefoxOS_2_5": {
-      "match": "*Gecko*",
-      "lite": false,
-      "standard": true,
-      "inherits": "FirefoxOS",
-      "properties": {
-        "Platform_Version": "2.5",
-        "Beta": true
-      }
-    },
-    "FirefoxOS_2_2": {
-      "match": "*Gecko*",
-      "lite": false,
-      "standard": true,
-      "inherits": "FirefoxOS",
-      "properties": {
-        "Platform_Version": "2.2"
-      }
-    },
-    "FirefoxOS_2_1": {
-      "match": "*Gecko*",
-      "lite": false,
-      "standard": true,
-      "inherits": "FirefoxOS",
-      "properties": {
-        "Platform_Version": "2.1"
-      }
-    },
-    "FirefoxOS_2_0": {
-      "match": "*Gecko*",
-      "lite": false,
-      "standard": true,
-      "inherits": "FirefoxOS",
-      "properties": {
-        "Platform_Version": "2.0"
-      }
-    },
-    "FirefoxOS_1_4": {
-      "match": "*Gecko*",
-      "lite": false,
-      "standard": false,
-      "inherits": "FirefoxOS",
-      "properties": {
-        "Platform_Version": "1.4"
-      }
-    },
-    "FirefoxOS_1_3": {
-      "match": "*Gecko*",
-      "lite": false,
-      "standard": false,
-      "inherits": "FirefoxOS",
-      "properties": {
-        "Platform_Version": "1.3"
-      }
-    },
-    "FirefoxOS_1_2": {
-      "match": "*Gecko*",
-      "lite": false,
-      "standard": false,
-      "inherits": "FirefoxOS",
-      "properties": {
-        "Platform_Version": "1.2"
-      }
-    },
-    "FirefoxOS_1_1": {
-      "match": "*Gecko*",
-      "lite": false,
-      "standard": false,
-      "inherits": "FirefoxOS",
-      "properties": {
-        "Platform_Version": "1.1"
-      }
-    },
-    "FirefoxOS_1_0": {
-      "match": "*Gecko*",
-      "lite": false,
-      "standard": false,
-      "inherits": "FirefoxOS",
-      "properties": {
-        "Platform_Version": "1.0"
-      }
-    },
-    "FirefoxOS_0_x": {
-      "match": "*Gecko*",
-      "lite": false,
-      "standard": false,
-      "inherits": "FirefoxOS",
-      "properties": {
-        "Platform_Version": "0.x"
-      }
-    },
-    "FirefoxOS": {
-      "match": "*Gecko*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "FirefoxOS",
-        "Platform_Maker": "Mozilla Foundation",
-        "Platform_Version": "unknown",
-        "Platform_Description": "FirefoxOS",
-        "Win32": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "KaiOS_2_0": {
-      "match": "*KaiOS/2.0*",
-      "lite": false,
-      "standard": true,
-      "inherits": "KaiOS",
-      "properties": {
-        "Platform_Version": "2.0"
-      }
-    },
-    "KaiOS_1_0": {
-      "match": "*KaiOS/1.0*",
-      "lite": false,
-      "standard": false,
-      "inherits": "KaiOS",
-      "properties": {
-        "Platform_Version": "1.0"
-      }
-    },
-    "KaiOS": {
-        "match": "*KaiOS/*",
-        "lite": false,
-        "standard": true,
-        "properties": {
-            "Platform": "KaiOS",
-            "Platform_Maker": "KaiOS Technologies Inc.",
-            "Platform_Version": "unknown",
-            "Platform_Description": "KaiOS",
-            "Win32": false,
-            "Browser_Bits": 32,
-            "Platform_Bits": 32
-        }
-    },
-    "SailfishOS": {
-      "match": "*Sailfish*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "SailfishOS",
-        "Platform_Maker": "Jolla Ltd.",
-        "Platform_Version": "unknown",
-        "Win32": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "MeeGo": {
-      "match": "*MeeGo*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "MeeGo",
-        "Platform_Maker": "Linux Foundation",
-        "Platform_Description": "MeeGo",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "OpenVMS": {
-      "match": "*OpenVMS*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "OpenVMS",
-        "Platform_Maker": "HP",
-        "Platform_Description": "OpenVMS",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "Nintendo3DS_OS": {
-      "match": "*Nintendo 3DS",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "Nintendo 3DS",
-        "Platform_Maker": "Nintendo",
-        "Platform_Version": "unknown",
-        "Platform_Description": "Nintendo 3DS/New Nintendo 3DS System Software",
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "NintendoWiiU_OS": {
-      "match": "Nintendo WiiU",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "Nintendo WiiU",
-        "Platform_Maker": "Nintendo",
-        "Platform_Version": "unknown",
-        "Platform_Description": "Nintendo WiiU System Software",
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "NintendoSwitch_OS": {
-      "match": "Nintendo Switch",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "Nintendo Switch",
-        "Platform_Maker": "Nintendo",
-        "Platform_Version": "unknown",
-        "Platform_Description": "Nintendo Switch System Software",
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "NintendoDS_OS": {
-      "match": "Nintendo DS",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "Nintendo DS",
-        "Platform_Maker": "Nintendo",
-        "Platform_Version": "unknown",
-        "Platform_Description": "Nintendo DS System Software",
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "NintendoWii_OS": {
-      "match": "Nintendo Wii",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "Nintendo Wii",
-        "Platform_Maker": "Nintendo",
-        "Platform_Version": "unknown",
-        "Platform_Description": "Nintendo Wii System Software",
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "NintendoDSi_OS": {
-      "match": "Nintendo DSi",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "Nintendo DSi",
-        "Platform_Maker": "Nintendo",
-        "Platform_Version": "unknown",
-        "Platform_Description": "Nintendo DSi System Software",
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "Series30": {
-      "match": "*Series40*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "Series30",
-        "Platform_Maker": "Nokia",
-        "Platform_Description": "Series 30",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "Asha": {
-      "match": "*Asha*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "Asha",
-        "Platform_Maker": "Nokia",
-        "Platform_Description": "Asha Platform",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "Haiku": {
-      "match": "*Haiku*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "Haiku",
-        "Platform_Maker": "Haiku, Inc.",
-        "Platform_Description": "Haiku",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "CellOS": {
-      "match": "*CellOS*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "CellOS",
-        "Platform_Maker": "Sony",
-        "Platform_Version": "unknown",
-        "Win32": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "Inferno": {
-      "match": "*Inferno*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "Inferno OS",
-        "Platform_Maker": "Vita Nuova Holdings Ltd",
-        "Platform_Version": "unknown",
-        "Win32": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "Liberate": {
-      "match": "*Liberate*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "Liberate",
-        "Platform_Maker": "unknown",
-        "Platform_Version": "unknown"
-      }
-    },
-    "OrbisOS": {
-      "match": "*OrbisOS*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "OrbisOS",
-        "Platform_Maker": "Sony",
-        "Platform_Version": "unknown",
-        "Win32": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "WyderOS": {
-      "match": "*WyderOS*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "WyderOS",
-        "Platform_Version": "unknown",
-        "Platform_Maker": "unknown"
-      }
-    },
-    "PS_Vita": {
-      "match": "PlayStation Vita",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "Playstation Vita",
-        "Platform_Maker": "Sony",
-        "Platform_Version": "unknown",
-        "Platform_Description": "Playstation Vita System Software"
-      }
-    },
-    "PalmOS_3": {
-      "match": "*Palm OS*",
-      "lite": false,
-      "standard": true,
-      "inherits": "PalmOS",
-      "properties": {
-        "Platform_Version": "3.0"
-      }
-    },
-    "PalmOS": {
-      "match": "*Palm OS*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "PalmOS",
-        "Platform_Maker": "Palm",
-        "Platform_Version": "unknown",
-        "Win32": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "Series40": {
-      "match": "*Series40*",
-      "lite": false,
-      "standard": true,
-      "properties": {
-        "Platform": "Series40",
-        "Platform_Maker": "Nokia",
-        "Platform_Description": "Series 40",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 32,
-        "Platform_Bits": 32
-      }
-    },
-    "any": {
-      "match": "*",
-      "lite": true,
-      "standard": true,
-      "properties": {
-        "Platform": "unknown",
-        "Platform_Description": "unknown",
-        "Platform_Maker": "unknown",
-        "Platform_Version": "unknown",
-        "Win16": false,
-        "Win32": false,
-        "Win64": false,
-        "Browser_Bits": 0,
-        "Platform_Bits": 0
-      }
+  "WinXPa_cygwin": {
+    "match": "*CYGWIN_NT-5.1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinXP",
+      "Platform_Version": "5.1",
+      "Platform_Description": "Windows XP"
+    }
+  },
+  "CygWin": {
+    "match": "*CygWin*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "CygWin",
+      "Platform_Maker": "Microsoft Corporation",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "Win10_x64_B": {
+    "match": "*Windows NT 10.0*Win64? x64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform": "Win10",
+      "Platform_Bits": 64,
+      "Platform_Version": "10.0",
+      "Platform_Description": "Windows 10",
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "Win10_64_B": {
+    "match": "*Windows NT 10.0*WOW64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "Win10",
+      "Platform_Bits": 64,
+      "Platform_Version": "10.0",
+      "Platform_Description": "Windows 10",
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "Win10_32_B": {
+    "match": "*Windows NT 10.0*",
+    "lite": true,
+    "standard": true,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "Win10",
+      "Platform_Version": "10.0",
+      "Platform_Description": "Windows 10"
+    }
+  },
+  "Win10_x64": {
+    "match": "*Windows NT 6.4*Win64? x64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform": "Win10",
+      "Platform_Bits": 64,
+      "Platform_Version": "6.4",
+      "Platform_Description": "Windows 10",
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "Win10_64": {
+    "match": "*Windows NT 6.4*WOW64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "Win10",
+      "Platform_Bits": 64,
+      "Platform_Version": "6.4",
+      "Platform_Description": "Windows 10",
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "Win10_32": {
+    "match": "*Windows NT 6.4*",
+    "lite": true,
+    "standard": true,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "Win10",
+      "Platform_Version": "6.4",
+      "Platform_Description": "Windows 10"
+    }
+  },
+  "WinRT8_1_32": {
+    "match": "*Windows NT 6.3; ARM*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinRT8.1",
+      "Platform_Version": "6.3",
+      "Platform_Description": "Windows RT 8.1",
+      "Win32": false
+    }
+  },
+  "Win8_1_x64": {
+    "match": "*Windows NT 6.3*Win64? x64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform": "Win8.1",
+      "Platform_Bits": 64,
+      "Platform_Version": "6.3",
+      "Platform_Description": "Windows 8.1",
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "Win8_1_64": {
+    "match": "*Windows NT 6.3*WOW64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "Win8.1",
+      "Platform_Bits": 64,
+      "Platform_Version": "6.3",
+      "Platform_Description": "Windows 8.1",
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "Win8_1_32": {
+    "match": "*Windows NT 6.3*",
+    "lite": true,
+    "standard": true,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "Win8.1",
+      "Platform_Version": "6.3",
+      "Platform_Description": "Windows 8.1"
+    }
+  },
+  "WinRT8_32": {
+    "match": "*Windows NT 6.2; ARM*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinRT8",
+      "Platform_Version": "6.2",
+      "Platform_Description": "Windows RT 8",
+      "Win32": false
+    }
+  },
+  "Win8_x64_2": {
+    "match": "*Windows NT 6.2 x64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform": "Win8",
+      "Platform_Bits": 64,
+      "Platform_Version": "6.2",
+      "Platform_Description": "Windows 8",
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "Win8_x64": {
+    "match": "*Windows NT 6.2*Win64? x64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform": "Win8",
+      "Platform_Bits": 64,
+      "Platform_Version": "6.2",
+      "Platform_Description": "Windows 8",
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "Win8_64": {
+    "match": "*Windows NT 6.2*WOW64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "Win8",
+      "Platform_Bits": 64,
+      "Platform_Version": "6.2",
+      "Platform_Description": "Windows 8",
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "Win8_32": {
+    "match": "*Windows NT 6.2*",
+    "lite": true,
+    "standard": true,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "Win8",
+      "Platform_Version": "6.2",
+      "Platform_Description": "Windows 8"
+    }
+  },
+  "Win7_x64_2": {
+    "match": "*Windows NT 6.1*x64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform": "Win7",
+      "Platform_Bits": 64,
+      "Platform_Version": "6.1",
+      "Platform_Description": "Windows 7",
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "Win7_x64_Trident": {
+    "match": "*Windows NT 6.1*Trident/?.0*Win64? x64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform": "Win7",
+      "Platform_Bits": 64,
+      "Platform_Version": "6.1",
+      "Platform_Description": "Windows 7",
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "Win7_x64": {
+    "match": "*Windows NT 6.1*Win64? x64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform": "Win7",
+      "Platform_Bits": 64,
+      "Platform_Version": "6.1",
+      "Platform_Description": "Windows 7",
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "Win7_64_Trident": {
+    "match": "*Windows NT 6.1*Trident/?.0*WOW64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "Win7",
+      "Platform_Bits": 64,
+      "Platform_Version": "6.1",
+      "Platform_Description": "Windows 7",
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "Win7_64": {
+    "match": "*Windows NT 6.1*WOW64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "Win7",
+      "Platform_Bits": 64,
+      "Platform_Version": "6.1",
+      "Platform_Description": "Windows 7",
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "Win7_32": {
+    "match": "*Windows NT 6.1*",
+    "lite": true,
+    "standard": true,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "Win7",
+      "Platform_Version": "6.1",
+      "Platform_Description": "Windows 7"
+    }
+  },
+  "Win7_32_2": {
+    "match": "*Windows;Microsoft Windows (6.1*)*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "Win7",
+      "Platform_Version": "6.1",
+      "Platform_Description": "Windows 7"
+    }
+  },
+  "Vista_x64_2": {
+    "match": "*Windows NT 6.0 x64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform": "WinVista",
+      "Platform_Bits": 64,
+      "Platform_Version": "6.0",
+      "Platform_Description": "Windows Vista",
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "Vista_x64": {
+    "match": "*Windows NT 6.0;*Win64? x64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform": "WinVista",
+      "Platform_Bits": 64,
+      "Platform_Version": "6.0",
+      "Platform_Description": "Windows Vista",
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "Vista_64_Trident": {
+    "match": "*Windows NT 6.0*Trident/?.0*WOW64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinVista",
+      "Platform_Bits": 64,
+      "Platform_Version": "6.0",
+      "Platform_Description": "Windows Vista",
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "Vista_64": {
+    "match": "*Windows NT 6.0*WOW64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinVista",
+      "Platform_Bits": 64,
+      "Platform_Version": "6.0",
+      "Platform_Description": "Windows Vista",
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "Vista_32": {
+    "match": "*Windows NT 6.0*",
+    "lite": true,
+    "standard": true,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinVista",
+      "Platform_Version": "6.0",
+      "Platform_Description": "Windows Vista"
+    }
+  },
+  "WinXPb_x64_3": {
+    "match": "*Windows NT 5.2;*Win64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinXP",
+      "Platform_Bits": 64,
+      "Platform_Version": "5.2",
+      "Platform_Description": "Windows XP",
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "WinXPb_x64_2": {
+    "match": "*Windows NT 5.2 x64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform": "WinXP",
+      "Platform_Bits": 64,
+      "Platform_Version": "5.2",
+      "Platform_Description": "Windows XP",
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "WinXPb_x64": {
+    "match": "*Windows NT 5.2;*Win64? x64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform": "WinXP",
+      "Platform_Bits": 64,
+      "Platform_Version": "5.2",
+      "Platform_Description": "Windows XP",
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "WinXPb_64": {
+    "match": "*Windows NT 5.2*WOW64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinXP",
+      "Platform_Bits": 64,
+      "Platform_Version": "5.2",
+      "Platform_Description": "Windows XP",
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "WinXPb_32": {
+    "match": "*Windows NT 5.2*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinXP",
+      "Platform_Version": "5.2",
+      "Platform_Description": "Windows XP"
+    }
+  },
+  "WinXPa_x64_2": {
+    "match": "*Windows NT 5.1 x64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform": "WinXP",
+      "Platform_Bits": 64,
+      "Platform_Version": "5.1",
+      "Platform_Description": "Windows XP",
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "WinXPa_x64": {
+    "match": "*Windows NT 5.1;*Win64? x64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform": "WinXP",
+      "Platform_Bits": 64,
+      "Platform_Version": "5.1",
+      "Platform_Description": "Windows XP",
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "WinXPa_64": {
+    "match": "*Windows NT 5.1*WOW64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinXP",
+      "Platform_Bits": 64,
+      "Platform_Version": "5.1",
+      "Platform_Description": "Windows XP",
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "WinXPa_32": {
+    "match": "*Windows NT 5.1*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinXP",
+      "Platform_Version": "5.1",
+      "Platform_Description": "Windows XP"
+    }
+  },
+  "WinXPa_v2": {
+    "match": "*Windows XP*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinXP",
+      "Platform_Version": "5.1",
+      "Platform_Description": "Windows XP"
+    }
+  },
+  "Win2000_3": {
+    "match": "*Windows NT 5.01*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "Win2000",
+      "Platform_Version": "5.01",
+      "Platform_Description": "Windows 2000"
+    }
+  },
+  "Win2000_2": {
+    "match": "*Windows 2000*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "Win2000",
+      "Platform_Version": "5.0",
+      "Platform_Description": "Windows 2000"
+    }
+  },
+  "Win2000_x64": {
+    "match": "*Windows NT 5.0;*Win64? x64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform": "Win2000",
+      "Platform_Bits": 64,
+      "Platform_Version": "5.0",
+      "Platform_Description": "Windows 2000",
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "Win2000_64": {
+    "match": "*Windows NT 5.0; *WOW64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "Win2000",
+      "Platform_Bits": 64,
+      "Platform_Version": "5.0",
+      "Platform_Description": "Windows 2000",
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "Win2000": {
+    "match": "*Windows NT 5.0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "Win2000",
+      "Platform_Version": "5.0",
+      "Platform_Description": "Windows 2000"
+    }
+  },
+  "Win2000_5": {
+    "match": "*Windows NT5.0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "Win2000",
+      "Platform_Version": "5.0",
+      "Platform_Description": "Windows 2000"
+    }
+  },
+  "NT4_1": {
+    "match": "*Windows NT 4.1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinNT",
+      "Platform_Version": "4.1",
+      "Platform_Description": "Windows NT"
+    }
+  },
+  "NT4_64": {
+    "match": "*Windows NT 4.0; *WOW64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinNT",
+      "Platform_Bits": 64,
+      "Platform_Version": "4.0",
+      "Platform_Description": "Windows NT",
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "NT4": {
+    "match": "*Windows NT 4.0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinNT",
+      "Platform_Version": "4.0",
+      "Platform_Description": "Windows NT"
+    }
+  },
+  "NT3.5": {
+    "match": "*Windows NT 3.5*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinNT",
+      "Platform_Version": "3.5",
+      "Platform_Description": "Windows NT"
+    }
+  },
+  "NT3.1": {
+    "match": "*Windows NT 3.1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinNT",
+      "Platform_Version": "3.1",
+      "Platform_Description": "Windows NT"
+    }
+  },
+  "NT_x64": {
+    "match": "*Windows NT; Win64? x64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform": "WinNT",
+      "Platform_Bits": 64,
+      "Platform_Description": "Windows NT",
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "NT_64": {
+    "match": "*Windows NT; *WOW64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinNT",
+      "Platform_Bits": 64,
+      "Platform_Description": "Windows NT",
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "NT": {
+    "match": "*Windows NT*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinNT",
+      "Platform_Description": "Windows NT"
+    }
+  },
+  "NT4_1_B": {
+    "match": "*Windows 4.10*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinNT",
+      "Platform_Version": "4.1",
+      "Platform_Description": "Windows NT"
+    }
+  },
+  "WinME_2": {
+    "match": "*Windows ME*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinME",
+      "Platform_Version": "ME",
+      "Platform_Description": "Windows ME"
+    }
+  },
+  "WinME_3": {
+    "match": "*Windows 98; Win 9x4.90*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinME",
+      "Platform_Version": "ME",
+      "Platform_Description": "Windows ME"
+    }
+  },
+  "Win98_2": {
+    "match": "*Windows 98*",
+    "inherits": "Win98",
+    "lite": false,
+    "standard": false
+  },
+  "Win98_3": {
+    "match": "*Windows*98*",
+    "inherits": "Win98",
+    "lite": false,
+    "standard": false
+  },
+  "Win95_2": {
+    "match": "*Windows 95*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "Win95",
+      "Platform_Version": "95",
+      "Platform_Description": "Windows 95"
+    }
+  },
+  "Win3.11_B": {
+    "match": "*Windows 3.11*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "Win31",
+      "Platform_Version": "3.11",
+      "Platform_Description": "Windows 3.11",
+      "Win16": true,
+      "Win32": false
+    }
+  },
+  "Win3.1_B": {
+    "match": "*Windows 3.1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Browser_Bits": 16,
+      "Platform": "Win31",
+      "Platform_Bits": 16,
+      "Platform_Version": "3.1",
+      "Platform_Description": "Windows 3.1",
+      "Win16": true,
+      "Win32": false
+    }
+  },
+  "Windows_x64": {
+    "match": "*Windows*x64*",
+    "lite": true,
+    "standard": true,
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform": "Win64",
+      "Platform_Bits": 64,
+      "Platform_Version": "unknown",
+      "Platform_Maker": "Microsoft Corporation",
+      "Platform_Description": "Windows",
+      "Win16": false,
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "Windows_64": {
+    "match": "*Windows*WOW64*",
+    "lite": true,
+    "standard": true,
+    "properties": {
+      "Browser_Bits": 32,
+      "Platform": "Win64",
+      "Platform_Bits": 64,
+      "Platform_Version": "unknown",
+      "Platform_Maker": "Microsoft Corporation",
+      "Platform_Description": "Windows",
+      "Win16": false,
+      "Win32": false,
+      "Win64": true
+    }
+  },
+  "Windows": {
+    "match": "*Windows*",
+    "lite": true,
+    "standard": true,
+    "properties": {
+      "Browser_Bits": 32,
+      "Platform": "Win32",
+      "Platform_Bits": 32,
+      "Platform_Version": "unknown",
+      "Platform_Maker": "Microsoft Corporation",
+      "Platform_Description": "Windows",
+      "Win16": false,
+      "Win32": true,
+      "Win64": false
+    }
+  },
+  "WinXPb_v2": {
+    "match": "*WinNT5.2*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinXP",
+      "Platform_Version": "5.2",
+      "Platform_Description": "Windows XP"
+    }
+  },
+  "WinXPa_v3": {
+    "match": "*WinNT5.1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinXP",
+      "Platform_Version": "5.1",
+      "Platform_Description": "Windows XP"
+    }
+  },
+  "Win2000_6": {
+    "match": "*WinNT5.0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "Win2000",
+      "Platform_Version": "5.0",
+      "Platform_Description": "Windows 2000"
+    }
+  },
+  "Win2000_4": {
+    "match": "*Win2000*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "Win2000",
+      "Platform_Version": "5.0",
+      "Platform_Description": "Windows 2000"
+    }
+  },
+  "NT4_B": {
+    "match": "*WinNT4.0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinNT",
+      "Platform_Version": "4.0",
+      "Platform_Description": "Windows NT"
+    }
+  },
+  "NT3.51": {
+    "match": "*WinNT3.51*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinNT",
+      "Platform_Version": "3.51",
+      "Platform_Description": "Windows NT"
+    }
+  },
+  "NT_2": {
+    "match": "*WinNT*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinNT",
+      "Platform_Description": "Windows NT"
+    }
+  },
+  "WinME": {
+    "match": "*Win 9x 4.90*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinME",
+      "Platform_Version": "ME",
+      "Platform_Description": "Windows ME"
+    }
+  },
+  "Win98": {
+    "match": "*Win98*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "Win98",
+      "Platform_Version": "98",
+      "Platform_Description": "Windows 98"
+    }
+  },
+  "Win95": {
+    "match": "*Win95*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "Win95",
+      "Platform_Version": "95",
+      "Platform_Description": "Windows 95"
+    }
+  },
+  "Win3.11": {
+    "match": "*Win3.11*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Browser_Bits": 16,
+      "Platform": "Win31",
+      "Platform_Bits": 16,
+      "Platform_Version": "3.11",
+      "Platform_Description": "Windows 3.11",
+      "Win16": true,
+      "Win32": false
+    }
+  },
+  "Win3.1": {
+    "match": "*Win3.1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Browser_Bits": 16,
+      "Platform": "Win31",
+      "Platform_Bits": 16,
+      "Platform_Version": "3.1",
+      "Platform_Description": "Windows 3.1",
+      "Win16": true,
+      "Win32": false
+    }
+  },
+  "Win32": {
+    "match": "*Win32*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows"
+  },
+  "Win16": {
+    "match": "*Win16*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Browser_Bits": 16,
+      "Platform": "Win16",
+      "Platform_Bits": 16,
+      "Win16": true,
+      "Win32": false
+    }
+  },
+  "OSX_PPC_3": {
+    "match": "*Macintosh*PPC* Mac OS X*",
+    "lite": false,
+    "standard": false,
+    "inherits": "OSX_PPC"
+  },
+  "OSX_PPC_10_5": {
+    "match": "*PPC Mac OS X 10?5*",
+    "lite": false,
+    "standard": false,
+    "inherits": "OSX_PPC",
+    "properties": {
+      "Platform_Version": "10.5"
+    }
+  },
+  "OSX_PPC_10_4": {
+    "match": "*PPC Mac OS X 10?4*",
+    "lite": false,
+    "standard": false,
+    "inherits": "OSX_PPC",
+    "properties": {
+      "Platform_Version": "10.4"
+    }
+  },
+  "OSX_PPC": {
+    "match": "*PPC* Mac OS X*",
+    "lite": false,
+    "standard": false,
+    "inherits": "OSX",
+    "properties": {
+      "Platform_Description": "Mac OS X for Power PC"
+    }
+  },
+  "OSX_PPC_2": {
+    "match": "*Mac_PowerPC* Mac OS X*",
+    "lite": false,
+    "standard": false,
+    "inherits": "OSX_PPC"
+  },
+  "OSX_10_14": {
+    "match": "*Mac OS X 10?14*",
+    "lite": false,
+    "standard": true,
+    "inherits": "OSX",
+    "properties": {
+      "Platform": "macOS",
+      "Platform_Description": "macOS",
+      "Platform_Version": "10.14"
+    }
+  },
+  "OSX_10_13": {
+    "match": "*Mac OS X 10?13*",
+    "lite": false,
+    "standard": true,
+    "inherits": "OSX",
+    "properties": {
+      "Platform": "macOS",
+      "Platform_Description": "macOS",
+      "Platform_Version": "10.13"
+    }
+  },
+  "OSX_10_12": {
+    "match": "*Mac OS X 10?12*",
+    "lite": false,
+    "standard": true,
+    "inherits": "OSX",
+    "properties": {
+      "Platform": "macOS",
+      "Platform_Description": "macOS",
+      "Platform_Version": "10.12"
+    }
+  },
+  "OSX_10_11": {
+    "match": "*Mac OS X 10?11*",
+    "lite": false,
+    "standard": true,
+    "inherits": "OSX",
+    "properties": {
+      "Platform_Version": "10.11"
+    }
+  },
+  "OSX_10_10": {
+    "match": "*Mac OS X 10?10*",
+    "lite": false,
+    "standard": true,
+    "inherits": "OSX",
+    "properties": {
+      "Platform_Version": "10.10"
+    }
+  },
+  "OSX_10_9": {
+    "match": "*Mac OS X 10?9*",
+    "lite": false,
+    "standard": true,
+    "inherits": "OSX",
+    "properties": {
+      "Platform_Version": "10.9"
+    }
+  },
+  "OSX_10_8": {
+    "match": "*Mac OS X 10?8*",
+    "lite": false,
+    "standard": false,
+    "inherits": "OSX",
+    "properties": {
+      "Platform_Version": "10.8"
+    }
+  },
+  "OSX_10_7": {
+    "match": "*Mac OS X 10?7*",
+    "lite": false,
+    "standard": false,
+    "inherits": "OSX",
+    "properties": {
+      "Platform_Version": "10.7"
+    }
+  },
+  "OSX_10_6": {
+    "match": "*Mac OS X 10?6*",
+    "lite": false,
+    "standard": false,
+    "inherits": "OSX",
+    "properties": {
+      "Platform_Version": "10.6"
+    }
+  },
+  "OSX_10_5": {
+    "match": "*Mac OS X 10?5*",
+    "lite": false,
+    "standard": false,
+    "inherits": "OSX",
+    "properties": {
+      "Platform_Version": "10.5"
+    }
+  },
+  "OSX_10_4": {
+    "match": "*Mac OS X 10?4*",
+    "lite": false,
+    "standard": false,
+    "inherits": "OSX",
+    "properties": {
+      "Platform_Version": "10.4"
+    }
+  },
+  "OSX_10_3": {
+    "match": "*Mac OS X 10?3*",
+    "lite": false,
+    "standard": false,
+    "inherits": "OSX",
+    "properties": {
+      "Platform_Version": "10.3"
+    }
+  },
+  "OSX_10_2": {
+    "match": "*Mac OS X 10?2*",
+    "lite": false,
+    "standard": false,
+    "inherits": "OSX",
+    "properties": {
+      "Platform_Version": "10.2"
+    }
+  },
+  "OSX_10_1": {
+    "match": "*Mac OS X 10?1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "OSX",
+    "properties": {
+      "Platform_Version": "10.1"
+    }
+  },
+  "OSX": {
+    "match": "*Mac OS X*",
+    "lite": true,
+    "standard": true,
+    "properties": {
+      "Platform": "MacOSX",
+      "Platform_Description": "Mac OS X",
+      "Platform_Maker": "Apple Inc",
+      "Platform_Bits": 32,
+      "Platform_Version": "10",
+      "Browser_Bits": 32,
+      "Win16": false,
+      "Win32": false,
+      "Win64": false
+    }
+  },
+  "OSX_B_10_12": {
+    "match": "*Macintosh; OS X 10.12*",
+    "lite": false,
+    "standard": true,
+    "inherits": "OSX",
+    "properties": {
+      "Platform": "macOS",
+      "Platform_Description": "macOS",
+      "Platform_Version": "10.12"
+    }
+  },
+  "OSX_B_10_11": {
+    "match": "*Macintosh; OS X 10.11*",
+    "lite": false,
+    "standard": true,
+    "inherits": "OSX",
+    "properties": {
+      "Platform_Version": "10.11"
+    }
+  },
+  "OSX_B_10_10": {
+    "match": "*Macintosh; OS X 10.10*",
+    "lite": false,
+    "standard": true,
+    "inherits": "OSX",
+    "properties": {
+      "Platform_Version": "10.10"
+    }
+  },
+  "OSX_B_10_9": {
+    "match": "*Macintosh; OS X 10.9*",
+    "lite": false,
+    "standard": true,
+    "inherits": "OSX",
+    "properties": {
+      "Platform_Version": "10.9"
+    }
+  },
+  "OSX_B_10_8": {
+    "match": "*Macintosh; OS X 10.8*",
+    "inherits": "OSX",
+    "lite": false,
+    "standard": false,
+    "properties": {
+      "Platform_Version": "10.8"
+    }
+  },
+  "OSX_B_10_7": {
+    "match": "*Macintosh; OS X 10.7*",
+    "inherits": "OSX",
+    "lite": false,
+    "standard": false,
+    "properties": {
+      "Platform_Version": "10.7"
+    }
+  },
+  "OSX_B_10_6": {
+    "match": "*Macintosh; OS X 10.6*",
+    "inherits": "OSX",
+    "lite": false,
+    "standard": false,
+    "properties": {
+      "Platform_Version": "10.6"
+    }
+  },
+  "OSX_B_10_5": {
+    "match": "*Macintosh; OS X 10.5*",
+    "inherits": "OSX",
+    "lite": false,
+    "standard": false,
+    "properties": {
+      "Platform_Version": "10.5"
+    }
+  },
+  "OSX_B_10_4": {
+    "match": "*Macintosh; OS X 10.4*",
+    "inherits": "OSX",
+    "lite": false,
+    "standard": false,
+    "properties": {
+      "Platform_Version": "10.4"
+    }
+  },
+  "OSX_B_10_3": {
+    "match": "*Macintosh; OS X 10.3*",
+    "inherits": "OSX",
+    "lite": false,
+    "standard": false,
+    "properties": {
+      "Platform_Version": "10.3"
+    }
+  },
+  "OSX_B_10_2": {
+    "match": "*Macintosh; OS X 10.2*",
+    "inherits": "OSX",
+    "lite": false,
+    "standard": false,
+    "properties": {
+      "Platform_Version": "10.2"
+    }
+  },
+  "OSX_B_10_1": {
+    "match": "*Macintosh; OS X 10.1*",
+    "inherits": "OSX",
+    "lite": false,
+    "standard": false,
+    "properties": {
+      "Platform_Version": "10.1"
+    }
+  },
+  "OSX_B": {
+    "match": "*Macintosh; OS X *",
+    "lite": true,
+    "standard": true,
+    "inherits": "OSX"
+  },
+  "OSX_C_10_12": {
+    "match": "*MacOS X 10?12*",
+    "lite": false,
+    "standard": true,
+    "inherits": "OSX",
+    "properties": {
+      "Platform": "macOS",
+      "Platform_Description": "macOS",
+      "Platform_Version": "10.12"
+    }
+  },
+  "OSX_C_10_11": {
+    "match": "*MacOS X 10?11*",
+    "lite": false,
+    "standard": true,
+    "inherits": "OSX",
+    "properties": {
+      "Platform_Version": "10.11"
+    }
+  },
+  "OSX_C_10_10": {
+    "match": "*MacOS X 10?10*",
+    "lite": false,
+    "standard": true,
+    "inherits": "OSX",
+    "properties": {
+      "Platform_Version": "10.10"
+    }
+  },
+  "OSX_C_10_9": {
+    "match": "*MacOS X 10?9*",
+    "lite": false,
+    "standard": true,
+    "inherits": "OSX",
+    "properties": {
+      "Platform_Version": "10.9"
+    }
+  },
+  "OSX_C_10_8": {
+    "match": "*MacOS X 10?8*",
+    "lite": false,
+    "standard": false,
+    "inherits": "OSX",
+    "properties": {
+      "Platform_Version": "10.8"
+    }
+  },
+  "OSX_C_10_7": {
+    "match": "*MacOS X 10?7*",
+    "lite": false,
+    "standard": false,
+    "inherits": "OSX",
+    "properties": {
+      "Platform_Version": "10.7"
+    }
+  },
+  "OSX_C_10_6": {
+    "match": "*MacOS X 10?6*",
+    "lite": false,
+    "standard": false,
+    "inherits": "OSX",
+    "properties": {
+      "Platform_Version": "10.6"
+    }
+  },
+  "OSX_C_10_5": {
+    "match": "*MacOS X 10?5*",
+    "lite": false,
+    "standard": false,
+    "inherits": "OSX",
+    "properties": {
+      "Platform_Version": "10.5"
+    }
+  },
+  "OSX_C": {
+    "match": "*MacOS X*",
+    "lite": true,
+    "standard": true,
+    "properties": {
+      "Platform": "MacOSX",
+      "Platform_Description": "Mac OS X",
+      "Platform_Maker": "Apple Inc",
+      "Platform_Bits": 32,
+      "Platform_Version": "10",
+      "Browser_Bits": 32,
+      "Win16": false,
+      "Win32": false,
+      "Win64": false
+    }
+  },
+  "ATV_OSX_8_3": {
+    "match": "*CPU OS 8_3* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "ATV_OSX",
+    "properties": {
+      "Platform_Version": "8.3"
+    }
+  },
+  "ATV_OSX": {
+    "match": "*CPU*OS* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform": "ATV OS X",
+      "Platform_Description": "ATV OS X is a special variant of iOS optimized for Apple TV"
+    }
+  },
+  "MacPPC_3": {
+    "match": "*Macintosh*PPC*",
+    "lite": false,
+    "standard": false,
+    "inherits": "MacPPC"
+  },
+  "MacPPC_2": {
+    "match": "*Mac_PowerPC*",
+    "lite": false,
+    "standard": false,
+    "inherits": "MacPPC"
+  },
+  "MacPPC": {
+    "match": "*PPC*",
+    "lite": false,
+    "standard": false,
+    "inherits": "OSX",
+    "properties": {
+      "Platform": "MacPPC",
+      "Platform_Version": "unknown",
+      "Platform_Description": "Mac OS for Power PC"
+    }
+  },
+  "Mac68K_2": {
+    "match": "*Mac_68K*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Mac68K"
+  },
+  "Mac68K": {
+    "match": "*Macintosh*68K*",
+    "lite": false,
+    "standard": false,
+    "inherits": "OSX",
+    "properties": {
+      "Platform": "Mac68K",
+      "Platform_Version": "unknown",
+      "Platform_Description": "Mac OS for Motorola 68000 Series"
+    }
+  },
+  "FreeBSD_64": {
+    "match": "*FreeBSD x86_64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "FreeBSD",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform_Bits": 64
+    }
+  },
+  "FreeBSD_64_2": {
+    "match": "*FreeBSD amd64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "FreeBSD",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform_Bits": 64
+    }
+  },
+  "FreeBSD": {
+    "match": "*FreeBSD*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "FreeBSD",
+      "Platform_Maker": "FreeBSD Foundation",
+      "Platform_Description": "FreeBSD",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "OpenBSD_64": {
+    "match": "*OpenBSD x86_64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "OpenBSD",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform_Bits": 64
+    }
+  },
+  "OpenBSD_64_2": {
+    "match": "*OpenBSD amd64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "OpenBSD",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform_Bits": 64
+    }
+  },
+  "OpenBSD_64_3": {
+    "match": "*OpenBSD sparc64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "OpenBSD",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform_Bits": 64
+    }
+  },
+  "OpenBSD": {
+    "match": "*OpenBSD*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "OpenBSD",
+      "Platform_Maker": "unknown",
+      "Platform_Description": "OpenBSD",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "NetBSD_64_2": {
+    "match": "*NetBSD amd64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "NetBSD",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform_Bits": 64
+    }
+  },
+  "NetBSD": {
+    "match": "*NetBSD*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "NetBSD",
+      "Platform_Maker": "unknown",
+      "Platform_Description": "NetBSD",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "DragonFlyBSD_64": {
+    "match": "*DragonFly x86_64*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "DragonFly BSD",
+      "Platform_Maker": "unknown",
+      "Platform_Description": "DragonFlyBSD",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 64,
+      "Platform_Bits": 64
+    }
+  },
+  "DragonFlyBSD": {
+    "match": "*DragonFly*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "DragonFly BSD",
+      "Platform_Maker": "unknown",
+      "Platform_Description": "DragonFlyBSD",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "BSD Four": {
+    "match": "*BSD Four*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "BSD",
+      "Platform_Maker": "University of California, Berkeley",
+      "Platform_Description": "BSD Four",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "HPUX": {
+    "match": "*HP-UX*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "HP-UX",
+      "Platform_Maker": "HP",
+      "Platform_Description": "HP-UX",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "HPUX_2": {
+    "match": "*HPUX*",
+    "lite": true,
+    "standard": true,
+    "inherits": "HPUX"
+  },
+  "IRIX64": {
+    "match": "*IRIX64*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "IRIX64",
+      "Platform_Maker": "SGI",
+      "Platform_Description": "IRIX64",
+      "Platform_Version": "unknown",
+      "Browser_Bits": 64,
+      "Platform_Bits": 64,
+      "Win16": false,
+      "Win32": false,
+      "Win64": false
+    }
+  },
+  "IRIX64_2": {
+    "match": "*IRIX*",
+    "lite": false,
+    "standard": true,
+    "inherits": "IRIX64"
+  },
+  "BeOS": {
+    "match": "*BeOS*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "BeOS",
+      "Platform_Maker": "Access",
+      "Platform_Description": "BeOS",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "SunOS": {
+    "match": "*SunOS*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "SunOS",
+      "Platform_Maker": "Oracle",
+      "Platform_Description": "SunOS",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "OS2": {
+    "match": "*OS/2*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "OS/2",
+      "Platform_Maker": "IBM",
+      "Platform_Description": "OS/2",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "Unix": {
+    "match": "*UNIX*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "Unix",
+      "Platform_Maker": "unknown",
+      "Platform_Description": "Unix",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "AIX": {
+    "match": "*AIX*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "AIX",
+      "Platform_Maker": "IBM",
+      "Platform_Description": "AIX",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "Tru64_Unix": {
+    "match": "*Digital Unix*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "Tru64 UNIX",
+      "Platform_Maker": "HP",
+      "Platform_Description": "Tru64 UNIX",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 64,
+      "Platform_Bits": 64
+    }
+  },
+  "Tru64_Unix_B": {
+    "match": "*OSF1*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "Tru64 UNIX",
+      "Platform_Maker": "HP",
+      "Platform_Description": "Tru64 UNIX",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 64,
+      "Platform_Bits": 64
+    }
+  },
+  "Solaris": {
+    "match": "*Solaris*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "Solaris",
+      "Platform_Maker": "Oracle",
+      "Platform_Description": "Solaris",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "iOS_A_dynamic": {
+    "match": "*CPU iPhone OS #MAJORVER#?#MINORVER#* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "#MAJORVER#.#MINORVER#"
+    }
+  },
+  "iOS_A_12_0": {
+    "match": "*CPU iPhone OS 12?0* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "12.0"
+    }
+  },
+  "iOS_A_11_4": {
+    "match": "*CPU iPhone OS 11?4* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "11.4"
+    }
+  },
+  "iOS_A_11_3": {
+    "match": "*CPU iPhone OS 11?3* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "11.3"
+    }
+  },
+  "iOS_A_11_2": {
+    "match": "*CPU iPhone OS 11?2* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "11.2"
+    }
+  },
+  "iOS_A_11_1": {
+    "match": "*CPU iPhone OS 11?1* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "11.1"
+    }
+  },
+  "iOS_A_11_0": {
+    "match": "*CPU iPhone OS 11?0* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "11.0"
+    }
+  },
+  "iOS_A_10_3": {
+    "match": "*CPU iPhone OS 10?3* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "10.3"
+    }
+  },
+  "iOS_A_10_2": {
+    "match": "*CPU iPhone OS 10?2* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "10.2"
+    }
+  },
+  "iOS_A_10_1": {
+    "match": "*CPU iPhone OS 10?1* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "10.1"
+    }
+  },
+  "iOS_A_10_0": {
+    "match": "*CPU iPhone OS 10?* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "10.0"
+    }
+  },
+  "iOS_A_9_3": {
+    "match": "*CPU iPhone OS 9?3* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "9.3"
+    }
+  },
+  "iOS_A_9_2": {
+    "match": "*CPU iPhone OS 9?2* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "9.2"
+    }
+  },
+  "iOS_A_9_1": {
+    "match": "*CPU iPhone OS 9?1* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "9.1"
+    }
+  },
+  "iOS_A_9_0": {
+    "match": "*CPU iPhone OS 9?* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "9.0"
+    }
+  },
+  "iOS_A_8_4": {
+    "match": "*CPU iPhone OS 8?4* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "8.4"
+    }
+  },
+  "iOS_A_8_3": {
+    "match": "*CPU iPhone OS 8?3* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "8.3"
+    }
+  },
+  "iOS_A_8_2": {
+    "match": "*CPU iPhone OS 8?2* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "8.2"
+    }
+  },
+  "iOS_A_8_1": {
+    "match": "*CPU iPhone OS 8?1* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "8.1"
+    }
+  },
+  "iOS_A_8_0": {
+    "match": "*CPU iPhone OS 8?* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "8.0"
+    }
+  },
+  "iOS_A_8_0_B": {
+    "match": "*CPU iPhone OS 10?10* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "8.0"
+    }
+  },
+  "iOS_A_7_1": {
+    "match": "*CPU iPhone OS 7?1* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "7.1"
+    }
+  },
+  "iOS_A_7_0": {
+    "match": "*CPU iPhone OS 7?* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "7.0"
+    }
+  },
+  "iOS_A_6_1": {
+    "match": "*CPU iPhone OS 6?1* like Mac OS X*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "6.1"
+    }
+  },
+  "iOS_A_6_0": {
+    "match": "*CPU iPhone OS 6?* like Mac OS X*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "6.0"
+    }
+  },
+  "iOS_A_5_1": {
+    "match": "*CPU iPhone OS 5?1* like Mac OS X*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "5.1"
+    }
+  },
+  "iOS_A_5_0": {
+    "match": "*CPU iPhone OS 5?* like Mac OS X*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "5.0"
+    }
+  },
+  "iOS_A_4_3": {
+    "match": "*CPU iPhone OS 4?3* like Mac OS X*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "4.3"
+    }
+  },
+  "iOS_A_4_2": {
+    "match": "*CPU iPhone OS 4?2* like Mac OS X*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "4.2"
+    }
+  },
+  "iOS_A_4_1": {
+    "match": "*CPU iPhone OS 4?1* like Mac OS X*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "4.1"
+    }
+  },
+  "iOS_A_4_0": {
+    "match": "*CPU iPhone OS 4?* like Mac OS X*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "4.0"
+    }
+  },
+  "iOS_A_3_2": {
+    "match": "*CPU iPhone OS 3?2 like Mac OS X**",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "3.2"
+    }
+  },
+  "iOS_A_3_1": {
+    "match": "*CPU iPhone OS 3?1* like Mac OS X*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "3.1"
+    }
+  },
+  "iOS_A_3_0": {
+    "match": "*CPU iPhone OS 3?* like Mac OS X*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "3.0"
+    }
+  },
+  "iOS_A_2_2": {
+    "match": "*CPU iPhone OS 2?2* like Mac OS X*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "2.2"
+    }
+  },
+  "iOS_A_2_1": {
+    "match": "*CPU iPhone OS 2?1* like Mac OS X*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "2.1"
+    }
+  },
+  "iOS_A_2_0": {
+    "match": "*CPU iPhone OS 2?* like Mac OS X*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "2.0"
+    }
+  },
+  "iOS_A": {
+    "match": "*CPU iPhone OS * like Mac OS X*",
+    "lite": true,
+    "standard": true,
+    "inherits": "iOS"
+  },
+  "iOS_C_dynamic": {
+    "match": "*CPU OS #MAJORVER#_#MINORVER#* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "#MAJORVER#.#MINORVER#"
+    }
+  },
+  "iOS_C_12_0": {
+    "match": "*CPU OS 12_0* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "12.0"
+    }
+  },
+  "iOS_C_11_4": {
+    "match": "*CPU OS 11_4* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "11.4"
+    }
+  },
+  "iOS_C_11_3": {
+    "match": "*CPU OS 11_3* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "11.3"
+    }
+  },
+  "iOS_C_11_2": {
+    "match": "*CPU OS 11_2* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "11.2"
+    }
+  },
+  "iOS_C_11_1": {
+    "match": "*CPU OS 11_1* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "11.1"
+    }
+  },
+  "iOS_C_11_0": {
+    "match": "*CPU OS 11_0* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "11.0"
+    }
+  },
+  "iOS_C_10_3": {
+    "match": "*CPU OS 10_3* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "10.3"
+    }
+  },
+  "iOS_C_10_2": {
+    "match": "*CPU OS 10_2* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "10.2"
+    }
+  },
+  "iOS_C_10_1": {
+    "match": "*CPU OS 10_1* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "10.1"
+    }
+  },
+  "iOS_C_10_0": {
+    "match": "*CPU OS 10* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "10.0"
+    }
+  },
+  "iOS_C_9_3": {
+    "match": "*CPU OS 9_3* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "9.3"
+    }
+  },
+  "iOS_C_9_2": {
+    "match": "*CPU OS 9_2* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "9.2"
+    }
+  },
+  "iOS_C_9_1": {
+    "match": "*CPU OS 9_1* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "9.1"
+    }
+  },
+  "iOS_C_9_0": {
+    "match": "*CPU OS 9* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "9.0"
+    }
+  },
+  "iOS_C_8_4": {
+    "match": "*CPU OS 8_4* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "8.4"
+    }
+  },
+  "iOS_C_8_3": {
+    "match": "*CPU OS 8_3* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "8.3"
+    }
+  },
+  "iOS_C_8_2": {
+    "match": "*CPU OS 8_2* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "8.2"
+    }
+  },
+  "iOS_C_8_1": {
+    "match": "*CPU OS 8_1* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "8.1"
+    }
+  },
+  "iOS_C_8_0": {
+    "match": "*CPU OS 8* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "8.0"
+    }
+  },
+  "iOS_C_7_1": {
+    "match": "*CPU OS 7_1* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "7.1"
+    }
+  },
+  "iOS_C_7_0": {
+    "match": "*CPU OS 7* like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "7.0"
+    }
+  },
+  "iOS_C_6_1": {
+    "match": "*CPU OS 6_1* like Mac OS X*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "6.1"
+    }
+  },
+  "iOS_C_6_0": {
+    "match": "*CPU OS 6* like Mac OS X*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "6.0"
+    }
+  },
+  "iOS_C_5_1": {
+    "match": "*CPU OS 5_1* like Mac OS X*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "5.1"
+    }
+  },
+  "iOS_C_5_0": {
+    "match": "*CPU OS 5* like Mac OS X*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "5.0"
+    }
+  },
+  "iOS_C_4_3": {
+    "match": "*CPU OS 4_3* like Mac OS X*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "4.3"
+    }
+  },
+  "iOS_C_4_2": {
+    "match": "*CPU OS 4_2* like Mac OS X*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "4.2"
+    }
+  },
+  "iOS_C_4_1": {
+    "match": "*CPU OS 4_1* like Mac OS X*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "4.1"
+    }
+  },
+  "iOS_C_4_0": {
+    "match": "*CPU OS 4* like Mac OS X*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "4.0"
+    }
+  },
+  "iOS_C_3_2": {
+    "match": "*CPU OS 3_2* like Mac OS X*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "3.2"
+    }
+  },
+  "iOS_C_3_1": {
+    "match": "*CPU OS 3_1* like Mac OS X*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "3.1"
+    }
+  },
+  "iOS_C_3_0": {
+    "match": "*CPU OS 3* like Mac OS X*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "3.0"
+    }
+  },
+  "iOS_C": {
+    "match": "*CPU*OS* like Mac OS X*",
+    "lite": true,
+    "standard": true,
+    "inherits": "iOS"
+  },
+  "iOS_N": {
+    "match": "*iOS*",
+    "lite": true,
+    "standard": true,
+    "inherits": "iOS"
+  },
+  "iOS_I_11_3": {
+    "match": "* iOS?11.3*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "11.3"
+    }
+  },
+  "iOS_I_11_2": {
+    "match": "* iOS?11.2*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "11.2"
+    }
+  },
+  "iOS_I_11_1": {
+    "match": "* iOS?11.1*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "11.1"
+    }
+  },
+  "iOS_I_11_0": {
+    "match": "* iOS?11.0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "11.0"
+    }
+  },
+  "iOS_I_10_3": {
+    "match": "* iOS?10.3*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "10.3"
+    }
+  },
+  "iOS_I_10_2": {
+    "match": "* iOS?10.2*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "10.2"
+    }
+  },
+  "iOS_I_10_1": {
+    "match": "* iOS?10.1*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "10.1"
+    }
+  },
+  "iOS_I_8_4": {
+    "match": "* iOS?8.4*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "8.4"
+    }
+  },
+  "iOS_I_8_0": {
+    "match": "* iOS?8.0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "8.0"
+    }
+  },
+  "iOS_I_7_1": {
+    "match": "* iOS?7.1*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "7.1"
+    }
+  },
+  "iOS_I_7_0": {
+    "match": "* iOS?7.0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "7.0"
+    }
+  },
+  "iOS_I": {
+    "match": "* iOS?*",
+    "lite": true,
+    "standard": true,
+    "inherits": "iOS"
+  },
+  "iOS_J_11_1": {
+    "match": "iOS/11.1*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "11.1"
+    }
+  },
+  "iOS_J_11_0": {
+    "match": "iOS/11.0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "11.0"
+    }
+  },
+  "iOS_J_10_3": {
+    "match": "iOS/10.3*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "10.3"
+    }
+  },
+  "iOS_J_8_0": {
+    "match": "iOS/8.0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "8.0"
+    }
+  },
+  "iOS_J_7_1": {
+    "match": "iOS/7.1*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "7.1"
+    }
+  },
+  "iOS_J_7_0": {
+    "match": "iOS/7.0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "7.0"
+    }
+  },
+  "iOS_J_6_1": {
+    "match": "iOS/6.1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "6.1"
+    }
+  },
+  "iOS_J_6_0": {
+    "match": "iOS/6.0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "6.0"
+    }
+  },
+  "iOS_J_5_1": {
+    "match": "iOS/5.1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "5.1"
+    }
+  },
+  "iOS_J": {
+    "match": "iOS/*",
+    "lite": true,
+    "standard": true,
+    "inherits": "iOS"
+  },
+  "iOS_E_10_3": {
+    "match": "*iPhone OS?10?3*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "10.3"
+    }
+  },
+  "iOS_E_10_2": {
+    "match": "*iPhone OS?10?2*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "10.2"
+    }
+  },
+  "iOS_E_10_1": {
+    "match": "*iPhone OS?10?1*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "10.1"
+    }
+  },
+  "iOS_E_10_0": {
+    "match": "*iPhone OS?10?0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "10.0"
+    }
+  },
+  "iOS_E_9_3": {
+    "match": "*iPhone OS?9?3*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "9.3"
+    }
+  },
+  "iOS_E_9_2": {
+    "match": "*iPhone OS?9?2*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "9.2"
+    }
+  },
+  "iOS_E_9_1": {
+    "match": "*iPhone OS?9?1*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "9.1"
+    }
+  },
+  "iOS_E_9_0": {
+    "match": "*iPhone OS?9?0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "9.0"
+    }
+  },
+  "iOS_E_8_1": {
+    "match": "*iPhone OS?8?1*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "8.1"
+    }
+  },
+  "iOS_E_8_0": {
+    "match": "*iPhone OS?8?0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "8.0"
+    }
+  },
+  "iOS_E_7_1": {
+    "match": "*iPhone OS?7?1*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "7.1"
+    }
+  },
+  "iOS_E_7_0": {
+    "match": "*iPhone OS?7?0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "7.0"
+    }
+  },
+  "iOS_E_6_1": {
+    "match": "*iPhone OS?6?1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "6.1"
+    }
+  },
+  "iOS_E_6_0": {
+    "match": "*iPhone OS?6?0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "6.0"
+    }
+  },
+  "iOS_E_5_1": {
+    "match": "*iPhone OS?5?1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "5.1"
+    }
+  },
+  "iOS_E_5_0": {
+    "match": "*iPhone OS?5?0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "5.0"
+    }
+  },
+  "iOS_E_4_3": {
+    "match": "*iPhone OS?4?3*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "4.3"
+    }
+  },
+  "iOS_E": {
+    "match": "*iPhone OS*",
+    "lite": true,
+    "standard": true,
+    "inherits": "iOS"
+  },
+  "iOS_G_4_3": {
+    "match": "IUC(U;iOS 4.3*)*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "4.3"
+    }
+  },
+  "iOS_G": {
+    "match": "IUC(U;iOS*)*",
+    "lite": true,
+    "standard": true,
+    "inherits": "iOS"
+  },
+  "iOS_K_8_1": {
+    "match": "*iPhone OS 8.1*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "8.1"
+    }
+  },
+  "iOS_K_8_0": {
+    "match": "*iPhone OS 8.0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "8.0"
+    }
+  },
+  "iOS_K": {
+    "match": "*iPhone OS*",
+    "lite": true,
+    "standard": true,
+    "inherits": "iOS"
+  },
+  "iOS_O_10_3": {
+    "match": "*iOS Version 10.3*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "10.3"
+    }
+  },
+  "iOS_O_10_2": {
+    "match": "*iOS Version 10.2*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "10.2"
+    }
+  },
+  "iOS_O_10_1": {
+    "match": "*iOS Version 10.1*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "10.1"
+    }
+  },
+  "iOS_O_10_0": {
+    "match": "*iOS Version 10.0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "10.0"
+    }
+  },
+  "iOS_O_9_3": {
+    "match": "*iOS Version 9.3*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "9.3"
+    }
+  },
+  "iOS_O_9_2": {
+    "match": "*iOS Version 9.2*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "9.2"
+    }
+  },
+  "iOS_O_9_1": {
+    "match": "*iOS Version 9.1*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "9.1"
+    }
+  },
+  "iOS_O_9_0": {
+    "match": "*iOS Version 9.0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "9.0"
+    }
+  },
+  "iOS_O_8_4": {
+    "match": "*iOS Version 8.4*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "8.4"
+    }
+  },
+  "iOS_O_8_3": {
+    "match": "*iOS Version 8.3*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "8.3"
+    }
+  },
+  "iOS_O_8_2": {
+    "match": "*iOS Version 8.2*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "8.2"
+    }
+  },
+  "iOS_O_8_1": {
+    "match": "*iOS Version 8.1*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "8.1"
+    }
+  },
+  "iOS_O_8_0": {
+    "match": "*iOS Version 8.0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "8.0"
+    }
+  },
+  "iOS_O": {
+    "match": "*iOS Version*",
+    "lite": true,
+    "standard": true,
+    "inherits": "iOS"
+  },
+  "iOS_L_8_1": {
+    "match": "*iosv8.1*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "8.1"
+    }
+  },
+  "iOS_L_8_0": {
+    "match": "*iosv8.0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "8.0"
+    }
+  },
+  "iOS_L_7_1": {
+    "match": "*iosv7.1*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "7.1"
+    }
+  },
+  "iOS_L_7_0": {
+    "match": "*iosv7.0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "7.0"
+    }
+  },
+  "iOS_L": {
+    "match": "*iosv*",
+    "lite": true,
+    "standard": true,
+    "inherits": "iOS"
+  },
+  "iOS_H_5_0": {
+    "match": "iPhone_OS/5.0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "5.0"
+    }
+  },
+  "iOS_H": {
+    "match": "iPhone_OS/*",
+    "lite": true,
+    "standard": true,
+    "inherits": "iOS"
+  },
+  "iOS_M": {
+    "match": "*iOS; like Mac OS X*",
+    "lite": true,
+    "standard": true,
+    "inherits": "iOS"
+  },
+  "iOS_B_1_0": {
+    "match": "*CPU like Mac OS X*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "1.0"
+    }
+  },
+  "iOS_B": {
+    "match": "*CPU like Mac OS X*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS"
+  },
+  "iOS_D_8_3": {
+    "match": "*iOS; U; iPh OS 8_3*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "8.3"
+    }
+  },
+  "iOS_D_8_2": {
+    "match": "*iOS; U; iPh OS 8_2*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "8.2"
+    }
+  },
+  "iOS_D_8_1": {
+    "match": "*iOS; U; iPh OS 8_1*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "8.1"
+    }
+  },
+  "iOS_D_8_0": {
+    "match": "*iOS; U; iPh OS 8_0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "8.0"
+    }
+  },
+  "iOS_D_7_1": {
+    "match": "*iOS; U; iPh OS 7_1*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "7.1"
+    }
+  },
+  "iOS_D_7_0": {
+    "match": "*iOS; U; iPh OS 7_0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "7.0"
+    }
+  },
+  "iOS_D_6_1": {
+    "match": "*iOS; U; iPh OS 6_1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "6.1"
+    }
+  },
+  "iOS_D_6_0": {
+    "match": "*iOS; U; iPh OS 6_0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "6.0"
+    }
+  },
+  "iOS_D_5_1": {
+    "match": "*iOS; U; iPh OS 5_1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "5.1"
+    }
+  },
+  "iOS_D_5_0": {
+    "match": "*iOS; U; iPh OS 5_0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "iOS",
+    "properties": {
+      "Platform_Version": "5.0"
+    }
+  },
+  "iOS_D": {
+    "match": "*iOS; U; iPh OS*",
+    "lite": true,
+    "standard": true,
+    "inherits": "iOS"
+  },
+  "iOS": {
+    "match": "*CPU iPhone OS *",
+    "lite": true,
+    "standard": true,
+    "properties": {
+      "Platform": "iOS",
+      "Platform_Maker": "Apple Inc",
+      "Platform_Description": "iPod, iPhone & iPad",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "Darwin_64": {
+    "match": "*Darwin*(x86_64)*",
+    "lite": false,
+    "standard": false,
+    "properties": {
+      "Platform": "Darwin",
+      "Platform_Maker": "Apple Inc",
+      "Platform_Description": "Darwin is a Core Component of MacOSX and iOS",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 64,
+      "Platform_Bits": 64
+    }
+  },
+  "Darwin": {
+    "match": "*Darwin*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "Darwin",
+      "Platform_Maker": "Apple Inc",
+      "Platform_Description": "Darwin is a Core Component of MacOSX and iOS",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "Tizen_Dynamic": {
+    "match": "*Linux*Tizen #MAJORVER#.#MINORVER#*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Tizen",
+    "properties": {
+      "Platform_Version": "#MAJORVER#.#MINORVER#"
+    }
+  },
+  "Tizen_4_0": {
+    "match": "*Linux*Tizen 4.0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Tizen",
+    "properties": {
+      "Platform_Version": "4.0"
+    }
+  },
+  "Tizen_3_0": {
+    "match": "*Linux*Tizen 3.0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Tizen",
+    "properties": {
+      "Platform_Version": "3.0"
+    }
+  },
+  "Tizen_2_4": {
+    "match": "*Linux*Tizen 2.4*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Tizen",
+    "properties": {
+      "Platform_Version": "2.4"
+    }
+  },
+  "Tizen_2_3": {
+    "match": "*Linux*Tizen 2.3*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Tizen",
+    "properties": {
+      "Platform_Version": "2.3"
+    }
+  },
+  "Tizen_2_2": {
+    "match": "*Linux*Tizen 2.2*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Tizen",
+    "properties": {
+      "Platform_Version": "2.2"
+    }
+  },
+  "Tizen_2_1": {
+    "match": "*Linux*Tizen 2.1*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Tizen",
+    "properties": {
+      "Platform_Version": "2.1"
+    }
+  },
+  "Tizen_2_0": {
+    "match": "*Linux*Tizen 2.0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Tizen",
+    "properties": {
+      "Platform_Version": "2.0"
+    }
+  },
+  "Tizen": {
+    "match": "*Linux*Tizen*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "Tizen",
+      "Platform_Maker": "Linux Foundation",
+      "Platform_Description": "Tizen",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "Maemo_ARM": {
+    "match": "*Linux arm*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Maemo"
+  },
+  "Maemo": {
+    "match": "*Maemo; Linux*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "Maemo",
+      "Platform_Maker": "Linux Foundation",
+      "Platform_Description": "Maemo",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "ChromeOS_ARM": {
+    "match": "*CrOS armv*",
+    "lite": false,
+    "standard": false,
+    "inherits": "ChromeOS"
+  },
+  "ChromeOS_64_ARM_fake_windows": {
+    "match": "*Windows aarch64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "ChromeOS"
+  },
+  "ChromeOS_x64": {
+    "match": "*CrOS x86_64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "ChromeOS",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform_Bits": 64
+    }
+  },
+  "ChromeOS_x64_fake_windows": {
+    "match": "*Windows x86_64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "ChromeOS",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform_Bits": 64
+    }
+  },
+  "ChromeOS": {
+    "match": "*CrOS*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "ChromeOS",
+      "Platform_Description": "Google Chrome OS",
+      "Platform_Maker": "Google Inc",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "Ubuntu_Touch_15_04": {
+    "match": "*Ubuntu?15.04*like Android*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Ubuntu_Touch",
+    "properties": {
+      "Platform_Version": "15.04"
+    }
+  },
+  "Ubuntu_Touch_14_04": {
+    "match": "*Ubuntu?14.04*like Android*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Ubuntu_Touch",
+    "properties": {
+      "Platform_Version": "14.04"
+    }
+  },
+  "Ubuntu_Touch": {
+    "match": "*Ubuntu*like Android*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Ubuntu",
+    "properties": {
+      "Platform": "Ubuntu Touch",
+      "Platform_Description": "Ubuntu Linux for Mobile"
+    }
+  },
+  "Ubuntu_14_04_64": {
+    "match": "*Ubuntu?14.04*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Ubuntu",
+    "properties": {
+      "Platform_Version": "14.04",
+      "Browser_Bits": 64,
+      "Platform_Bits": 64
+    }
+  },
+  "Ubuntu_12_04_64": {
+    "match": "*Ubuntu/12.04*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Ubuntu",
+    "properties": {
+      "Platform_Version": "12.04",
+      "Browser_Bits": 64,
+      "Platform_Bits": 64
+    }
+  },
+  "Ubuntu_11_04_64": {
+    "match": "*Ubuntu/11.04*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Ubuntu",
+    "properties": {
+      "Platform_Version": "11.04",
+      "Browser_Bits": 64,
+      "Platform_Bits": 64
+    }
+  },
+  "Ubuntu_10_10_64": {
+    "match": "*Ubuntu/10.10*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Ubuntu",
+    "properties": {
+      "Platform_Version": "10.10",
+      "Browser_Bits": 64,
+      "Platform_Bits": 64
+    }
+  },
+  "Ubuntu_10_04_64": {
+    "match": "*Ubuntu/10.04*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Ubuntu",
+    "properties": {
+      "Platform_Version": "10.04",
+      "Browser_Bits": 64,
+      "Platform_Bits": 64
+    }
+  },
+  "Ubuntu_08_10_64": {
+    "match": "*Ubuntu/8.10*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Ubuntu",
+    "properties": {
+      "Platform_Version": "8.10",
+      "Browser_Bits": 64,
+      "Platform_Bits": 64
+    }
+  },
+  "Ubuntu_08_04_64": {
+    "match": "*Ubuntu/8.04*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Ubuntu",
+    "properties": {
+      "Platform_Version": "8.04",
+      "Browser_Bits": 64,
+      "Platform_Bits": 64
+    }
+  },
+  "Ubuntu_64": {
+    "match": "*Ubuntu; Linux x86_64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Ubuntu",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform_Bits": 64
+    }
+  },
+  "Ubuntu_14_04": {
+    "match": "*Ubuntu?14.04*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Ubuntu",
+    "properties": {
+      "Platform_Version": "14.04"
+    }
+  },
+  "Ubuntu_12_04": {
+    "match": "*Ubuntu/12.04*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Ubuntu",
+    "properties": {
+      "Platform_Version": "12.04"
+    }
+  },
+  "Ubuntu_11_10": {
+    "match": "*Ubuntu/11.10*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Ubuntu",
+    "properties": {
+      "Platform_Version": "11.10"
+    }
+  },
+  "Ubuntu_11_04": {
+    "match": "*Ubuntu/11.04*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Ubuntu",
+    "properties": {
+      "Platform_Version": "11.04"
+    }
+  },
+  "Ubuntu_10_10": {
+    "match": "*Ubuntu/10.10*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Ubuntu",
+    "properties": {
+      "Platform_Version": "10.10"
+    }
+  },
+  "Ubuntu_10_04": {
+    "match": "*Ubuntu/10.04*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Ubuntu",
+    "properties": {
+      "Platform_Version": "10.04"
+    }
+  },
+  "Ubuntu_09_25": {
+    "match": "*Ubuntu/9.25*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Ubuntu",
+    "properties": {
+      "Platform_Version": "9.25"
+    }
+  },
+  "Ubuntu_08_10": {
+    "match": "*Ubuntu/8.10*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Ubuntu",
+    "properties": {
+      "Platform_Version": "8.10"
+    }
+  },
+  "Ubuntu_08_04": {
+    "match": "*Ubuntu/8.04*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Ubuntu",
+    "properties": {
+      "Platform_Version": "8.04"
+    }
+  },
+  "Ubuntu": {
+    "match": "*Ubuntu*",
+    "lite": false,
+    "standard": false,
+    "properties": {
+      "Platform": "Ubuntu",
+      "Platform_Maker": "Canonical Foundation",
+      "Platform_Description": "Ubuntu Linux",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "CentOS": {
+    "match": "*CentOS*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "CentOS",
+      "Platform_Maker": "unknown",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "Debian_32_on_x64_2": {
+    "match": "*Linux i686 (x86_64)*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Debian",
+    "properties": {
+      "Platform_Bits": 64
+    }
+  },
+  "Debian_64": {
+    "match": "*Linux x86_64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Debian",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform_Bits": 64
+    }
+  },
+  "Debian": {
+    "match": "*Linux*",
+    "lite": false,
+    "standard": false,
+    "properties": {
+      "Platform": "Debian",
+      "Platform_Description": "Debian Linux",
+      "Platform_Maker": "Software in the Public Interest, Inc.",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "Fedora": {
+    "match": "*Fedora*",
+    "lite": false,
+    "standard": false,
+    "properties": {
+      "Platform": "Fedora",
+      "Platform_Maker": "Red Hat Inc",
+      "Platform_Description": "Fedora Linux",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "Red_Hat": {
+    "match": "*Red Hat*",
+    "lite": false,
+    "standard": false,
+    "properties": {
+      "Platform": "Red Hat",
+      "Platform_Maker": "Red Hat Inc",
+      "Platform_Description": "Red Hat Linux",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "Linux_32_on_x64": {
+    "match": "*Linux i686 on x86_64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Linux",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform_Bits": 64
+    }
+  },
+  "Linux_32_on_x64_2": {
+    "match": "*Linux i686 (x86_64)*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Linux",
+    "properties": {
+      "Platform_Bits": 64
+    }
+  },
+  "Linux_x64": {
+    "match": "*linux x64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Linux",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform_Bits": 64
+    }
+  },
+  "Linux_64_ARM": {
+    "match": "*Linux aarch64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Linux",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform_Bits": 64
+    }
+  },
+  "Linux_64_sparc": {
+    "match": "*linux sparc64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Linux",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform_Bits": 64
+    }
+  },
+  "Linux_64_amd": {
+    "match": "*Linux*amd64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Linux",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform_Bits": 64
+    }
+  },
+  "Linux_64": {
+    "match": "*Linux*x86_64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Linux",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform_Bits": 64
+    }
+  },
+  "Linux_64_B": {
+    "match": "*x86_64*linux*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Linux",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform_Bits": 64
+    }
+  },
+  "Linux_PPC": {
+    "match": "*Linux*; PPC*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Linux"
+  },
+  "Linux_MIPS": {
+    "match": "*Linux* mips*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Linux"
+  },
+  "Linux_ARM": {
+    "match": "*Linux* arm*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Linux"
+  },
+  "Linux_SH4": {
+    "match": "*Linux* sh4*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Linux"
+  },
+  "Mobilinux": {
+    "match": "*Linux*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Linux",
+    "properties": {
+      "Platform": "Mobilinux",
+      "Platform_Maker": "MontaVista",
+      "Platform_Description": "An Embedded-Linux-Distribution for Phones"
+    }
+  },
+  "Linux": {
+    "match": "*Linux*",
+    "lite": true,
+    "standard": true,
+    "properties": {
+      "Platform": "Linux",
+      "Platform_Maker": "Linux Foundation",
+      "Platform_Description": "Linux",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "WinPhone10_Continuum": {
+    "match": "*Windows NT 10.0*ARM;*",
+    "lite": false,
+    "standard": true,
+    "inherits": "WinPhone10",
+    "properties": {
+      "Browser_Modus": "Continuum Mode (Desktop)"
+    }
+  },
+  "WinPhone10_B": {
+    "match": "*Windows; U; wds 10.0*",
+    "lite": true,
+    "standard": true,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinPhone10",
+      "Platform_Version": "10.0",
+      "Platform_Description": "Windows Phone OS 10.0",
+      "Win32": false
+    }
+  },
+  "WinPhone10": {
+    "match": "*Windows Phone 10.0*",
+    "lite": true,
+    "standard": true,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinPhone10",
+      "Platform_Version": "10.0",
+      "Platform_Description": "Windows Phone OS 10.0",
+      "Win32": false
+    }
+  },
+  "WinPhone8.1_B": {
+    "match": "*Windows; U; wds 8.1*",
+    "lite": true,
+    "standard": true,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinPhone8.1",
+      "Platform_Version": "8.1",
+      "Platform_Description": "Windows Phone OS 8.1",
+      "Win32": false
+    }
+  },
+  "WinPhone8.1": {
+    "match": "*Windows Phone 8.1*",
+    "lite": true,
+    "standard": true,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinPhone8.1",
+      "Platform_Version": "8.1",
+      "Platform_Description": "Windows Phone OS 8.1",
+      "Win32": false
+    }
+  },
+  "WinPhone8_osmeta": {
+    "match": "*like iPhone; U; osmeta 8.*",
+    "lite": true,
+    "standard": true,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinPhone8",
+      "Platform_Version": "8.0",
+      "Platform_Description": "Windows Phone OS 8 (osmeta)",
+      "Win32": false
+    }
+  },
+  "WinPhone8_B": {
+    "match": "*Windows; U; wds 8*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinPhone8",
+      "Platform_Version": "8.0",
+      "Platform_Description": "Windows Phone OS 8",
+      "Win32": false
+    }
+  },
+  "WinPhone8": {
+    "match": "*Windows Phone 8*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinPhone8",
+      "Platform_Version": "8.0",
+      "Platform_Description": "Windows Phone OS 8",
+      "Win32": false
+    }
+  },
+  "WinPhone710": {
+    "match": "*Windows Phone OS 7.10*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinPhone7.10",
+      "Platform_Version": "7.10",
+      "Platform_Description": "Windows Phone OS 7.10",
+      "Win32": false
+    }
+  },
+  "WinPhone78": {
+    "match": "*Windows Phone OS 7.8*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinPhone7.8",
+      "Platform_Version": "7.8",
+      "Platform_Description": "Windows Phone OS 7.8",
+      "Win32": false
+    }
+  },
+  "WinPhone75": {
+    "match": "*Windows Phone OS 7.5*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinPhone7.5",
+      "Platform_Version": "7.5",
+      "Platform_Description": "Windows Phone OS 7.5",
+      "Win32": false
+    }
+  },
+  "WinPhone7_C": {
+    "match": "*Windows; U; wds 7*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinPhone7",
+      "Platform_Version": "7.0",
+      "Platform_Description": "Windows Phone OS 7",
+      "Win32": false
+    }
+  },
+  "WinPhone7": {
+    "match": "*Windows Phone OS 7.0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinPhone7",
+      "Platform_Version": "7.0",
+      "Platform_Description": "Windows Phone OS 7",
+      "Win32": false
+    }
+  },
+  "WinPhone65": {
+    "match": "*Windows Phone 6.5*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinPhone6",
+      "Platform_Version": "6.5",
+      "Platform_Description": "Windows Phone OS 6.5",
+      "Win32": false
+    }
+  },
+  "WinPhone": {
+    "match": "*Windows Phone*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinPhone",
+      "Platform_Description": "Windows Phone OS",
+      "Win32": false
+    }
+  },
+  "WinMobile": {
+    "match": "*Windows*Mobile*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinMobile",
+      "Platform_Description": "Windows Mobile OS",
+      "Win32": false
+    }
+  },
+  "WinCE": {
+    "match": "*Windows CE*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Windows",
+    "properties": {
+      "Platform": "WinCE",
+      "Platform_Description": "Windows CE",
+      "Win32": false
+    }
+  },
+  "Miui_OS_Dynamic": {
+    "match": "*MIUI/#MAJORVER#.#MINORVER#*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Miui_OS",
+    "properties": {
+      "Platform_Version": "#MAJORVER#.#MINORVER#"
+    }
+  },
+  "Miui_OS_Dynamic_B": {
+    "match": "*MIUI/V#MAJORVER#.#MINORVER#*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Miui_OS",
+    "properties": {
+      "Platform_Version": "#MAJORVER#.#MINORVER#"
+    }
+  },
+  "Miui_OS_8_2": {
+    "match": "*MIUI/V8.2*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Miui_OS",
+    "properties": {
+      "Platform_Version": "8.2"
+    }
+  },
+  "Miui_OS_7_3": {
+    "match": "*MIUI/V7.3*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Miui_OS",
+    "properties": {
+      "Platform_Version": "7.3"
+    }
+  },
+  "Miui_OS": {
+    "match": "*MIUI*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "Miui OS",
+      "Platform_Maker": "Xiaomi Tech",
+      "Platform_Version": "unknown",
+      "Platform_Description": "a fork of Android OS by Xiaomi",
+      "Win32": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "Android_Dynamic": {
+    "match": "*Linux*Android?#MAJORVER#.#MINORVER#*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "#MAJORVER#.#MINORVER#"
+    }
+  },
+  "Android_9_0": {
+    "match": "*Linux*Android?9;*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "9.0"
+    }
+  },
+  "Android_8_1": {
+    "match": "*Linux*Android?8.1*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "8.1"
+    }
+  },
+  "Android_8_0": {
+    "match": "*Linux*Android?8.0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "8.0"
+    }
+  },
+  "Android_7_1": {
+    "match": "*Linux*Android?7.1*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "7.1"
+    }
+  },
+  "Android_7_0": {
+    "match": "*Linux*Android?7.0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "7.0"
+    }
+  },
+  "Android_6_0": {
+    "match": "*Linux*Android?6.0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "6.0"
+    }
+  },
+  "Android_5_1": {
+    "match": "*Linux*Android?5.1*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "5.1"
+    }
+  },
+  "Android_5_0": {
+    "match": "*Linux*Android?5.0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "5.0"
+    }
+  },
+  "Android_4_4": {
+    "match": "*Linux*Android?4.4*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.4"
+    }
+  },
+  "Android_4_3": {
+    "match": "*Linux*Android?4.3*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.3"
+    }
+  },
+  "Android_4_2": {
+    "match": "*Linux*Android?4.2*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.2"
+    }
+  },
+  "Android_4_1": {
+    "match": "*Linux*Android?4.1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.1"
+    }
+  },
+  "Android_4_1_E": {
+    "match": "*Linux*Android; 4.1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.1"
+    }
+  },
+  "Android_4_0": {
+    "match": "*Linux*Android?4.0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.0"
+    }
+  },
+  "Android_3_2": {
+    "match": "*Linux*Android?3.2*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "3.2"
+    }
+  },
+  "Android_3_1": {
+    "match": "*Linux*Android?3.1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "3.1"
+    }
+  },
+  "Android_3_0": {
+    "match": "*Linux*Android?3.0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "3.0"
+    }
+  },
+  "Android_2_3": {
+    "match": "*Linux*Android?2.3*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.3"
+    }
+  },
+  "Android_2_2": {
+    "match": "*Linux*Android?2.2*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.2"
+    }
+  },
+  "Android_2_1": {
+    "match": "*Linux*Android?2.1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.1"
+    }
+  },
+  "Android_2_0": {
+    "match": "*Linux*Android?2.0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.0"
+    }
+  },
+  "Android_1_6": {
+    "match": "*Linux*Android?1.6*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "1.6"
+    }
+  },
+  "Android_1_5": {
+    "match": "*Linux*Android?1.5*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "1.5"
+    }
+  },
+  "Android_1_1": {
+    "match": "*Linux*Android?1.1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "1.1"
+    }
+  },
+  "Android_1_0": {
+    "match": "*Linux*Android?1.0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "1.0"
+    }
+  },
+  "Android_1_0_B": {
+    "match": "*Linux*Android?v1.0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "1.0"
+    }
+  },
+  "Android": {
+    "match": "*Linux*Android*",
+    "lite": true,
+    "standard": true,
+    "properties": {
+      "Platform": "Android",
+      "Platform_Description": "Android OS",
+      "Platform_Maker": "Google Inc",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "Android_H_8_1": {
+    "match": "*Android?8.1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "8.1"
+    }
+  },
+  "Android_H_8_0": {
+    "match": "*Android?8.0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "8.0"
+    }
+  },
+  "Android_H_7_1": {
+    "match": "*Android?7.1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "7.1"
+    }
+  },
+  "Android_H_7_0": {
+    "match": "*Android?7.0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "7.0"
+    }
+  },
+  "Android_H_6_0": {
+    "match": "*Android?6.0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "6.0"
+    }
+  },
+  "Android_H_5_1": {
+    "match": "*Android?5.1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "5.1"
+    }
+  },
+  "Android_H_5_0": {
+    "match": "*Android?5.0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "5.0"
+    }
+  },
+  "Android_H_4_4": {
+    "match": "*Android?4.4*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.4"
+    }
+  },
+  "Android_H_4_3": {
+    "match": "*Android?4.3*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.3"
+    }
+  },
+  "Android_H_4_2": {
+    "match": "*Android?4.2*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.2"
+    }
+  },
+  "Android_H_4_1": {
+    "match": "*Android?4.1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.1"
+    }
+  },
+  "Android_H_4_0": {
+    "match": "*Android?4.0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.0"
+    }
+  },
+  "Android_H_2_3": {
+    "match": "*Android?2.3*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.3"
+    }
+  },
+  "Android_H_2_2": {
+    "match": "*Android?2.2*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.2"
+    }
+  },
+  "Android_H_2_1": {
+    "match": "*Android?2.1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.1"
+    }
+  },
+  "Android_H_2_0": {
+    "match": "*Android?2.0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.0"
+    }
+  },
+  "Android_H": {
+    "match": "*Android*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android"
+  },
+  "Android_B_2_3": {
+    "match": "* Build/GINGERBREAD*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.3"
+    }
+  },
+  "Android_B": {
+    "match": "* Build/*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android"
+  },
+  "Android_F_8_0": {
+    "match": "*Android?8.0*Linux*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "8.0"
+    }
+  },
+  "Android_F_7_1": {
+    "match": "*Android?7.1*Linux*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "7.1"
+    }
+  },
+  "Android_F_7_0": {
+    "match": "*Android?7.0*Linux*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "7.0"
+    }
+  },
+  "Android_F_6_0": {
+    "match": "*Android?6.0*Linux*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "6.0"
+    }
+  },
+  "Android_F_5_1": {
+    "match": "*Android?5.1*Linux*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "5.1"
+    }
+  },
+  "Android_F_5_0": {
+    "match": "*Android?5.0*Linux*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "5.0"
+    }
+  },
+  "Android_F_4_4": {
+    "match": "*Android?4.4*Linux*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.4"
+    }
+  },
+  "Android_F_4_3": {
+    "match": "*Android?4.3*Linux*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.3"
+    }
+  },
+  "Android_F_4_2": {
+    "match": "*Android?4.2*Linux*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.2"
+    }
+  },
+  "Android_F_4_1": {
+    "match": "*Android?4.1*Linux*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.1"
+    }
+  },
+  "Android_F_4_0": {
+    "match": "*Android?4.0*Linux*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.0"
+    }
+  },
+  "Android_F_3_2": {
+    "match": "*Android?3.2*Linux*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "3.2"
+    }
+  },
+  "Android_F_3_1": {
+    "match": "*Android?3.1*Linux*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "3.1"
+    }
+  },
+  "Android_F_3_0": {
+    "match": "*Android?3.0*Linux*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "3.0"
+    }
+  },
+  "Android_F_2_3": {
+    "match": "*Android?2.3*Linux*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.3"
+    }
+  },
+  "Android_F_2_2": {
+    "match": "*Android?2.2*Linux*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.2"
+    }
+  },
+  "Android_F_2_1": {
+    "match": "*Android?2.1*Linux*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.1"
+    }
+  },
+  "Android_F_2_0": {
+    "match": "*Android?2.0*Linux*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.0"
+    }
+  },
+  "Android_F_1_6": {
+    "match": "*Android?1.6*Linux*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "1.6"
+    }
+  },
+  "Android_F": {
+    "match": "*Android?*Linux*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android"
+  },
+  "Android_D_5_1": {
+    "match": "JUC (Linux; U; 5.1*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "5.1"
+    }
+  },
+  "Android_D_5_0": {
+    "match": "JUC (Linux; U; 5.0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "5.0"
+    }
+  },
+  "Android_D_4_4": {
+    "match": "JUC (Linux; U; 4.4*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.4"
+    }
+  },
+  "Android_D_4_3": {
+    "match": "JUC (Linux; U; 4.3*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.3"
+    }
+  },
+  "Android_D_4_2": {
+    "match": "JUC (Linux; U; 4.2*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.2"
+    }
+  },
+  "Android_D_4_1": {
+    "match": "JUC (Linux; U; 4.1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.1"
+    }
+  },
+  "Android_D_4_0": {
+    "match": "JUC (Linux; U; 4.0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.0"
+    }
+  },
+  "Android_D_2_3": {
+    "match": "JUC (Linux; U; 2.3*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.3"
+    }
+  },
+  "Android_D_2_2": {
+    "match": "JUC (Linux; U; 2.2*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.2"
+    }
+  },
+  "Android_D_2_1": {
+    "match": "JUC (Linux; U; 2.1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.1"
+    }
+  },
+  "Android_D_2_0": {
+    "match": "JUC (Linux; U; 2.0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.0"
+    }
+  },
+  "Android_D_1_6": {
+    "match": "JUC (Linux; U; 1.6*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "1.6"
+    }
+  },
+  "Android_D_1_5": {
+    "match": "JUC (Linux; U; 1.5*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "1.5"
+    }
+  },
+  "Android_D": {
+    "match": "JUC (Linux; U; *",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android"
+  },
+  "Android_E_8_0": {
+    "match": "*; U; Adr 8.0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "8.0"
+    }
+  },
+  "Android_E_7_1": {
+    "match": "*; U; Adr 7.1*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "7.1"
+    }
+  },
+  "Android_E_7_0": {
+    "match": "*; U; Adr 7.0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "7.0"
+    }
+  },
+  "Android_E_6_0": {
+    "match": "*; U; Adr 6.0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "6.0"
+    }
+  },
+  "Android_E_5_1": {
+    "match": "*; U; Adr 5.1*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "5.1"
+    }
+  },
+  "Android_E_5_0": {
+    "match": "*; U; Adr 5.0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "5.0"
+    }
+  },
+  "Android_E_4_4": {
+    "match": "*; U; Adr 4.4*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.4"
+    }
+  },
+  "Android_E_4_3": {
+    "match": "*; U; Adr 4.3*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.3"
+    }
+  },
+  "Android_E_4_2": {
+    "match": "*; U; Adr 4.2*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.2"
+    }
+  },
+  "Android_E_4_1": {
+    "match": "*; U; Adr 4.1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.1"
+    }
+  },
+  "Android_E_4_0": {
+    "match": "*; U; Adr 4.0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.0"
+    }
+  },
+  "Android_E_3_2": {
+    "match": "*; U; Adr 3.2*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "3.2"
+    }
+  },
+  "Android_E_3_1": {
+    "match": "*; U; Adr 3.1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "3.1"
+    }
+  },
+  "Android_E_3_0": {
+    "match": "*; U; Adr 3.0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "3.0"
+    }
+  },
+  "Android_E_2_3": {
+    "match": "*; U; Adr 2.3*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.3"
+    }
+  },
+  "Android_E_2_2": {
+    "match": "*; U; Adr 2.2*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.2"
+    }
+  },
+  "Android_E_2_1": {
+    "match": "*; U; Adr 2.1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.1"
+    }
+  },
+  "Android_E_2_0": {
+    "match": "*; U; Adr 2.0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.0"
+    }
+  },
+  "Android_E": {
+    "match": "*; U; Adr *",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android"
+  },
+  "Android_C_4_4": {
+    "match": "JUC(Linux;U;Android4.4*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.4"
+    }
+  },
+  "Android_C_4_3": {
+    "match": "JUC(Linux;U;Android4.3*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.3"
+    }
+  },
+  "Android_C_4_2": {
+    "match": "JUC(Linux;U;Android4.2*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.2"
+    }
+  },
+  "Android_C_4_1": {
+    "match": "JUC(Linux;U;Android4.1*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.1"
+    }
+  },
+  "Android_C_4_0": {
+    "match": "JUC(Linux;U;Android4.0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.0"
+    }
+  },
+  "Android_C_3_2": {
+    "match": "JUC(Linux;U;Android3.2*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "3.2"
+    }
+  },
+  "Android_C_3_1": {
+    "match": "JUC(Linux;U;Android3.1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "3.1"
+    }
+  },
+  "Android_C_3_0": {
+    "match": "JUC(Linux;U;Android3.0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "3.0"
+    }
+  },
+  "Android_C_2_3": {
+    "match": "JUC(Linux;U;Android2.3*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.3"
+    }
+  },
+  "Android_C_2_2": {
+    "match": "JUC(Linux;U;Android2.2*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.2"
+    }
+  },
+  "Android_C_2_1": {
+    "match": "JUC(Linux;U;Android2.1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.1"
+    }
+  },
+  "Android_C_2_0": {
+    "match": "JUC(Linux;U;Android2.0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.0"
+    }
+  },
+  "Android_C_1_6": {
+    "match": "JUC(Linux;U;Android1.6*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "1.6"
+    }
+  },
+  "Android_C_1_5": {
+    "match": "JUC(Linux;U;Android1.5*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "1.5"
+    }
+  },
+  "Android_C": {
+    "match": "JUC(Linux;U;Android*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android"
+  },
+  "Android_G_2_3": {
+    "match": "JUC(Linux;?;2.3*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.3"
+    }
+  },
+  "Android_G_2_2": {
+    "match": "JUC(Linux;?;2.2*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.2"
+    }
+  },
+  "Android_G_2_1": {
+    "match": "JUC(Linux;?;2.1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.1"
+    }
+  },
+  "Android_G_1_5": {
+    "match": "JUC(Linux;?;1.5*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "1.5"
+    }
+  },
+  "Android_G": {
+    "match": "JUC(Linux;?;*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android"
+  },
+  "Android_I_4_4": {
+    "match": "*Linux* 4.4*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.4"
+    }
+  },
+  "Android_I_4_3": {
+    "match": "*Linux* 4.3*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.3"
+    }
+  },
+  "Android_I_4_2": {
+    "match": "*Linux* 4.2*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.2"
+    }
+  },
+  "Android_I_4_1": {
+    "match": "*Linux* 4.1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.1"
+    }
+  },
+  "Android_I_4_0": {
+    "match": "*Linux* 4.0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.0"
+    }
+  },
+  "Android_I_2_3": {
+    "match": "*Linux* 2.3*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.3"
+    }
+  },
+  "Android_I": {
+    "match": "*Linux*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android"
+  },
+  "AndroidTablet_8_1": {
+    "match": "*Android 8.1*Tablet*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "8.1"
+    }
+  },
+  "AndroidTablet_8_0": {
+    "match": "*Android 8.0*Tablet*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "8.0"
+    }
+  },
+  "AndroidTablet_7_1": {
+    "match": "*Android 7.1*Tablet*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "7.1"
+    }
+  },
+  "AndroidTablet_7_0": {
+    "match": "*Android 7.0*Tablet*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "7.0"
+    }
+  },
+  "AndroidTablet_6_0": {
+    "match": "*Android 6.0*Tablet*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "6.0"
+    }
+  },
+  "AndroidTablet_5_1": {
+    "match": "*Android 5.1*Tablet*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "5.1"
+    }
+  },
+  "AndroidTablet_5_0": {
+    "match": "*Android 5.0*Tablet*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "5.0"
+    }
+  },
+  "AndroidTablet_4_4": {
+    "match": "*Android 4.4*Tablet*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.4"
+    }
+  },
+  "AndroidTablet_4_3": {
+    "match": "*Android 4.3*Tablet*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.3"
+    }
+  },
+  "AndroidTablet_4_2": {
+    "match": "*Android 4.2*Tablet*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.2"
+    }
+  },
+  "AndroidTablet_4_1": {
+    "match": "*Android 4.1*Tablet*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.1"
+    }
+  },
+  "AndroidTablet_4_0": {
+    "match": "*Android 4.0*Tablet*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.0"
+    }
+  },
+  "AndroidTablet_3_2": {
+    "match": "*Android 3.2*Tablet*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "3.2"
+    }
+  },
+  "AndroidTablet_3_1": {
+    "match": "*Android 3.1*Tablet*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "3.1"
+    }
+  },
+  "AndroidTablet_3_0": {
+    "match": "*Android 3.0*Tablet*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "3.0"
+    }
+  },
+  "AndroidTablet_2_3": {
+    "match": "*Android 2.3*Tablet*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.3"
+    }
+  },
+  "AndroidTablet_2_2": {
+    "match": "*Android 2.2*Tablet*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.2"
+    }
+  },
+  "AndroidTablet_2_1": {
+    "match": "*Android 2.1*Tablet*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.1"
+    }
+  },
+  "AndroidTablet_2_0": {
+    "match": "*Android 2.0*Tablet*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.0"
+    }
+  },
+  "AndroidTablet": {
+    "match": "*Android*Tablet*",
+    "lite": true,
+    "standard": true,
+    "inherits": "Android"
+  },
+  "AndroidMobile_8_1": {
+    "match": "*Android 8.1*Mobile*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "8.1"
+    }
+  },
+  "AndroidMobile_8_0": {
+    "match": "*Android 8.0*Mobile*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "8.0"
+    }
+  },
+  "AndroidMobile_7_1": {
+    "match": "*Android 7.1*Mobile*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "7.1"
+    }
+  },
+  "AndroidMobile_7_0": {
+    "match": "*Android 7.0*Mobile*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "7.0"
+    }
+  },
+  "AndroidMobile_6_0": {
+    "match": "*Android 6.0*Mobile*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "6.0"
+    }
+  },
+  "AndroidMobile_5_1": {
+    "match": "*Android 5.1*Mobile*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "5.1"
+    }
+  },
+  "AndroidMobile_5_0": {
+    "match": "*Android 5.0*Mobile*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "5.0"
+    }
+  },
+  "AndroidMobile_4_4": {
+    "match": "*Android 4.4*Mobile*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.4"
+    }
+  },
+  "AndroidMobile_4_3": {
+    "match": "*Android 4.3*Mobile*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.3"
+    }
+  },
+  "AndroidMobile_4_2": {
+    "match": "*Android 4.2*Mobile*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.2"
+    }
+  },
+  "AndroidMobile_4_1": {
+    "match": "*Android 4.1*Mobile*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.1"
+    }
+  },
+  "AndroidMobile_4_0": {
+    "match": "*Android 4.0*Mobile*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "4.0"
+    }
+  },
+  "AndroidMobile_2_3": {
+    "match": "*Android 2.3*Mobile*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.3"
+    }
+  },
+  "AndroidMobile_2_2": {
+    "match": "*Android 2.2*Mobile*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.2"
+    }
+  },
+  "AndroidMobile_2_1": {
+    "match": "*Android 2.1*Mobile*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.1"
+    }
+  },
+  "AndroidMobile_2_0": {
+    "match": "*Android 2.0*Mobile*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform_Version": "2.0"
+    }
+  },
+  "AndroidMobile": {
+    "match": "*Android*Mobile*",
+    "lite": true,
+    "standard": true,
+    "inherits": "Android"
+  },
+  "Android_GoogleTV_3_2": {
+    "match": "*Linux*GoogleTV 3.2*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Android",
+    "properties": {
+      "Platform": "Android for GoogleTV",
+      "Platform_Version": "3.2",
+      "Platform_Description": "Android OS for GoogleTV"
+    }
+  },
+  "Android_GoogleTV": {
+    "match": "*Linux*GoogleTV*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Android",
+    "properties": {
+      "Platform": "Android for GoogleTV",
+      "Platform_Description": "Android OS for GoogleTV"
+    }
+  },
+  "AndroidGeneric": {
+    "match": "*Android*",
+    "lite": true,
+    "standard": true,
+    "inherits": "Android"
+  },
+  "Maui": {
+    "match": "*MAUI*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "MAUI",
+      "Platform_Maker": "MediaTek",
+      "Platform_Description": "MAUI Runtime Environment (MRE)",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "Chromecast_OS_64_ARM": {
+    "match": "*Linux aarch64*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Chromecast_OS_ARM",
+    "properties": {
+      "Browser_Bits": 64,
+      "Platform_Bits": 64
+    }
+  },
+  "Chromecast_OS_ARM": {
+    "match": "*Linux* arm*",
+    "lite": false,
+    "standard": false,
+    "properties": {
+      "Platform": "Chromecast OS",
+      "Platform_Maker": "Google Inc",
+      "Platform_Description": "Chromecast OS is a Linux/Android based Platform for the Chromecast",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "Brew_MP": {
+    "match": "*Brew MP*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Brew",
+    "properties": {
+      "Platform_Version": "5.0",
+      "Platform": "Brew MP"
+    }
+  },
+  "Brew_4_0": {
+    "match": "*Brew 4.0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Brew",
+    "properties": {
+      "Platform_Version": "4.0"
+    }
+  },
+  "Brew_3_1": {
+    "match": "*Brew 3.1*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Brew",
+    "properties": {
+      "Platform_Version": "3.1"
+    }
+  },
+  "Brew_3_0": {
+    "match": "*Brew 3.0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Brew",
+    "properties": {
+      "Platform_Version": "3.0"
+    }
+  },
+  "Brew": {
+    "match": "*BREW*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "Brew",
+      "Platform_Version": "2.0",
+      "Platform_Description": "Qualcomm Brew",
+      "Platform_Maker": "Qualcomm",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "Syllable": {
+    "match": "*Syllable*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "Syllable",
+      "Platform_Maker": "Syllable Project",
+      "Platform_Version": "unknown",
+      "Win32": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "SymbianOS": {
+    "match": "*SymbianOS*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "SymbianOS",
+      "Platform_Maker": "Symbian Foundation",
+      "Platform_Description": "Symbian OS",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "SymbianOS_B": {
+    "match": "*Symbian; U; *",
+    "lite": false,
+    "standard": true,
+    "inherits": "SymbianOS"
+  },
+  "SymbianOS_C": {
+    "match": "*SymbOS*",
+    "lite": false,
+    "standard": true,
+    "inherits": "SymbianOS"
+  },
+  "SymbianOS_D": {
+    "match": "*Symbian OS*",
+    "lite": false,
+    "standard": true,
+    "inherits": "SymbianOS"
+  },
+  "JAVA": {
+    "match": "*/MIDP*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "JAVA",
+      "Platform_Maker": "Oracle",
+      "Platform_Version": "unknown",
+      "Platform_Description": "unknown",
+      "Win32": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "Amiga": {
+    "match": "*AmigaOS*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "Amiga OS",
+      "Platform_Maker": "Commodore International",
+      "Platform_Version": "unknown",
+      "Platform_Description": "Amiga OS",
+      "Win32": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "RIM_Tablet_OS_2_1": {
+    "match": "*RIM Tablet OS*",
+    "lite": false,
+    "standard": true,
+    "inherits": "RIM_Tablet_OS",
+    "properties": {
+      "Platform_Version": "2.1"
+    }
+  },
+  "RIM_Tablet_OS_2_0": {
+    "match": "*RIM Tablet OS*",
+    "lite": false,
+    "standard": true,
+    "inherits": "RIM_Tablet_OS",
+    "properties": {
+      "Platform_Version": "2.0"
+    }
+  },
+  "RIM_Tablet_OS_1": {
+    "match": "*RIM Tablet OS*",
+    "lite": false,
+    "standard": true,
+    "inherits": "RIM_Tablet_OS",
+    "properties": {
+      "Platform_Version": "1.0"
+    }
+  },
+  "RIM_Tablet_OS": {
+    "match": "*RIM Tablet OS*",
+    "lite": false,
+    "standard": true,
+    "inherits": "RIMOS",
+    "properties": {
+      "Platform": "RIM Tablet OS"
+    }
+  },
+  "RIMOS_10_X": {
+    "match": "*BB10*",
+    "lite": false,
+    "standard": true,
+    "inherits": "RIMOS",
+    "properties": {
+      "Platform_Version": "#MAJORVER#.#MINORVER#"
+    }
+  },
+  "RIMOS_Dynamic": {
+    "match": "*BlackBerry; U*",
+    "lite": false,
+    "standard": true,
+    "inherits": "RIMOS",
+    "properties": {
+      "Platform_Version": "#MAJORVER#.#MINORVER#"
+    }
+  },
+  "RIMOS_7_1": {
+    "match": "*BlackBerry; U*",
+    "lite": false,
+    "standard": true,
+    "inherits": "RIMOS",
+    "properties": {
+      "Platform_Version": "7.1"
+    }
+  },
+  "RIMOS_7_0": {
+    "match": "*BlackBerry; U*",
+    "lite": false,
+    "standard": true,
+    "inherits": "RIMOS",
+    "properties": {
+      "Platform_Version": "7.0"
+    }
+  },
+  "RIMOS_6_0": {
+    "match": "*BlackBerry; U*",
+    "lite": false,
+    "standard": false,
+    "inherits": "RIMOS",
+    "properties": {
+      "Platform_Version": "6.0"
+    }
+  },
+  "RIMOS_5_0": {
+    "match": "*BlackBerry; U*",
+    "lite": false,
+    "standard": false,
+    "inherits": "RIMOS",
+    "properties": {
+      "Platform_Version": "5.0"
+    }
+  },
+  "RIMOS_4_7": {
+    "match": "*BlackBerry; U*",
+    "lite": false,
+    "standard": false,
+    "inherits": "RIMOS",
+    "properties": {
+      "Platform_Version": "4.7"
+    }
+  },
+  "RIMOS_4_6": {
+    "match": "*BlackBerry; U*",
+    "lite": false,
+    "standard": false,
+    "inherits": "RIMOS",
+    "properties": {
+      "Platform_Version": "4.6"
+    }
+  },
+  "RIMOS_4_5": {
+    "match": "*BlackBerry; U*",
+    "lite": false,
+    "standard": false,
+    "inherits": "RIMOS",
+    "properties": {
+      "Platform_Version": "4.5"
+    }
+  },
+  "RIMOS_4_3": {
+    "match": "*BlackBerry; U*",
+    "lite": false,
+    "standard": false,
+    "inherits": "RIMOS",
+    "properties": {
+      "Platform_Version": "4.3"
+    }
+  },
+  "RIMOS_4_2_B": {
+    "match": "*BlackBerry; U; 4.2*",
+    "lite": false,
+    "standard": false,
+    "inherits": "RIMOS",
+    "properties": {
+      "Platform_Version": "4.2"
+    }
+  },
+  "RIMOS_4_2": {
+    "match": "*BlackBerry; U*",
+    "lite": false,
+    "standard": false,
+    "inherits": "RIMOS",
+    "properties": {
+      "Platform_Version": "4.2"
+    }
+  },
+  "RIMOS_4_1": {
+    "match": "*BlackBerry; U*",
+    "lite": false,
+    "standard": false,
+    "inherits": "RIMOS",
+    "properties": {
+      "Platform_Version": "4.1"
+    }
+  },
+  "RIMOS_4_0": {
+    "match": "*BlackBerry; U*",
+    "lite": false,
+    "standard": false,
+    "inherits": "RIMOS",
+    "properties": {
+      "Platform_Version": "4.0"
+    }
+  },
+  "RIMOS_3_8": {
+    "match": "*BlackBerry; U*",
+    "lite": false,
+    "standard": false,
+    "inherits": "RIMOS",
+    "properties": {
+      "Platform_Version": "3.8"
+    }
+  },
+  "RIMOS_3_7": {
+    "match": "*BlackBerry; U*",
+    "lite": false,
+    "standard": false,
+    "inherits": "RIMOS",
+    "properties": {
+      "Platform_Version": "3.7"
+    }
+  },
+  "RIMOS_3_6": {
+    "match": "*BlackBerry; U*",
+    "lite": false,
+    "standard": false,
+    "inherits": "RIMOS",
+    "properties": {
+      "Platform_Version": "3.6"
+    }
+  },
+  "RIMOS": {
+    "match": "*BlackBerry; U*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "RIM OS",
+      "Platform_Description": "RIM OS",
+      "Platform_Maker": "Research In Motion Limited",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "webOS 3.0 (LG)": {
+    "match": "*web0S*Linux/SmartTV*",
+    "lite": false,
+    "standard": true,
+    "inherits": "webOS (LG)",
+    "properties": {
+      "Platform_Version": "3.0"
+    }
+  },
+  "webOS 2.0 (LG)": {
+    "match": "*web0S*Linux/SmartTV*",
+    "lite": false,
+    "standard": true,
+    "inherits": "webOS (LG)",
+    "properties": {
+      "Platform_Version": "2.0"
+    }
+  },
+  "webOS (LG)": {
+    "match": "*web0S*Linux/SmartTV*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "webOS",
+      "Platform_Description": "LG webOS",
+      "Platform_Maker": "LG",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "webOS_B_30": {
+    "match": "*hpwOS/3.*",
+    "lite": false,
+    "standard": true,
+    "inherits": "webOS",
+    "properties": {
+      "Platform_Version": "3.0"
+    }
+  },
+  "webOS_B": {
+    "match": "*hpwOS/*",
+    "lite": false,
+    "standard": true,
+    "inherits": "webOS"
+  },
+  "webOS_22": {
+    "match": "*webOS/2.2*",
+    "lite": false,
+    "standard": true,
+    "inherits": "webOS",
+    "properties": {
+      "Platform_Version": "2.2"
+    }
+  },
+  "webOS_21": {
+    "match": "*webOS/2.1*",
+    "lite": false,
+    "standard": true,
+    "inherits": "webOS",
+    "properties": {
+      "Platform_Version": "2.1"
+    }
+  },
+  "webOS_20": {
+    "match": "*webOS/2.0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "webOS",
+    "properties": {
+      "Platform_Version": "2.0"
+    }
+  },
+  "webOS_14": {
+    "match": "*webOS/1.4*",
+    "lite": false,
+    "standard": false,
+    "inherits": "webOS",
+    "properties": {
+      "Platform_Version": "1.4"
+    }
+  },
+  "webOS_13": {
+    "match": "*webOS/1.3*",
+    "lite": false,
+    "standard": false,
+    "inherits": "webOS",
+    "properties": {
+      "Platform_Version": "1.3"
+    }
+  },
+  "webOS_12": {
+    "match": "*webOS/1.2*",
+    "lite": false,
+    "standard": false,
+    "inherits": "webOS",
+    "properties": {
+      "Platform_Version": "1.2"
+    }
+  },
+  "webOS_11": {
+    "match": "*webOS/1.1*",
+    "lite": false,
+    "standard": false,
+    "inherits": "webOS",
+    "properties": {
+      "Platform_Version": "1.1"
+    }
+  },
+  "webOS_10": {
+    "match": "*webOS/1.0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "webOS",
+    "properties": {
+      "Platform_Version": "1.0"
+    }
+  },
+  "webOS": {
+    "match": "*webOS/*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "webOS",
+      "Platform_Description": "HP webOS",
+      "Platform_Maker": "HP",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "Bada_2_0": {
+    "match": "*Bada/2.*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Bada",
+    "properties": {
+      "Platform_Version": "2.0"
+    }
+  },
+  "Bada_1_2": {
+    "match": "*Bada/1.2*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Bada",
+    "properties": {
+      "Platform_Version": "1.2"
+    }
+  },
+  "Bada_1_0": {
+    "match": "*Bada/1.*",
+    "lite": false,
+    "standard": false,
+    "inherits": "Bada",
+    "properties": {
+      "Platform_Version": "1.0"
+    }
+  },
+  "Bada": {
+    "match": "*Bada*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "Bada",
+      "Platform_Version": "unknown",
+      "Platform_Description": "Samsung Bada",
+      "Platform_Maker": "Samsung",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "Xbox_OS_10_Mobile": {
+    "match": "*Windows Phone 10.0*",
+    "lite": true,
+    "standard": true,
+    "inherits": "Xbox_OS_10",
+    "properties": {
+      "Platform": "Xbox OS 10 (Mobile View)"
+    }
+  },
+  "Xbox_OS_10": {
+    "match": "*Windows NT 10.0*Win64? x64*",
+    "lite": true,
+    "standard": true,
+    "inherits": "Xbox_OS",
+    "properties": {
+      "Platform": "Xbox OS 10",
+      "Platform_Description": "Windows 10 on Xbox One"
+    }
+  },
+  "Xbox_OS_Mobile_A": {
+    "match": "*Windows Phone OS 7.5*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Xbox_OS_Mobile"
+  },
+  "Xbox_OS_Mobile": {
+    "match": "*Windows Phone 8.0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Xbox_OS",
+    "properties": {
+      "Platform": "Xbox OS (Mobile View)"
+    }
+  },
+  "Xbox_OS": {
+    "match": "*Windows NT 6.2*",
+    "lite": true,
+    "standard": true,
+    "properties": {
+      "Platform": "Xbox OS",
+      "Platform_Maker": "Microsoft Corporation",
+      "Platform_Version": "unknown",
+      "Platform_Description": "Xbox One System Software",
+      "Win64": true,
+      "Browser_Bits": 64,
+      "Platform_Bits": 64
+    }
+  },
+  "Xbox_360_Mobile": {
+    "match": "*Windows Phone OS 7.5*",
+    "lite": false,
+    "standard": true,
+    "inherits": "Xbox_360",
+    "properties": {
+      "Platform": "Xbox 360 (Mobile View)"
+    }
+  },
+  "Xbox_360": {
+    "match": "*Windows NT 6.1*",
+    "lite": true,
+    "standard": true,
+    "properties": {
+      "Platform": "Xbox 360",
+      "Platform_Maker": "Microsoft Corporation",
+      "Platform_Version": "unknown",
+      "Platform_Description": "Xbox 360 System Software",
+      "Win32": true,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "RISC_OS": {
+    "match": "*RISC*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "RISC OS",
+      "Platform_Maker": "unknown",
+      "Platform_Description": "RISC OS",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "FirefoxOS_2_5": {
+    "match": "*Gecko*",
+    "lite": false,
+    "standard": true,
+    "inherits": "FirefoxOS",
+    "properties": {
+      "Platform_Version": "2.5",
+      "Beta": true
+    }
+  },
+  "FirefoxOS_2_2": {
+    "match": "*Gecko*",
+    "lite": false,
+    "standard": true,
+    "inherits": "FirefoxOS",
+    "properties": {
+      "Platform_Version": "2.2"
+    }
+  },
+  "FirefoxOS_2_1": {
+    "match": "*Gecko*",
+    "lite": false,
+    "standard": true,
+    "inherits": "FirefoxOS",
+    "properties": {
+      "Platform_Version": "2.1"
+    }
+  },
+  "FirefoxOS_2_0": {
+    "match": "*Gecko*",
+    "lite": false,
+    "standard": true,
+    "inherits": "FirefoxOS",
+    "properties": {
+      "Platform_Version": "2.0"
+    }
+  },
+  "FirefoxOS_1_4": {
+    "match": "*Gecko*",
+    "lite": false,
+    "standard": false,
+    "inherits": "FirefoxOS",
+    "properties": {
+      "Platform_Version": "1.4"
+    }
+  },
+  "FirefoxOS_1_3": {
+    "match": "*Gecko*",
+    "lite": false,
+    "standard": false,
+    "inherits": "FirefoxOS",
+    "properties": {
+      "Platform_Version": "1.3"
+    }
+  },
+  "FirefoxOS_1_2": {
+    "match": "*Gecko*",
+    "lite": false,
+    "standard": false,
+    "inherits": "FirefoxOS",
+    "properties": {
+      "Platform_Version": "1.2"
+    }
+  },
+  "FirefoxOS_1_1": {
+    "match": "*Gecko*",
+    "lite": false,
+    "standard": false,
+    "inherits": "FirefoxOS",
+    "properties": {
+      "Platform_Version": "1.1"
+    }
+  },
+  "FirefoxOS_1_0": {
+    "match": "*Gecko*",
+    "lite": false,
+    "standard": false,
+    "inherits": "FirefoxOS",
+    "properties": {
+      "Platform_Version": "1.0"
+    }
+  },
+  "FirefoxOS_0_x": {
+    "match": "*Gecko*",
+    "lite": false,
+    "standard": false,
+    "inherits": "FirefoxOS",
+    "properties": {
+      "Platform_Version": "0.x"
+    }
+  },
+  "FirefoxOS": {
+    "match": "*Gecko*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "FirefoxOS",
+      "Platform_Maker": "Mozilla Foundation",
+      "Platform_Version": "unknown",
+      "Platform_Description": "FirefoxOS",
+      "Win32": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "KaiOS_2_0": {
+    "match": "*KaiOS/2.0*",
+    "lite": false,
+    "standard": true,
+    "inherits": "KaiOS",
+    "properties": {
+      "Platform_Version": "2.0"
+    }
+  },
+  "KaiOS_1_0": {
+    "match": "*KaiOS/1.0*",
+    "lite": false,
+    "standard": false,
+    "inherits": "KaiOS",
+    "properties": {
+      "Platform_Version": "1.0"
+    }
+  },
+  "KaiOS": {
+    "match": "*KaiOS/*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "KaiOS",
+      "Platform_Maker": "KaiOS Technologies Inc.",
+      "Platform_Version": "unknown",
+      "Platform_Description": "KaiOS",
+      "Win32": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "SailfishOS": {
+    "match": "*Sailfish*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "SailfishOS",
+      "Platform_Maker": "Jolla Ltd.",
+      "Platform_Version": "unknown",
+      "Win32": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "MeeGo": {
+    "match": "*MeeGo*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "MeeGo",
+      "Platform_Maker": "Linux Foundation",
+      "Platform_Description": "MeeGo",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "OpenVMS": {
+    "match": "*OpenVMS*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "OpenVMS",
+      "Platform_Maker": "HP",
+      "Platform_Description": "OpenVMS",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "Nintendo3DS_OS": {
+    "match": "*Nintendo 3DS",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "Nintendo 3DS",
+      "Platform_Maker": "Nintendo",
+      "Platform_Version": "unknown",
+      "Platform_Description": "Nintendo 3DS/New Nintendo 3DS System Software",
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "NintendoWiiU_OS": {
+    "match": "Nintendo WiiU",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "Nintendo WiiU",
+      "Platform_Maker": "Nintendo",
+      "Platform_Version": "unknown",
+      "Platform_Description": "Nintendo WiiU System Software",
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "NintendoSwitch_OS": {
+    "match": "Nintendo Switch",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "Nintendo Switch",
+      "Platform_Maker": "Nintendo",
+      "Platform_Version": "unknown",
+      "Platform_Description": "Nintendo Switch System Software",
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "NintendoDS_OS": {
+    "match": "Nintendo DS",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "Nintendo DS",
+      "Platform_Maker": "Nintendo",
+      "Platform_Version": "unknown",
+      "Platform_Description": "Nintendo DS System Software",
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "NintendoWii_OS": {
+    "match": "Nintendo Wii",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "Nintendo Wii",
+      "Platform_Maker": "Nintendo",
+      "Platform_Version": "unknown",
+      "Platform_Description": "Nintendo Wii System Software",
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "NintendoDSi_OS": {
+    "match": "Nintendo DSi",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "Nintendo DSi",
+      "Platform_Maker": "Nintendo",
+      "Platform_Version": "unknown",
+      "Platform_Description": "Nintendo DSi System Software",
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "Series30": {
+    "match": "*Series40*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "Series30",
+      "Platform_Maker": "Nokia",
+      "Platform_Description": "Series 30",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "Asha": {
+    "match": "*Asha*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "Asha",
+      "Platform_Maker": "Nokia",
+      "Platform_Description": "Asha Platform",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "Haiku": {
+    "match": "*Haiku*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "Haiku",
+      "Platform_Maker": "Haiku, Inc.",
+      "Platform_Description": "Haiku",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "CellOS": {
+    "match": "*CellOS*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "CellOS",
+      "Platform_Maker": "Sony",
+      "Platform_Version": "unknown",
+      "Win32": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "Inferno": {
+    "match": "*Inferno*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "Inferno OS",
+      "Platform_Maker": "Vita Nuova Holdings Ltd",
+      "Platform_Version": "unknown",
+      "Win32": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "Liberate": {
+    "match": "*Liberate*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "Liberate",
+      "Platform_Maker": "unknown",
+      "Platform_Version": "unknown"
+    }
+  },
+  "OrbisOS": {
+    "match": "*OrbisOS*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "OrbisOS",
+      "Platform_Maker": "Sony",
+      "Platform_Version": "unknown",
+      "Win32": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "WyderOS": {
+    "match": "*WyderOS*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "WyderOS",
+      "Platform_Version": "unknown",
+      "Platform_Maker": "unknown"
+    }
+  },
+  "PS_Vita": {
+    "match": "PlayStation Vita",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "Playstation Vita",
+      "Platform_Maker": "Sony",
+      "Platform_Version": "unknown",
+      "Platform_Description": "Playstation Vita System Software"
+    }
+  },
+  "PalmOS_3": {
+    "match": "*Palm OS*",
+    "lite": false,
+    "standard": true,
+    "inherits": "PalmOS",
+    "properties": {
+      "Platform_Version": "3.0"
+    }
+  },
+  "PalmOS": {
+    "match": "*Palm OS*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "PalmOS",
+      "Platform_Maker": "Palm",
+      "Platform_Version": "unknown",
+      "Win32": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "Series40": {
+    "match": "*Series40*",
+    "lite": false,
+    "standard": true,
+    "properties": {
+      "Platform": "Series40",
+      "Platform_Maker": "Nokia",
+      "Platform_Description": "Series 40",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 32,
+      "Platform_Bits": 32
+    }
+  },
+  "any": {
+    "match": "*",
+    "lite": true,
+    "standard": true,
+    "properties": {
+      "Platform": "unknown",
+      "Platform_Description": "unknown",
+      "Platform_Maker": "unknown",
+      "Platform_Version": "unknown",
+      "Win16": false,
+      "Win32": false,
+      "Win64": false,
+      "Browser_Bits": 0,
+      "Platform_Bits": 0
     }
   }
 }

--- a/resources/user-agents/apps/dalvik/dalvik-1-6.json
+++ b/resources/user-agents/apps/dalvik/dalvik-1-6.json
@@ -134,8 +134,7 @@
             "SM-P605*": "Samsung SM-P605"
           },
           "platforms": [
-            "Android_4_4",
-            "Android_4_3"
+            "Android_4_4", "Android_4_3"
           ]
         },
         {
@@ -154,8 +153,7 @@
             "MediaPad M1 8.0": "Huawei MediaPad M1 8.0"
           },
           "platforms": [
-            "Android_4_4",
-            "Android_4_2"
+            "Android_4_4", "Android_4_2"
           ]
         },
         {
@@ -177,8 +175,7 @@
             "SGP321": "Sony SGP321"
           },
           "platforms": [
-            "Android_4_3",
-            "Android_4_2"
+            "Android_4_3", "Android_4_2"
           ]
         },
         {

--- a/resources/user-agents/apps/dalvik/dalvik-2-1.json
+++ b/resources/user-agents/apps/dalvik/dalvik-2-1.json
@@ -251,8 +251,7 @@
           "platforms": [
             "Android_7_0",
             "Android_6_0",
-            "Android_5_1",
-            "Android_5_0"
+            "Android_5_1", "Android_5_0"
           ]
         },
         {
@@ -456,8 +455,7 @@
             "SGP311": "Sony SGP311"
           },
           "platforms": [
-            "Android_5_1",
-            "Android_5_0"
+            "Android_5_1", "Android_5_0"
           ]
         },
         {

--- a/resources/user-agents/apps/fluidapp.json
+++ b/resources/user-agents/apps/fluidapp.json
@@ -20,8 +20,8 @@
         {
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) FluidApp Version/* Safari/*",
           "platforms": [
-            "OSX_10_13", "OSX_10_12", "OSX_10_11", "OSX_10_10",
-            "OSX_10_9", "OSX_10_8", "OSX_10_7", "OSX_10_6",
+            "OSX_10_13", "OSX_10_12",
+            "OSX_10_11", "OSX_10_10", "OSX_10_9", "OSX_10_8", "OSX_10_7", "OSX_10_6",
             "OSX"
           ]
         }

--- a/resources/user-agents/apps/shopkeep/shopkeep-generic.json
+++ b/resources/user-agents/apps/shopkeep/shopkeep-generic.json
@@ -7,8 +7,8 @@
     {
       "userAgent": "ShopKeep App Generic for Android",
       "browser": "shopkeep",
-      "engine": "WebKit",
       "platform": "Android_H",
+      "engine": "WebKit",
       "device": "general Mobile Phone (Touch)",
       "properties": {
         "Parent": "DefaultProperties",
@@ -32,8 +32,8 @@
     {
       "userAgent": "ShopKeep App Generic for iOS",
       "browser": "shopkeep",
-      "engine": "WebKit",
       "platform": "iOS_J",
+      "engine": "WebKit",
       "device": "general Mobile Device (Apple)",
       "properties": {
         "Parent": "DefaultProperties",

--- a/resources/user-agents/apps/shopkeep/shopkeep.json
+++ b/resources/user-agents/apps/shopkeep/shopkeep.json
@@ -8,8 +8,8 @@
     {
       "userAgent": "ShopKeep App #MAJORVER#.#MINORVER# for Android",
       "browser": "shopkeep",
-      "engine": "WebKit",
       "platform": "Android_H",
+      "engine": "WebKit",
       "device": "general Mobile Phone (Touch)",
       "properties": {
         "Parent": "DefaultProperties",
@@ -70,8 +70,8 @@
     {
       "userAgent": "ShopKeep App #MAJORVER#.#MINORVER# for iOS",
       "browser": "shopkeep",
-      "engine": "WebKit",
       "platform": "iOS_J",
+      "engine": "WebKit",
       "device": "general Mobile Device (Apple)",
       "properties": {
         "Parent": "DefaultProperties",

--- a/resources/user-agents/browsers/aloha/aloha.json
+++ b/resources/user-agents/browsers/aloha/aloha.json
@@ -132,7 +132,7 @@
           "platforms": [
             "iOS_C_12_0",
             "iOS_C_11_4", "iOS_C_11_3", "iOS_C_11_2", "iOS_C_11_1", "iOS_C_11_0",
-            "iOS_C_10_3",  "iOS_C_10_2", "iOS_C_10_1", "iOS_C_10_0",
+            "iOS_C_10_3", "iOS_C_10_2", "iOS_C_10_1", "iOS_C_10_0",
             "iOS_C_9_3",
             "iOS_C"
           ]

--- a/resources/user-agents/browsers/firefox-focus/firefox-focus-ios-1-0-on.json
+++ b/resources/user-agents/browsers/firefox-focus/firefox-focus-ios-1-0-on.json
@@ -37,7 +37,7 @@
             "iPad": "iPad"
           },
           "platforms": [
-            "iOS_C_12_0", 
+            "iOS_C_12_0",
             "iOS_C_11_4", "iOS_C_11_3", "iOS_C_11_2", "iOS_C_11_1", "iOS_C_11_0",
             "iOS_C_10_3", "iOS_C_10_2", "iOS_C_10_1", "iOS_C_10_0",
             "iOS_C_9_3", "iOS_C_9_2", "iOS_C_9_1", "iOS_C_9_0",

--- a/resources/user-agents/browsers/firefox-on-kaios/firefox-kaios-2-0.json
+++ b/resources/user-agents/browsers/firefox-on-kaios/firefox-kaios-2-0.json
@@ -32,13 +32,13 @@
             "LYF?F81E": "Lyf F81E"
           },
           "platforms": [
-              "KaiOS_2_0"
+            "KaiOS_2_0"
           ]
         },
         {
           "match": "Mozilla/5.0 (Mobile; *rv:#MAJORVER#.#MINORVER#*)*Gecko/#MAJORVER#.#MINORVER#*Firefox/#MAJORVER#.#MINORVER##PLATFORM#",
           "platforms": [
-              "KaiOS_2_0"
+            "KaiOS_2_0"
           ]
         }
       ]

--- a/resources/user-agents/browsers/firefox-on-kaios/firefox-kaios-generic.json
+++ b/resources/user-agents/browsers/firefox-on-kaios/firefox-kaios-generic.json
@@ -18,9 +18,9 @@
         {
           "match": "Mozilla/5.0 (Mobile; *rv:*)*Gecko*Firefox/#PLATFORM#",
           "platforms": [
-              "KaiOS_2_0",
-              "KaiOS_1_0",
-              "KaiOS"
+            "KaiOS_2_0",
+            "KaiOS_1_0",
+            "KaiOS"
           ]
         }
       ]

--- a/resources/user-agents/browsers/iridium/iridium-generic.json
+++ b/resources/user-agents/browsers/iridium/iridium-generic.json
@@ -18,7 +18,8 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) Iridium/* Safari/*Chrome/*",
           "device": "Windows Desktop",
           "platforms": [
-            "Win10_64", "Win10_32", "Win10_64_B", "Win10_32_B",
+            "Win10_64_B", "Win10_32_B",
+            "Win10_64", "Win10_32",
             "Win8_1_x64", "Win8_1_64", "Win8_1_32",
             "Win8_x64", "Win8_64", "Win8_32",
             "Win7_x64", "Win7_64", "Win7_32"

--- a/resources/user-agents/browsers/iridium/iridium.json
+++ b/resources/user-agents/browsers/iridium/iridium.json
@@ -20,7 +20,8 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) Iridium/#MAJORVER#.* Safari/*Chrome/*",
           "device": "Windows Desktop",
           "platforms": [
-            "Win10_64", "Win10_32", "Win10_64_B", "Win10_32_B",
+            "Win10_64_B", "Win10_32_B",
+            "Win10_64", "Win10_32",
             "Win8_1_x64", "Win8_1_64", "Win8_1_32",
             "Win8_x64", "Win8_64", "Win8_32",
             "Win7_x64", "Win7_64", "Win7_32"

--- a/resources/user-agents/browsers/kinza/kinza-3-1-on.json
+++ b/resources/user-agents/browsers/kinza/kinza-3-1-on.json
@@ -31,8 +31,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) Chrome/* Safari/* Kinza/#MAJORVER#.#MINORVER#*",
           "device": "Macintosh",
           "platforms": [
-            "OSX_10_13",
-            "OSX_10_12",
+            "OSX_10_13", "OSX_10_12",
             "OSX_10_11",
             "OSX"
           ]

--- a/resources/user-agents/browsers/misc/blue-browser.json
+++ b/resources/user-agents/browsers/misc/blue-browser.json
@@ -82,7 +82,7 @@
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) Version/* Chrome/* Safari/* SurfBrowser/*",
           "browser": "surf browser",
           "platforms": [
-            "Android_H_8_0", 
+            "Android_H_8_0",
             "Android_H_7_1", "Android_H_7_0",
             "Android_H_6_0",
             "Android_H_5_1", "Android_H_5_0",

--- a/resources/user-agents/browsers/mobile-safari/mobile-safari-generic.json
+++ b/resources/user-agents/browsers/mobile-safari/mobile-safari-generic.json
@@ -90,7 +90,7 @@
             "iPad": "iPad"
           },
           "platforms": [
-            "iOS_C_12_0", 
+            "iOS_C_12_0",
             "iOS_C_11_4", "iOS_C_11_3", "iOS_C_11_2", "iOS_C_11_1", "iOS_C_11_0",
             "iOS_C_10_3", "iOS_C_10_2", "iOS_C_10_1", "iOS_C_10_0",
             "iOS_C_9_3", "iOS_C_9_2", "iOS_C_9_1", "iOS_C_9_0",

--- a/resources/user-agents/browsers/mqq-browser/mqq-browser-ios.json
+++ b/resources/user-agents/browsers/mqq-browser/mqq-browser-ios.json
@@ -20,7 +20,7 @@
           "match": "Mozilla/5.0 (iPhone#PLATFORM#) applewebkit* (*khtml*like*gecko*) Version/* MQQBrowser/#MAJORVER#.#MINORVER#* Mobile* Safari*",
           "device": "iPhone",
           "platforms": [
-            "iOS_A_12_0", 
+            "iOS_A_12_0",
             "iOS_A_11_4", "iOS_A_11_3", "iOS_A_11_2", "iOS_A_11_1", "iOS_A_11_0",
             "iOS_A_10_3", "iOS_A_10_2", "iOS_A_10_1", "iOS_A_10_0",
             "iOS_A_9_3", "iOS_A_9_2", "iOS_A_9_1", "iOS_A_9_0",

--- a/resources/user-agents/browsers/ntent/ntent-generic.json
+++ b/resources/user-agents/browsers/ntent/ntent-generic.json
@@ -29,7 +29,7 @@
         {
           "match": "Mozilla/5.0 (#PLATFORM#) applewebkit* (*khtml*like*gecko*) NTENTBrowser/* Safari/*",
           "platforms": [
-            "Android_H_8_0",   
+            "Android_H_8_0",
             "Android_H_7_1", "Android_H_7_0",
             "Android_H_6_0",
             "Android_H_5_1", "Android_H_5_0",

--- a/resources/user-agents/browsers/smart-viera/smart-viera-generic.json
+++ b/resources/user-agents/browsers/smart-viera/smart-viera-generic.json
@@ -17,7 +17,8 @@
           "match": "Mozilla/5.0 (#PLATFORM# Viera*) applewebkit* (*khtml*like*gecko*) Viera/* Chrome/*Safari/*",
           "engine": "WebKit",
           "platforms": [
-            "FreeBSD", "Linux"
+            "FreeBSD",
+            "Linux"
           ]
         },
         {

--- a/resources/user-agents/browsers/smart-viera/smart-viera.json
+++ b/resources/user-agents/browsers/smart-viera/smart-viera.json
@@ -20,7 +20,8 @@
         {
           "match": "Mozilla/5.0 (#PLATFORM# Viera*) applewebkit* (*khtml*like*gecko*) Viera/#MAJORVER#.#MINORVER#* Chrome/*Safari/*",
           "platforms": [
-            "FreeBSD", "Linux"
+            "FreeBSD",
+            "Linux"
           ]
         }
       ]

--- a/resources/user-agents/browsers/vivo/vivo-5-0-to-5-2.json
+++ b/resources/user-agents/browsers/vivo/vivo-5-0-to-5-2.json
@@ -8,8 +8,8 @@
     {
       "userAgent": "Vivo Browser #MAJORVER#.#MINORVER#",
       "browser": "vivo",
-      "engine": "Blink",
       "platform": "Android",
+      "engine": "Blink",
       "device": "general Mobile Phone (Touch)",
       "properties": {
         "Parent": "DefaultProperties",

--- a/resources/user-agents/browsers/vivo/vivo-5-3-on.json
+++ b/resources/user-agents/browsers/vivo/vivo-5-3-on.json
@@ -8,8 +8,8 @@
     {
       "userAgent": "Vivo Browser #MAJORVER#.#MINORVER#",
       "browser": "vivo",
-      "engine": "Blink",
       "platform": "Android",
+      "engine": "Blink",
       "device": "general Mobile Phone (Touch)",
       "properties": {
         "Parent": "DefaultProperties",

--- a/resources/user-agents/browsers/vivo/vivo-generic.json
+++ b/resources/user-agents/browsers/vivo/vivo-generic.json
@@ -7,8 +7,8 @@
     {
       "userAgent": "Vivo Browser Generic",
       "browser": "vivo",
-      "engine": "Blink",
       "platform": "Android",
+      "engine": "Blink",
       "device": "general Mobile Phone (Touch)",
       "properties": {
         "Parent": "DefaultProperties",

--- a/resources/user-agents/browsers/whale/whale.json
+++ b/resources/user-agents/browsers/whale/whale.json
@@ -81,24 +81,24 @@
       ]
     },
     {
-        "userAgent": "Whale Browser for Android",
-        "browser": "whale browser",
-        "platform": "Android",
-        "engine": "Blink",
-        "device": "general Mobile Phone (Touch)",
-        "properties": {
-          "Parent": "DefaultProperties",
-          "Comment": "Whale Browser"
-        },
-        "children": [
-          {
-            "match": "Mozilla/5.0 (#PLATFORM#) AppleWebKit/* (*khtml*like*gecko*) Chrome/* Whale/* Mobile Safari/*",
-            "platforms": [
-              "Android_6_0",
-              "Android"
-            ]
-          }
-        ]
-      }
+      "userAgent": "Whale Browser for Android",
+      "browser": "whale browser",
+      "platform": "Android",
+      "engine": "Blink",
+      "device": "general Mobile Phone (Touch)",
+      "properties": {
+        "Parent": "DefaultProperties",
+        "Comment": "Whale Browser"
+      },
+      "children": [
+        {
+          "match": "Mozilla/5.0 (#PLATFORM#) AppleWebKit/* (*khtml*like*gecko*) Chrome/* Whale/* Mobile Safari/*",
+          "platforms": [
+            "Android_6_0",
+            "Android"
+          ]
+        }
+      ]
+    }
   ]
 }

--- a/schema/engines.json
+++ b/schema/engines.json
@@ -1,73 +1,67 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "properties": {
-    "engines": {
-      "type": "object",
-      "minItems": 1,
-      "uniqueItems": true,
-      "items": {
+  "minItems": 1,
+  "uniqueItems": true,
+  "items": {
+    "type": "object",
+    "properties": {
+      "inherits": {
+        "type": "string"
+      },
+      "properties": {
         "type": "object",
         "properties": {
-          "inherits": {
+          "RenderingEngine_Name": {
             "type": "string"
           },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "RenderingEngine_Name": {
-                "type": "string"
-              },
-              "RenderingEngine_Version": {
-                "type": "string"
-              },
-              "RenderingEngine_Description": {
-                "type": "string"
-              },
-              "RenderingEngine_Maker": {
-                "type": "string"
-              },
-              "JavaScript": {
-                "type": "boolean"
-              },
-              "Cookies": {
-                "type": "boolean"
-              },
-              "Frames": {
-                "type": "boolean"
-              },
-              "IFrames": {
-                "type": "boolean"
-              },
-              "Tables": {
-                "type": "boolean"
-              },
-              "JavaApplets": {
-                "type": "boolean"
-              },
-              "VBScript": {
-                "type": "boolean"
-              },
-              "ActiveXControls": {
-                "type": "boolean"
-              },
-              "BackgroundSounds": {
-                "type": "boolean"
-              },
-              "CssVersion": {
-                "type": "integer"
-              }
-            },
-            "required": [
-              "RenderingEngine_Version"
-            ]
+          "RenderingEngine_Version": {
+            "type": "string"
+          },
+          "RenderingEngine_Description": {
+            "type": "string"
+          },
+          "RenderingEngine_Maker": {
+            "type": "string"
+          },
+          "JavaScript": {
+            "type": "boolean"
+          },
+          "Cookies": {
+            "type": "boolean"
+          },
+          "Frames": {
+            "type": "boolean"
+          },
+          "IFrames": {
+            "type": "boolean"
+          },
+          "Tables": {
+            "type": "boolean"
+          },
+          "JavaApplets": {
+            "type": "boolean"
+          },
+          "VBScript": {
+            "type": "boolean"
+          },
+          "ActiveXControls": {
+            "type": "boolean"
+          },
+          "BackgroundSounds": {
+            "type": "boolean"
+          },
+          "CssVersion": {
+            "type": "integer"
           }
         },
         "required": [
-          "properties"
+          "RenderingEngine_Version"
         ]
       }
     },
-    "required": ["engines"]
+    "required": [
+      "properties"
+    ]
   }
 }

--- a/schema/platforms.json
+++ b/schema/platforms.json
@@ -1,71 +1,63 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "properties": {
-    "platforms": {
-      "type": "object",
-      "minItems": 1,
-      "uniqueItems": true,
-      "items": {
+  "minItems": 1,
+  "uniqueItems": true,
+  "items": {
+    "type": "object",
+    "properties": {
+      "match": {
+        "type": "string"
+      },
+      "lite": {
+        "type": "boolean"
+      },
+      "standard": {
+        "type": "boolean"
+      },
+      "inherits": {
+        "type": "string"
+      },
+      "properties": {
         "type": "object",
         "properties": {
-          "match": {
+          "Platform": {
             "type": "string"
           },
-          "lite": {
-            "type": "boolean"
-          },
-          "standard": {
-            "type": "boolean"
-          },
-          "inherits": {
+          "Platform_Version": {
             "type": "string"
           },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "Platform": {
-                "type": "string"
-              },
-              "Platform_Version": {
-                "type": "string"
-              },
-              "Platform_Description": {
-                "type": "string"
-              },
-              "Platform_Maker": {
-                "type": "string"
-              },
-              "Win16": {
-                "type": "boolean"
-              },
-              "Win32": {
-                "type": "boolean"
-              },
-              "Win64": {
-                "type": "boolean"
-              },
-              "Browser_Bits": {
-                "type": "integer"
-              },
-              "Platform_Bits": {
-                "type": "integer"
-              }
-            },
-            "required": [
-              "Platform_Version"
-            ]
+          "Platform_Description": {
+            "type": "string"
+          },
+          "Platform_Maker": {
+            "type": "string"
+          },
+          "Win16": {
+            "type": "boolean"
+          },
+          "Win32": {
+            "type": "boolean"
+          },
+          "Win64": {
+            "type": "boolean"
+          },
+          "Browser_Bits": {
+            "type": "integer"
+          },
+          "Platform_Bits": {
+            "type": "integer"
           }
         },
         "required": [
-          "match",
-          "lite",
-          "standard"
+          "Platform_Version"
         ]
       }
     },
     "required": [
-      "platforms"
+      "match",
+      "lite",
+      "standard"
     ]
   }
 }

--- a/src/Browscap/Command/RewriteDivisionsCommand.php
+++ b/src/Browscap/Command/RewriteDivisionsCommand.php
@@ -201,14 +201,14 @@ class RewriteDivisionsCommand extends Command
                         continue;
                     }
 
-                    $platforms = $this->sortPlatforms(array_unique($childData['platforms']), array_keys($allPlatforms['platforms']));
+                    $platforms = $this->sortPlatforms(array_unique($childData['platforms']), array_keys($allPlatforms));
 
                     $currentPlatform = ['name' => '', 'major-version' => 0, 'minor-version' => 0, 'key' => ''];
                     $currentChunk    = -1;
                     $chunk           = [];
 
                     foreach ($platforms as $key => $platformkey) {
-                        $platform = $allPlatforms['platforms'][$platformkey];
+                        $platform = $allPlatforms[$platformkey];
 
                         if ((!isset($platform['properties']['Platform']) || !isset($platform['properties']['Platform_Version']))
                             && isset($platform['inherits'])
@@ -220,7 +220,7 @@ class RewriteDivisionsCommand extends Command
                             }
 
                             do {
-                                $parentPlatform     = $allPlatforms['platforms'][$platform['inherits']];
+                                $parentPlatform     = $allPlatforms[$platform['inherits']];
                                 $platformProperties = array_merge($parentPlatform['properties'], $platformProperties);
                                 unset($platform['inherits']);
 

--- a/src/Browscap/Data/Factory/DataCollectionFactory.php
+++ b/src/Browscap/Data/Factory/DataCollectionFactory.php
@@ -132,15 +132,12 @@ class DataCollectionFactory
     {
         $decodedFileContent = $this->loadFile($filename);
 
-        Assertion::keyExists($decodedFileContent, 'platforms', 'required "platforms" structure is missing');
-        Assertion::isArray($decodedFileContent['platforms'], 'required "platforms" structure has to be an array');
-
         $platformFactory = new PlatformFactory();
 
-        foreach (array_keys($decodedFileContent['platforms']) as $platformName) {
-            $platformData = $decodedFileContent['platforms'][$platformName];
+        foreach (array_keys($decodedFileContent) as $platformName) {
+            $platformData = $decodedFileContent[$platformName];
 
-            $this->collection->addPlatform($platformName, $platformFactory->build($platformData, $decodedFileContent['platforms'], $platformName));
+            $this->collection->addPlatform($platformName, $platformFactory->build($platformData, $decodedFileContent, $platformName));
         }
     }
 
@@ -157,15 +154,12 @@ class DataCollectionFactory
     {
         $decodedFileContent = $this->loadFile($filename);
 
-        Assertion::keyExists($decodedFileContent, 'engines', 'required "engines" structure is missing');
-        Assertion::isArray($decodedFileContent['engines'], 'required "engines" structure has to be an array');
-
         $engineFactory = new EngineFactory();
 
-        foreach (array_keys($decodedFileContent['engines']) as $engineName) {
-            $engineData = $decodedFileContent['engines'][$engineName];
+        foreach (array_keys($decodedFileContent) as $engineName) {
+            $engineData = $decodedFileContent[$engineName];
 
-            $this->collection->addEngine($engineName, $engineFactory->build($engineData, $decodedFileContent['engines'], $engineName));
+            $this->collection->addEngine($engineName, $engineFactory->build($engineData, $decodedFileContent, $engineName));
         }
     }
 

--- a/src/Browscap/Data/Factory/PlatformFactory.php
+++ b/src/Browscap/Data/Factory/PlatformFactory.php
@@ -22,7 +22,7 @@ final class PlatformFactory
      */
     public function build(array $platformData, array $dataAllPlatforms, string $platformName) : Platform
     {
-        Assertion::isArray($platformData, 'each entry inside the "platforms" structure has to be an array');
+        Assertion::isArray($platformData, 'each entry has to be an array');
         Assertion::keyExists($platformData, 'lite', 'the value for "lite" key is missing for the platform with the key "' . $platformName . '"');
         Assertion::keyExists($platformData, 'standard', 'the value for "standard" key is missing for the platform with the key "' . $platformName . '"');
         Assertion::keyExists($platformData, 'match', 'the value for the "match" key is missing for the platform with the key "' . $platformName . '"');

--- a/src/Browscap/Writer/CsvWriter.php
+++ b/src/Browscap/Writer/CsvWriter.php
@@ -49,7 +49,7 @@ class CsvWriter implements WriterInterface
     public function __construct(string $file, LoggerInterface $logger)
     {
         $this->logger = $logger;
-        $this->file   = fopen($file, 'w');
+        $this->file   = fopen($file, 'wb');
     }
 
     /**

--- a/src/Browscap/Writer/IniWriter.php
+++ b/src/Browscap/Writer/IniWriter.php
@@ -55,7 +55,7 @@ class IniWriter implements WriterInterface
     public function __construct(string $file, LoggerInterface $logger)
     {
         $this->logger       = $logger;
-        $this->file         = fopen($file, 'w');
+        $this->file         = fopen($file, 'wb');
         $this->trimProperty = new TrimProperty();
     }
 

--- a/src/Browscap/Writer/JsonWriter.php
+++ b/src/Browscap/Writer/JsonWriter.php
@@ -55,7 +55,7 @@ class JsonWriter implements WriterInterface
     public function __construct(string $file, LoggerInterface $logger)
     {
         $this->logger       = $logger;
-        $this->file         = fopen($file, 'w');
+        $this->file         = fopen($file, 'wb');
         $this->trimProperty = new TrimProperty();
     }
 

--- a/src/Browscap/Writer/XmlWriter.php
+++ b/src/Browscap/Writer/XmlWriter.php
@@ -49,7 +49,7 @@ class XmlWriter implements WriterInterface
     public function __construct(string $file, LoggerInterface $logger)
     {
         $this->logger = $logger;
-        $this->file   = fopen($file, 'w');
+        $this->file   = fopen($file, 'wb');
     }
 
     /**

--- a/tests/BrowscapTest/Generator/Helper/BuildHelperTest.php
+++ b/tests/BrowscapTest/Generator/Helper/BuildHelperTest.php
@@ -822,7 +822,7 @@ class BuildHelperTest extends TestCase
         $resourceFolder = realpath(__DIR__ . '/../../../fixtures/duplicate-useragent-entries');
 
         $this->expectException(DuplicateDataException::class);
-        $this->expectExceptionMessage(sprintf('Mozilla/5.0 (Build/*) applewebkit* (*khtml*like*gecko*) Version/* Chrome/* Safari/* Mb2345Browser/#MAJORVER#.#MINORVER#*" for division "2345 Browser #MAJORVER#.#MINORVER#" in file "%s/user-agents/test1.json", but this was already added before', $resourceFolder));
+        $this->expectExceptionMessage(sprintf('tried to add section "Mozilla/5.0 (Build/*) applewebkit* (*khtml*like*gecko*) Version/* Chrome/* Safari/* Mb2345Browser/#MAJORVER#.#MINORVER#*" for division "2345 Browser #MAJORVER#.#MINORVER#" in file "%s/user-agents/test1.json", but this was already added before', $resourceFolder));
 
         BuildHelper::run(
             'test',

--- a/tests/fixtures/duplicate-browser-entries/engines.json
+++ b/tests/fixtures/duplicate-browser-entries/engines.json
@@ -1,12 +1,10 @@
 {
-  "engines": {
-    "Foobar": {
-      "properties": {
-        "RenderingEngine_Name": "Foobar"
-      }
-    },
-    "Foo": {
-      "inherits": "Foobar"
+  "Foobar": {
+    "properties": {
+      "RenderingEngine_Name": "Foobar"
     }
+  },
+  "Foo": {
+    "inherits": "Foobar"
   }
 }

--- a/tests/fixtures/duplicate-browser-entries/platforms.json
+++ b/tests/fixtures/duplicate-browser-entries/platforms.json
@@ -1,23 +1,21 @@
 {
-  "platforms": {
-    "Platform1": {
-      "match": "*Platform1*",
-      "lite": true,
-      "standard": true,
-      "properties": {
-        "Platform": "Platform1",
-        "Platform_Description": "The first test platform",
-        "Win32": false
-      }
-    },
-    "Platform2": {
-      "match": "*Platform2*",
-      "lite": true,
-      "standard": true,
-      "properties": {
-        "Platform": "Platform2",
-        "Win32": false
-      }
+  "Platform1": {
+    "match": "*Platform1*",
+    "lite": true,
+    "standard": true,
+    "properties": {
+      "Platform": "Platform1",
+      "Platform_Description": "The first test platform",
+      "Win32": false
+    }
+  },
+  "Platform2": {
+    "match": "*Platform2*",
+    "lite": true,
+    "standard": true,
+    "properties": {
+      "Platform": "Platform2",
+      "Win32": false
     }
   }
 }

--- a/tests/fixtures/duplicate-device-entries/engines.json
+++ b/tests/fixtures/duplicate-device-entries/engines.json
@@ -1,12 +1,10 @@
 {
-  "engines": {
-    "Foobar": {
-      "properties": {
-        "RenderingEngine_Name": "Foobar"
-      }
-    },
-    "Foo": {
-      "inherits": "Foobar"
+  "Foobar": {
+    "properties": {
+      "RenderingEngine_Name": "Foobar"
     }
+  },
+  "Foo": {
+    "inherits": "Foobar"
   }
 }

--- a/tests/fixtures/duplicate-device-entries/platforms.json
+++ b/tests/fixtures/duplicate-device-entries/platforms.json
@@ -1,23 +1,21 @@
 {
-  "platforms": {
-    "Platform1": {
-      "match": "*Platform1*",
-      "lite": true,
-      "standard": true,
-      "properties": {
-        "Platform": "Platform1",
-        "Platform_Description": "The first test platform",
-        "Win32": false
-      }
-    },
-    "Platform2": {
-      "match": "*Platform2*",
-      "lite": true,
-      "standard": true,
-      "properties": {
-        "Platform": "Platform2",
-        "Win32": false
-      }
+  "Platform1": {
+    "match": "*Platform1*",
+    "lite": true,
+    "standard": true,
+    "properties": {
+      "Platform": "Platform1",
+      "Platform_Description": "The first test platform",
+      "Win32": false
+    }
+  },
+  "Platform2": {
+    "match": "*Platform2*",
+    "lite": true,
+    "standard": true,
+    "properties": {
+      "Platform": "Platform2",
+      "Win32": false
     }
   }
 }

--- a/tests/fixtures/duplicate-useragent-entries/engines.json
+++ b/tests/fixtures/duplicate-useragent-entries/engines.json
@@ -1,12 +1,10 @@
 {
-  "engines": {
-    "Foobar": {
-      "properties": {
-        "RenderingEngine_Name": "Foobar"
-      }
-    },
-    "Foo": {
-      "inherits": "Foobar"
+  "Foobar": {
+    "properties": {
+      "RenderingEngine_Name": "Foobar"
     }
+  },
+  "Foo": {
+    "inherits": "Foobar"
   }
 }

--- a/tests/fixtures/duplicate-useragent-entries/platforms.json
+++ b/tests/fixtures/duplicate-useragent-entries/platforms.json
@@ -1,27 +1,25 @@
 {
-  "platforms": {
-    "Platform1": {
-      "match": "*Platform1*",
-      "lite": true,
-      "standard": true,
-      "properties": {
-        "Platform": "Platform1",
-        "Platform_Description": "The first test platform",
-        "Platform_Bits": 0,
-        "Platform_Maker": "unknown",
-        "Win32": false
-      }
-    },
-    "Platform2": {
-      "match": "*Platform2*",
-      "lite": true,
-      "standard": true,
-      "properties": {
-        "Platform": "Platform2",
-        "Platform_Bits": 0,
-        "Platform_Maker": "unknown",
-        "Win32": false
-      }
+  "Platform1": {
+    "match": "*Platform1*",
+    "lite": true,
+    "standard": true,
+    "properties": {
+      "Platform": "Platform1",
+      "Platform_Description": "The first test platform",
+      "Platform_Bits": 0,
+      "Platform_Maker": "unknown",
+      "Win32": false
+    }
+  },
+  "Platform2": {
+    "match": "*Platform2*",
+    "lite": true,
+    "standard": true,
+    "properties": {
+      "Platform": "Platform2",
+      "Platform_Bits": 0,
+      "Platform_Maker": "unknown",
+      "Win32": false
     }
   }
 }

--- a/tests/fixtures/engines.json
+++ b/tests/fixtures/engines.json
@@ -1,12 +1,10 @@
 {
-  "engines": {
-    "Foobar": {
-      "properties": {
-        "RenderingEngine_Name": "Foobar"
-      }
-    },
-    "Foo": {
-      "inherits": "Foobar"
+  "Foobar": {
+    "properties": {
+      "RenderingEngine_Name": "Foobar"
     }
+  },
+  "Foo": {
+    "inherits": "Foobar"
   }
 }

--- a/tests/fixtures/engines/engines-without-properties.json
+++ b/tests/fixtures/engines/engines-without-properties.json
@@ -1,5 +1,3 @@
 {
-  "engines": {
-    "Foobar": {}
-  }
+  "Foobar": {}
 }

--- a/tests/fixtures/engines/engines.json
+++ b/tests/fixtures/engines/engines.json
@@ -1,12 +1,10 @@
 {
-  "engines": {
-    "Foobar": {
-      "properties": {
-        "RenderingEngine_Name": "Foobar"
-      }
-    },
-    "Foo": {
-      "inherits": "Foobar"
+  "Foobar": {
+    "properties": {
+      "RenderingEngine_Name": "Foobar"
     }
+  },
+  "Foo": {
+    "inherits": "Foobar"
   }
 }

--- a/tests/fixtures/platforms.json
+++ b/tests/fixtures/platforms.json
@@ -1,23 +1,21 @@
 {
-  "platforms": {
-    "Platform1": {
-      "match": "*Platform1*",
-      "lite": true,
-      "standard": true,
-      "properties": {
-        "Platform": "Platform1",
-        "Platform_Description": "The first test platform",
-        "Win32": false
-      }
-    },
-    "Platform2": {
-      "match": "*Platform2*",
-      "lite": true,
-      "standard": true,
-      "properties": {
-        "Platform": "Platform2",
-        "Win32": false
-      }
+  "Platform1": {
+    "match": "*Platform1*",
+    "lite": true,
+    "standard": true,
+    "properties": {
+      "Platform": "Platform1",
+      "Platform_Description": "The first test platform",
+      "Win32": false
+    }
+  },
+  "Platform2": {
+    "match": "*Platform2*",
+    "lite": true,
+    "standard": true,
+    "properties": {
+      "Platform": "Platform2",
+      "Win32": false
     }
   }
 }

--- a/tests/fixtures/platforms/platforms-without-match.json
+++ b/tests/fixtures/platforms/platforms-without-match.json
@@ -1,11 +1,9 @@
 {
-  "platforms": {
-    "Platform1": {
-      "properties": {
-        "Platform": "Platform1",
-        "Platform_Description": "The first test platform",
-        "Win32": false
-      }
+  "Platform1": {
+    "properties": {
+      "Platform": "Platform1",
+      "Platform_Description": "The first test platform",
+      "Win32": false
     }
   }
 }

--- a/tests/fixtures/platforms/platforms-without-properties.json
+++ b/tests/fixtures/platforms/platforms-without-properties.json
@@ -1,7 +1,5 @@
 {
-  "platforms": {
-    "Platform1": {
-      "match": "*Platform1*"
-    }
+  "Platform1": {
+    "match": "*Platform1*"
   }
 }

--- a/tests/fixtures/platforms/platforms.json
+++ b/tests/fixtures/platforms/platforms.json
@@ -1,23 +1,21 @@
 {
-  "platforms": {
-    "Platform1": {
-      "match": "*Platform1*",
-      "lite": true,
-      "standard": true,
-      "properties": {
-        "Platform": "Platform1",
-        "Platform_Description": "The first test platform",
-        "Win32": false
-      }
-    },
-    "Platform2": {
-      "match": "*Platform2*",
-      "lite": true,
-      "standard": true,
-      "properties": {
-        "Platform": "Platform2",
-        "Win32": false
-      }
+  "Platform1": {
+    "match": "*Platform1*",
+    "lite": true,
+    "standard": true,
+    "properties": {
+      "Platform": "Platform1",
+      "Platform_Description": "The first test platform",
+      "Win32": false
+    }
+  },
+  "Platform2": {
+    "match": "*Platform2*",
+    "lite": true,
+    "standard": true,
+    "properties": {
+      "Platform": "Platform2",
+      "Win32": false
     }
   }
 }


### PR DESCRIPTION
This PR intends to remove the extra namespace in the files `engines.json` and `platforms.json`. This would help to optimize the rewrite and validate commands.

All other resource files are rewritten to match the current schema (fix whitespaces, EOF).