### PR TITLE
Allow FilterCollection to be used anywhere that FilterInterface can be used

### DIFF
--- a/src/Browscap/Filter/FilterCollection.php
+++ b/src/Browscap/Filter/FilterCollection.php
@@ -10,10 +10,20 @@ use Browscap\Writer\WriterInterface;
 /**
  * with this filter it is possible to combine other filters
  */
-class FilterCollection
+class FilterCollection implements FilterInterface
 {
     /** @var FilterInterface[] */
     private array $filters = [];
+
+    /**
+     * returns the Type of the filter
+     *
+     * @throws void
+     */
+    public function getType(): string
+    {
+        return FilterInterface::TYPE_COLLECTION;
+    }
 
     /**
      * add a new filter to the collection

--- a/src/Browscap/Filter/FilterInterface.php
+++ b/src/Browscap/Filter/FilterInterface.php
@@ -9,10 +9,11 @@ use Browscap\Writer\WriterInterface;
 
 interface FilterInterface
 {
-    public const TYPE_FULL     = 'FULL';
-    public const TYPE_STANDARD = '';
-    public const TYPE_LITE     = 'LITE';
-    public const TYPE_CUSTOM   = 'CUSTOM';
+    public const TYPE_FULL       = 'FULL';
+    public const TYPE_STANDARD   = '';
+    public const TYPE_LITE       = 'LITE';
+    public const TYPE_CUSTOM     = 'CUSTOM';
+    public const TYPE_COLLECTION = 'COLLECTION';
 
     /**
      * returns the Type of the filter

--- a/tests/BrowscapTest/Filter/FilterCollectionTest.php
+++ b/tests/BrowscapTest/Filter/FilterCollectionTest.php
@@ -12,6 +12,8 @@ use PHPUnit\Framework\MockObject\MethodCannotBeConfiguredException;
 use PHPUnit\Framework\MockObject\MethodNameAlreadyConfiguredException;
 use PHPUnit\Framework\TestCase;
 
+use function range;
+
 class FilterCollectionTest extends TestCase
 {
     private FilterCollection $object;
@@ -20,6 +22,50 @@ class FilterCollectionTest extends TestCase
     protected function setUp(): void
     {
         $this->object = new FilterCollection();
+    }
+
+    /**
+     * tests getter for the filter type with filters of a different types, and without filters
+     *
+     * @dataProvider dataProviderForTestGetType
+     */
+    public function testGetType(int $noOfFilters): void
+    {
+        for ($i = 0; $i < $noOfFilters; $i++) {
+            $mockFilter = $this->createMock(FilterInterface::class);
+            $mockFilter
+                ->expects(static::never())
+                ->method('getType');
+            $mockFilter
+                ->expects(static::never())
+                ->method('isOutput');
+            $mockFilter
+                ->expects(static::never())
+                ->method('isOutputSection');
+            $mockFilter
+                ->expects(static::never())
+                ->method('isOutputProperty');
+
+            $this->object->addFilter($mockFilter);
+        }
+
+        static::assertSame(FilterInterface::TYPE_COLLECTION, $this->object->getType());
+    }
+
+    /**
+     * Data Provider for testGetType
+     *
+     * @return array<array<int>>
+     */
+    public function dataProviderForTestGetType(): array
+    {
+        $funcArgs = [];
+
+        foreach (range(0, 10) as $noOfFilters) {
+            $funcArgs[] = [$noOfFilters];
+        }
+
+        return $funcArgs;
     }
 
     /**


### PR DESCRIPTION
What it says on the tin really.
I wanted to combine the `CustomFilter` with the `StandardFilter`, so I could reduce the number of fields, but retain the smaller size of the standard file. The `FilterCollection` couldn't be passed to `WriterCollection::setFilter` as it didn't implement `FilterInterface`, but it seemed to make sense allow a combination of filters to be passed to this, and `FilterCollection` seemingly being intended for this purpose, hence these updates.