### PR TITLE
Ability to specify a version range instead of specifying each version

### DIFF
--- a/src/Browscap/Data/Division.php
+++ b/src/Browscap/Data/Division.php
@@ -65,8 +65,17 @@ class Division
         $this->userAgents = $userAgents;
         $this->lite       = $lite;
         $this->standard   = $standard;
-        $this->versions   = $versions;
         $this->fileName   = $fileName;
+
+        foreach ($versions as $version) {
+            if (isset($version['start']) && isset($version['end'])) {
+                foreach (range($version['start'], $version['end']) as $version) {
+                    $this->versions[] = $version;
+                }
+            } else {
+                $this->versions[] = $version;
+            }
+        }
     }
 
     public function isLite() : bool


### PR DESCRIPTION
For example, instead of:
```
{
    "versions": [88, 73, 72, 71, 70, 69, 68, 67, 66, 65, 64, 63, 62, 61, 60, 59, 58, 57, 56, 55, 54, 53, 44]
}
```

We can use:
```
{
    "versions": [88, {"start":53,"end":73}, 44]
}
```