### PR TITLE
Remove words I accidentally left in the README.md with my previous commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,9 +203,9 @@ $buildGenerator = new BuildGenerator(
     $dataCollectionFactory
 );
 
-$version       = '';                       // version what you want to be written into the generated file
-$dateTime      = new \DateTimeImmutable(); // date what you want to be written into the generated file
-$createZipFile = false;                    // It is not possible yet to create a zipped version of a custom named browscap file
+$version       = ''; // version you want to be written into the generated file
+$dateTime      = new \DateTimeImmutable(); // date you want to be written into the generated file
+$createZipFile = false; // It is not possible yet to create a zipped version of a custom named browscap file
 
 $buildGenerator->run($version, $dateTime, $createZipFile);
 ```


### PR DESCRIPTION
Apologies, I left the word "what" on these two lines when I raised my PR yesterday. I've now removed these.
I've also made the comments align to the end of the lines as they do in the rest of this section.